### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,15 @@ jobs:
         CLANG_TIDY_TARBALL: riscv64-unknown-elf-clang-tidy.tar.xz
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: clang-format
+      run: |
+        HEAD_SHA=${{ github.event.pull_request.head.sha }}
+        BASE_SHA=${{ github.event.pull_request.base.sha }}
+        MERGE_BASE_SHA=$(git merge-base $HEAD_SHA $BASE_SHA)
+        git diff --name-only $MERGE_BASE_SHA $HEAD_SHA | \
+          egrep "\.(c|h)$" | \
+          xargs -I{} bash -c "if [ -f {} ] ; then clang-format --dry-run -style=file --Werror {} ; fi"
+
     - name: Configure and build (tests and benchmarks)
       run: |
         cmake -B ${{ github.workspace }}/build \
@@ -85,12 +94,3 @@ jobs:
     - name: Run (benchmarks only)
       working-directory: ${{ github.workspace }}/build
       run: ctest --verbose --output-on-failure
-
-    - name: clang-format
-      run: |
-        HEAD_SHA=${{ github.event.pull_request.head.sha }}
-        BASE_SHA=${{ github.event.pull_request.base.sha }}
-        MERGE_BASE_SHA=$(git merge-base $HEAD_SHA $BASE_SHA)
-        git diff --name-only $MERGE_BASE_SHA $HEAD_SHA | \
-          egrep "\.(c|h)$" | \
-          xargs -I{} bash -c "if [ -f {} ] ; then clang-format --dry-run -style=file --Werror {} ; fi"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+name: SKL CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    types: [ opened, synchronize ]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  CI:
+    runs-on:
+      group: linux-runners
+      labels: ubuntu-22.04-x64-2
+
+    env:
+      SKL_TAG: v0.0.0
+      TOOLCHAIN_TAG: 2025.08.28
+
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup QEMU
+      run: |
+        gh release download $SKL_TAG -p "$QEMU_TARBALL"
+        tar -xvf $QEMU_TARBALL
+        echo "${{ github.workspace }}" >> $GITHUB_PATH
+      env:
+        QEMU_TARBALL: qemu-riscv64-v10.1.0-ubuntu-22.04.tar.xz
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup toolchain
+      run: |
+        gh release download $TOOLCHAIN_TAG -R riscv-collab/riscv-gnu-toolchain -p "$TOOLCHAIN_TARBALL"
+        tar -xvf $TOOLCHAIN_TARBALL
+        echo "${{ github.workspace }}/riscv/bin" >> $GITHUB_PATH
+      env:
+        TOOLCHAIN_TARBALL: riscv64-elf-ubuntu-22.04-llvm-nightly-${{ env.TOOLCHAIN_TAG }}-nightly.tar.xz
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup clang-tidy
+      run: |
+        gh release download $SKL_TAG -p "$CLANG_TIDY_TARBALL"
+        tar -xvf $CLANG_TIDY_TARBALL -C ${{ github.workspace }}/riscv/bin
+      env:
+        CLANG_TIDY_TARBALL: riscv64-unknown-elf-clang-tidy.tar.xz
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Configure and build (tests and benchmarks)
+      run: |
+        cmake -B ${{ github.workspace }}/build \
+              -DCMAKE_TOOLCHAIN_FILE=cmake/riscv.cmake \
+              -DSKL_BUILD_TESTS=ON -DSKL_BUILD_BENCHMARKS=ON
+        cmake --build ${{ github.workspace }}/build --verbose
+
+    - name: Run (tests and benchmarks)
+      working-directory: ${{ github.workspace }}/build
+      run: ctest --verbose --output-on-failure
+
+    - name: Configure and build (tests only)
+      run: |
+        cmake -B ${{ github.workspace }}/build \
+              -DCMAKE_TOOLCHAIN_FILE=cmake/riscv.cmake \
+              -DSKL_BUILD_TESTS=ON -DSKL_BUILD_BENCHMARKS=OFF
+        cmake --build ${{ github.workspace }}/build --verbose
+
+    - name: Run (tests only)
+      working-directory: ${{ github.workspace }}/build
+      run: ctest --verbose --output-on-failure
+
+    - name: Configure and build (benchmarks only)
+      run: |
+        cmake -B ${{ github.workspace }}/build \
+              -DCMAKE_TOOLCHAIN_FILE=cmake/riscv.cmake \
+              -DSKL_BUILD_TESTS=OFF -DSKL_BUILD_BENCHMARKS=ON
+        cmake --build ${{ github.workspace }}/build --verbose
+
+    - name: Run (benchmarks only)
+      working-directory: ${{ github.workspace }}/build
+      run: ctest --verbose --output-on-failure
+
+    - name: clang-format
+      run: |
+        HEAD_SHA=${{ github.event.pull_request.head.sha }}
+        BASE_SHA=${{ github.event.pull_request.base.sha }}
+        MERGE_BASE_SHA=$(git merge-base $HEAD_SHA $BASE_SHA)
+        git diff --name-only $MERGE_BASE_SHA $HEAD_SHA | \
+          egrep "\.(c|h)$" | \
+          xargs -I{} bash -c "if [ -f {} ] ; then clang-format --dry-run -style=file --Werror {} ; fi"

--- a/cmake/riscv.cmake
+++ b/cmake/riscv.cmake
@@ -1,5 +1,7 @@
 set(CMAKE_SYSTEM_PROCESSOR riscv)
 
+set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
+
 set(CMAKE_C_COMPILER riscv64-unknown-elf-clang)
 option(SKL_ENABLE_CLANG_TIDY "Enable clang-tidy command" ON)
 if(SKL_ENABLE_CLANG_TIDY)
@@ -10,22 +12,22 @@ set(SKL_ARCH_EXTENSIONS
   rv64gcv
   zba
   zbb
-  xsfmmbase
-  xsfmm32a8f
-  xsfmm32a8i
-  xsfmm32a16f
-  xsfmm32a32f
-  xsfmm64t
+  # xsfmmbase
+  # xsfmm32a8f
+  # xsfmm32a8i
+  # xsfmm32a16f
+  # xsfmm32a32f
+  # xsfmm64t
   zfh
   zvfh
-  xsfvfbfa
-  xsfvfbfexp16e
-  xsfvfexp16e
-  xsfvfexp32e
-  xsfvfexpa
-  zvfofp8min0p2
-  zvfofp4min0p1
-  xsfvqdotq
+  # xsfvfbfa
+  # xsfvfbfexp16e
+  # xsfvfexp16e
+  # xsfvfexp32e
+  # xsfvfexpa
+  # zvfofp8min0p2
+  # zvfofp4min0p1
+  # xsfvqdotq
   zvfbfmin
 )
 

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -1,0 +1,8 @@
+# SKL CI
+
+CI for SKL uses GitHub Actions.
+The workflow script can be found at `.github/workflows/ci.yml`.
+CI runs the entire SKL test suite for the three possible configurations (tests only, benchmarks only, both tests and benchmarks), a lint check using clang-tidy, and a code format check using clang-format.
+Pull requests must pass all CI checks before they can be merged into `main`.
+CI is triggered automatically for new pull requests and whenever changes are pushed to an existing pull request.
+Contributors can visit the Actions tab of the repository to view more detailed information for a CI run and see which checks passed or failed.


### PR DESCRIPTION
This PR adds the workflow file for public CI along with documentation. Extensions not yet in upstream QEMU have been temporarily disabled. A test release with tag `v0.0.0` was created to store the QEMU and clang-tidy binaries as assets.