### PR TITLE
CODEOWNERS update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
+* @ericlove
+
 /cmake @Aaron-Hutchinson
 /doc @Aaron-Hutchinson
 /include @Aaron-Hutchinson

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,13 @@
-* @ericlove
+/cmake @Aaron-Hutchinson
+/doc @Aaron-Hutchinson
+/include @Aaron-Hutchinson
+
+/src/gemm/rvv @Aaron-Hutchinson
+/src/gemm/scalar @Aaron-Hutchinson
+/src/transpose/rvv @Aaron-Hutchinson
+/src/transpose/scalar @Aaron-Hutchinson
+
+/test/gemm @Aaron-Hutchinson
+/test/transpose @Aaron-Hutchinson
+
+/CMakeLists.txt @Aaron-Hutchinson


### PR DESCRIPTION
Populating `CODEOWNERS` with myself.

~I've removed `* @ericlove` (CC @ericlove) because, based on my understanding of how a codeowners file works, that line conflicts with those I've added since only one codeowner line is selected for a given file.~

I ordered the lines in the way they appear on GitHub (alphabetically, but with directories first), and used newlines to group large categories (`src` and `test`).