### PR TITLE
Fix clang-format step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: clang-format
+      if: ${{ github.event_name == 'pull_request' }}
       run: |
         HEAD_SHA=${{ github.event.pull_request.head.sha }}
         BASE_SHA=${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,7 @@ jobs:
 
     - name: clang-format
       run: |
-        HEAD_SHA=${{ github.event.pull_request.head.sha }}
-        BASE_SHA=${{ github.event.pull_request.base.sha }}
-        MERGE_BASE_SHA=$(git merge-base $HEAD_SHA $BASE_SHA)
-        git diff --name-only $MERGE_BASE_SHA $HEAD_SHA | \
-          egrep "\.(c|h)$" | \
+        git ls-files "*.[ch]" | \
           xargs -I{} bash -c "if [ -f {} ] ; then clang-format --dry-run -style=file --Werror {} ; fi"
 
     - name: Configure and build (tests and benchmarks)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,11 @@ jobs:
 
     - name: clang-format
       run: |
-        git ls-files "*.[ch]" | \
+        HEAD_SHA=${{ github.event.pull_request.head.sha }}
+        BASE_SHA=${{ github.event.pull_request.base.sha }}
+        MERGE_BASE_SHA=$(git merge-base $HEAD_SHA $BASE_SHA)
+        git diff --name-only $MERGE_BASE_SHA $HEAD_SHA | \
+          egrep "\.(c|h)$" | \
           xargs -I{} bash -c "if [ -f {} ] ; then clang-format --dry-run -style=file --Werror {} ; fi"
 
     - name: Configure and build (tests and benchmarks)


### PR DESCRIPTION
This PR fixes the clang-format step in CI so it will work post-merge as well. Originally, for a PR, clang-format would only run on files that were changed. This PR modifies it so that clang-format will simply run on all `.c` and `.h` files.