### PR TITLE
Add CONTRIBUTORS.md file

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,11 @@
+# Initial contributors
+
+Aaron Hutchinson
+Eric Bavier
+Eric Love
+Harlen Chen
+Hugues de Lassus
+Jesse Chen
+Michael Yeh
+Patty Lin
+Yazmau Chen

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,11 +1,11 @@
 # Initial contributors
 
-Aaron Hutchinson
-Eric Bavier
-Eric Love
-Harlen Chen
-Hugues de Lassus
-Jesse Chen
-Michael Yeh
-Patty Lin
-Yazmau Chen
+* [Aaron Hutchinson](https://github.com/Aaron-Hutchinson)
+* [Eric Bavier](https://github.com/ebavier)
+* [Eric Love](https://github.com/ericlove)
+* [Harlen Chen](https://github.com/Harlen126)
+* [Hugues de Lassus](https://github.com/hdelassus)
+* [Jesse Chen](https://github.com/france5289)
+* [Michael Yeh](https://github.com/myeh01)
+* [Patty Lin](https://github.com/peichialin)
+* [Yazmau Chen](https://github.com/Yazmau)


### PR DESCRIPTION
# What this PR does

It adds a `CONTRIBUTORS.md` file listing every contributor that authored one or more commits to the SKL codebase before its open-source release. It was autogenerated with a combination of `git-log`, `sort`, and `uniq` commands.

# Motivation

The SKL repository will be recreated from scratch, very likely with a history squashed to a single "Initial commit", before its open-source release. Thus, the names of its initial contributors will be unknown from the rewritten git history. A file listing such contributors will acknowledge their contributions to the open-source repository.