### PR TITLE
Remove SKL-Open mentions

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
 # SKL Examples
 
-This directory contains example implementations that demonstrate how to use SKL-Open library functions to build higher-level operations and algorithms.
+This directory contains example implementations that demonstrate how to use SKL functions to build higher-level operations and algorithms.
 
 ## Purpose
 

--- a/example/conv2d/README.md
+++ b/example/conv2d/README.md
@@ -138,7 +138,7 @@ An optimized implementation that leverages bulk memory operations:
 
 The example uses the optimized RISC-V Vector GEMM kernel:
 - **Function**: `skl_gemm_f32_f32_f32_zve32f_x390`
-- **Location**: `skl-open/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c`
+- **Location**: `src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c`
 - **Features**:
   - RVV float32 matrix-matrix multiplication (SGEMM) for row-major matrices
   - RISC-V Vector extension (Zve32f) optimized, tuned for X390


### PR DESCRIPTION
Cleans up a couple occurrences of "SKL-Open" left in READMEs.