### PR TITLE
Add a shared benchmark macro to be used by kernel tests

### DIFF
--- a/test/gelu/gelu_f32.c
+++ b/test/gelu/gelu_f32.c
@@ -145,21 +145,6 @@ int main(void) {
   printf("Measuring %d-element GELU:\n", NUM_ELEMS);
   init_random(input, NUM_ELEMS); // input data
 
-#if defined(ENABLE_BENCHMARK)
-  // cycle and instruction counts
-  uint64_t c0, c1, i0, i1; // NOLINT(*-isolate-declaration)
-#define MEASURE_PERF(FUNCTION, NAME)                                           \
-  /* Measure 2nd run after caches warmed */                                    \
-  riscv_fence();                                                               \
-  c0 = riscv_read_mcycle(), i0 = riscv_read_minstret();                        \
-  FUNCTION(output, input, NUM_ELEMS);                                          \
-  riscv_fence();                                                               \
-  c1 = riscv_read_mcycle(), i1 = riscv_read_minstret();                        \
-  report_perf_epc(NAME, c1 - c0, i1 - i0, NUM_ELEMS);
-#else
-#define MEASURE_PERF(FUNCTION, NAME)
-#endif
-
 #if defined(ENABLE_TEST)
   memset(ref_output, 0, NUM_ELEMS * sizeof(*ref_output));
   reference_gelu_f32(ref_output, input, NUM_ELEMS);
@@ -173,7 +158,8 @@ int main(void) {
 #define RUN_(FUNCTION, NAME, TOL, GEN2, GEN1, GE0, SPECIALS)                   \
   memset(output, 0, NUM_ELEMS * sizeof(*output));                              \
   FUNCTION(output, input, NUM_ELEMS);                                          \
-  MEASURE_PERF(FUNCTION, NAME);                                                \
+  SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, SKL_TEST_WARMUP, FUNCTION, output, input, \
+                    NUM_ELEMS);                                                \
   CHECK_RESULT(FUNCTION, NAME, TOL, GEN2, GEN1, GE0, SPECIALS);
 
 #define PASTE3(a, b, c) a##b##c

--- a/test/gelu/gelu_f32.c
+++ b/test/gelu/gelu_f32.c
@@ -157,7 +157,6 @@ int main(void) {
 
 #define RUN_(FUNCTION, NAME, TOL, GEN2, GEN1, GE0, SPECIALS)                   \
   memset(output, 0, NUM_ELEMS * sizeof(*output));                              \
-  FUNCTION(output, input, NUM_ELEMS);                                          \
   SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, SKL_TEST_WARMUP, FUNCTION, output, input, \
                     NUM_ELEMS);                                                \
   CHECK_RESULT(FUNCTION, NAME, TOL, GEN2, GEN1, GE0, SPECIALS);

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -13,7 +13,8 @@
 
 /* Extract the test name from SKL_TEST_NAME as a string. */
 #define SKL_TEST_NAME_STR(NAME) #NAME
-#define DECL_SKL_TEST_NAME(NAME) const char *skl_test_name = SKL_TEST_NAME_STR(NAME);
+#define DECL_SKL_TEST_NAME(NAME)                                               \
+  const char *skl_test_name = SKL_TEST_NAME_STR(NAME);
 DECL_SKL_TEST_NAME(SKL_TEST_NAME)
 
 #if __riscv_xlen == 32
@@ -54,29 +55,25 @@ static inline void print_float(float x) {
 }
 
 /**
- * @brief Output performance results in throughput and latency.
+ * @brief Output performance results in throughput and latency. (Default)
  *
  * @param name The name of the function.
  * @param cycles The number of cycles of execution.
  * @param insts The number of instructions executed.
  * @param num_elems The number of elements (application-specific)
- *
- * Writes a performance report to stdout in the following format:
- * ```
- * SIFIVE <name> latency: <cycles> cycles
- * SIFIVE <name> throughput: <epc> elements/cycle
- * ```
  */
 static inline void report_perf_epc(const char *name, uint64_t cycles,
                                    uint64_t insts, size_t num_elems) {
+  printf("SKL Benchmark %s (%zu elements):\n", name, (size_t)num_elems);
+  printf("%15s : ", name);
   float epc = (float)num_elems / (float)cycles;
-  printf("\n%15s : ", name);
   print_float(epc);
   printf(" elements / cycle (%" PRIu64 " cycles)\n", cycles);
   float ipe = (float)insts / (float)num_elems;
   printf("%15s : ", name);
   print_float(ipe);
   printf(" insts / element  (%" PRIu64 " insts)\n", insts);
+  printf("\n");
 }
 
 /** @brief Determine whether to execute a warmup iteration.
@@ -86,6 +83,23 @@ static inline void report_perf_epc(const char *name, uint64_t cycles,
  */
 #if !defined(SKL_TEST_WARMUP)
 #define SKL_TEST_WARMUP 1
+#endif
+
+/**
+ * @brief Set benchmark performance reporting function.
+ *
+ * Must be a function with the following signature:
+ *
+ * ```c
+ * void report_perf(const char *name, uint64_t cycles, uint64_t insts, size_t
+ * num_elems);
+ * ```
+ *
+ * Used by most SKL benchmarks as a default. Can be overridden by defining
+ * before including skl-test.h.
+ */
+#if !defined(SKL_TEST_PERF_REPORT)
+#define SKL_TEST_PERF_REPORT report_perf_epc
 #endif
 
 /**
@@ -108,7 +122,6 @@ static inline void report_perf_epc(const char *name, uint64_t cycles,
 #if defined(ENABLE_BENCHMARK)
 #define SKL_BENCHMARK_RUN(name, num_elems, warmup, func, ...)                  \
   do {                                                                         \
-    printf("SKL Benchmark %s (%zu elements):\n", name, (size_t)num_elems);     \
     if (warmup) {                                                              \
       func(__VA_ARGS__);                                                       \
     }                                                                          \
@@ -121,11 +134,7 @@ static inline void report_perf_epc(const char *name, uint64_t cycles,
     uint64_t i1 = riscv_read_minstret();                                       \
     uint64_t cycles = c1 - c0;                                                 \
     uint64_t insts = i1 - i0;                                                  \
-    printf("SIFIVE %s latency: %" PRIu64 " cycles\n", name, cycles);           \
-    printf("SIFIVE %s instructions: %" PRIu64 " instructions\n", name, insts); \
-    printf("SIFIVE %s throughput: ", name);                                    \
-    print_float((float)num_elems / (float)cycles);                             \
-    printf(" elements/cycle\n");                                               \
+    SKL_TEST_PERF_REPORT(name, cycles, insts, (size_t)(num_elems));            \
   } while (0)
 #else
 #define SKL_BENCHMARK_RUN(name, num_elems, warmup, func, ...) ((void)0)

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -79,6 +79,15 @@ static inline void report_perf_epc(const char *name, uint64_t cycles,
   printf(" insts / element  (%" PRIu64 " insts)\n", insts);
 }
 
+/** @brief Determine whether to execute a warmup iteration.
+ *
+ * Used by most SKL benchmarks as a default. Can be overridden by defining
+ * before including skl-test.h.
+ */
+#if !defined(SKL_TEST_WARMUP)
+#define SKL_TEST_WARMUP 1
+#endif
+
 /**
  * @brief Run a benchmark and report performance.
  *
@@ -92,6 +101,7 @@ static inline void report_perf_epc(const char *name, uint64_t cycles,
  * riscv_read_minstret() to measure the performance of a function.
  *
  * If warmup is true, run the function once before timing to warm up caches.
+ * Usually warmup is set to SKL_TEST_WARMUP, which is 1 by default.
  *
  * If ENABLE_BENCHMARK is not defined, this macro does nothing.
  */

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -77,9 +77,10 @@ static inline void report_perf_epc(const char *name, uint64_t cycles,
 /**
  * @brief Run a benchmark and report performance.
  *
+ * @param name - The name of the benchmark.
  * @param num_elems - The number of elements (application-specific).
  * @param warmup - Whether to run a warmup iteration.
- * @param func - The name of the function to benchmark.
+ * @param func - The function to benchmark (will be applied to __VA_ARGS__).
  * @param ... - The arguments to pass to the function.
  *
  * This macro is a wrapper around riscv_read_mcycle() and
@@ -90,9 +91,9 @@ static inline void report_perf_epc(const char *name, uint64_t cycles,
  * If ENABLE_BENCHMARK is not defined, this macro does nothing.
  */
 #if defined(ENABLE_BENCHMARK)
-#define SKL_BENCHMARK_RUN(num_elems, warmup, func, ...)                     \
+#define SKL_BENCHMARK_RUN(name, num_elems, warmup, func, ...)                  \
   do {                                                                         \
-    printf("SKL Benchmark %s (%zu elements):\n", #func, (size_t)num_elems);     \
+    printf("SKL Benchmark %s (%zu elements):\n", name, (size_t)num_elems);     \
     if (warmup) {                                                              \
       func(__VA_ARGS__);                                                       \
     }                                                                          \
@@ -105,14 +106,14 @@ static inline void report_perf_epc(const char *name, uint64_t cycles,
     uint64_t i1 = riscv_read_minstret();                                       \
     uint64_t cycles = c1 - c0;                                                 \
     uint64_t insts = i1 - i0;                                                  \
-    printf("SIFIVE %s latency: %" PRIu64 " cycles\n", #func, cycles);           \
-    printf("SIFIVE %s instructions: %" PRIu64 " instructions\n", #func, insts); \
-    printf("SIFIVE %s throughput: ", #func);                                    \
+    printf("SIFIVE %s latency: %" PRIu64 " cycles\n", name, cycles);           \
+    printf("SIFIVE %s instructions: %" PRIu64 " instructions\n", name, insts); \
+    printf("SIFIVE %s throughput: ", name);                                    \
     print_float((float)num_elems / (float)cycles);                             \
     printf(" elements/cycle\n");                                               \
   } while (0)
 #else
-#define SKL_BENCHMARK_RUN(num_elems, warmup, func, ...) ((void)0)
+#define SKL_BENCHMARK_RUN(name, num_elems, warmup, func, ...) ((void)0)
 #endif
 
 /**

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -55,7 +55,7 @@ static inline void print_float(float x) {
 }
 
 /**
- * @brief Output performance results in throughput and latency. (Default)
+ * @brief Output performance results in throughput. (Default)
  *
  * @param name The name of the function.
  * @param cycles The number of cycles of execution.
@@ -64,9 +64,8 @@ static inline void print_float(float x) {
  */
 static inline void report_perf_epc(const char *name, uint64_t cycles,
                                    uint64_t insts, size_t num_elems) {
-  printf("SKL Benchmark %s (%zu elements):\n", name, (size_t)num_elems);
-  printf("%15s : ", name);
   float epc = (float)num_elems / (float)cycles;
+  printf("\n%15s : ", name);
   print_float(epc);
   printf(" elements / cycle (%" PRIu64 " cycles)\n", cycles);
   float ipe = (float)insts / (float)num_elems;

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -54,17 +54,29 @@ static inline void print_float(float x) {
   printf("%d.%04d", i, f);
 }
 
+/** @brief Determine whether to execute a warmup iteration.
+ *
+ * Used by most SKL benchmarks as a default. Can be overridden by defining
+ * before including skl-test.h.
+ */
+#if !defined(SKL_TEST_WARMUP)
+#define SKL_TEST_WARMUP 1
+#endif
+
 /**
  * @brief Output performance results in throughput and latency. (Default)
  *
  * @param name The name of the function.
+ * @param num_elems The number of elements (application-specific)
+ * @param warmup Whether this is a warmup iteration.
  * @param cycles The number of cycles of execution.
  * @param insts The number of instructions executed.
- * @param num_elems The number of elements (application-specific)
  */
-static inline void report_perf_epc(const char *name, uint64_t cycles,
-                                   uint64_t insts, size_t num_elems) {
-  printf("SKL Benchmark %s (%zu elements):\n", name, (size_t)num_elems);
+static inline void report_perf_epc(const char *name, size_t num_elems,
+                                   bool warmup, uint64_t cycles,
+                                   uint64_t insts) {
+  printf("SKL Benchmark %s (%zu elements%s):\n", name, (size_t)num_elems,
+         warmup ? ", warmup" : "");
   printf("%15s : ", name);
   float epc = (float)num_elems / (float)cycles;
   print_float(epc);
@@ -76,23 +88,14 @@ static inline void report_perf_epc(const char *name, uint64_t cycles,
   printf("\n");
 }
 
-/** @brief Determine whether to execute a warmup iteration.
- *
- * Used by most SKL benchmarks as a default. Can be overridden by defining
- * before including skl-test.h.
- */
-#if !defined(SKL_TEST_WARMUP)
-#define SKL_TEST_WARMUP 1
-#endif
-
 /**
  * @brief Set benchmark performance reporting function.
  *
  * Must be a function with the following signature:
  *
  * ```c
- * void report_perf(const char *name, uint64_t cycles, uint64_t insts, size_t
- * num_elems);
+ * void report_perf(const char *name, size_t num_elems, bool warmup,
+ * uint64_t cycles, uint64_t insts);
  * ```
  *
  * Used by most SKL benchmarks as a default. Can be overridden by defining
@@ -134,7 +137,8 @@ static inline void report_perf_epc(const char *name, uint64_t cycles,
     uint64_t i1 = riscv_read_minstret();                                       \
     uint64_t cycles = c1 - c0;                                                 \
     uint64_t insts = i1 - i0;                                                  \
-    SKL_TEST_PERF_REPORT(name, cycles, insts, (size_t)(num_elems));            \
+    SKL_TEST_PERF_REPORT(name, (size_t)(num_elems), (bool)(warmup), cycles,    \
+                         insts);                                               \
   } while (0)
 #else
 #define SKL_BENCHMARK_RUN(name, num_elems, warmup, func, ...) ((void)0)

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -109,7 +109,8 @@ static inline void report_perf_epc(const char *name, uint64_t cycles,
  * If WARMUP is true, run the function once before timing to warm up caches.
  * Usually WARMUP is set to SKL_TEST_WARMUP, which is 1 by default.
  *
- * If ENABLE_BENCHMARK is not defined, this macro does nothing.
+ * If ENABLE_BENCHMARK is not defined, but ENABLE_TEST is defined, this macro
+ * calls FUNC(__VA_ARGS__).  Otherwise, this macro does nothing.
  */
 #if defined(ENABLE_BENCHMARK)
 #define SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, WARMUP, FUNC, ...)                  \
@@ -127,6 +128,11 @@ static inline void report_perf_epc(const char *name, uint64_t cycles,
     uint64_t cycles = c1 - c0;                                                 \
     uint64_t insts = i1 - i0;                                                  \
     SKL_TEST_PERF_REPORT(NAME, cycles, insts, (size_t)(NUM_ELEMS));            \
+  } while (0)
+#elif defined(ENABLE_TEST)
+#define SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, WARMUP, FUNC, ...)                  \
+  do {                                                                         \
+    FUNC(__VA_ARGS__);                                                         \
   } while (0)
 #else
 #define SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, WARMUP, FUNC, ...) ((void)0)

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -68,7 +68,7 @@ static inline void print_float(float x) {
  *
  * @param name The name of the function.
  * @param num_elems The number of elements (application-specific)
- * @param warmup Whether this is a warmup iteration.
+ * @param warmup Whether warmup was performed for this result.
  * @param cycles The number of cycles of execution.
  * @param insts The number of instructions executed.
  */

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -11,12 +11,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-/* Extract the test name from SKL_TEST_NAME as a string. */
-#define SKL_TEST_NAME_STR(NAME) #NAME
-#define DECL_SKL_TEST_NAME(NAME)                                               \
-  const char *skl_test_name = SKL_TEST_NAME_STR(NAME);
-DECL_SKL_TEST_NAME(SKL_TEST_NAME)
-
 #if __riscv_xlen == 32
 #define RISCV_READ_COUNTER_FUNC(COUNTER)                                       \
   static inline uint64_t riscv_read_m##COUNTER(void) {                         \

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -118,8 +118,8 @@ static inline void report_perf_epc(const char *name, uint64_t cycles,
       FUNC(__VA_ARGS__);                                                       \
     }                                                                          \
     riscv_fence();                                                             \
-    uint64_t c0 = riscv_read_mcycle();                                         \
     uint64_t i0 = riscv_read_minstret();                                       \
+    uint64_t c0 = riscv_read_mcycle();                                         \
     FUNC(__VA_ARGS__);                                                         \
     riscv_fence();                                                             \
     uint64_t c1 = riscv_read_mcycle();                                         \

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -54,29 +54,17 @@ static inline void print_float(float x) {
   printf("%d.%04d", i, f);
 }
 
-/** @brief Determine whether to execute a warmup iteration.
- *
- * Used by most SKL benchmarks as a default. Can be overridden by defining
- * before including skl-test.h.
- */
-#if !defined(SKL_TEST_WARMUP)
-#define SKL_TEST_WARMUP 1
-#endif
-
 /**
  * @brief Output performance results in throughput and latency. (Default)
  *
  * @param name The name of the function.
- * @param num_elems The number of elements (application-specific)
- * @param warmup Whether warmup was performed for this result.
  * @param cycles The number of cycles of execution.
  * @param insts The number of instructions executed.
+ * @param num_elems The number of elements (application-specific)
  */
-static inline void report_perf_epc(const char *name, size_t num_elems,
-                                   bool warmup, uint64_t cycles,
-                                   uint64_t insts) {
-  printf("SKL Benchmark %s (%zu elements%s):\n", name, (size_t)num_elems,
-         warmup ? ", warmup" : "");
+static inline void report_perf_epc(const char *name, uint64_t cycles,
+                                   uint64_t insts, size_t num_elems) {
+  printf("SKL Benchmark %s (%zu elements):\n", name, (size_t)num_elems);
   printf("%15s : ", name);
   float epc = (float)num_elems / (float)cycles;
   print_float(epc);
@@ -87,14 +75,23 @@ static inline void report_perf_epc(const char *name, size_t num_elems,
   printf(" insts / element  (%" PRIu64 " insts)\n", insts);
 }
 
+/** @brief Determine whether to execute a warmup iteration.
+ *
+ * Used by most SKL benchmarks as a default. Can be overridden by defining
+ * before including skl-test.h.
+ */
+#if !defined(SKL_TEST_WARMUP)
+#define SKL_TEST_WARMUP 1
+#endif
+
 /**
  * @brief Set benchmark performance reporting function.
  *
  * Must be a function with the following signature:
  *
  * ```c
- * void report_perf(const char *name, size_t num_elems, bool warmup,
- * uint64_t cycles, uint64_t insts);
+ * void report_perf(const char *name, uint64_t cycles, uint64_t insts, size_t
+ * num_elems);
  * ```
  *
  * Used by most SKL benchmarks as a default. Can be overridden by defining
@@ -136,8 +133,7 @@ static inline void report_perf_epc(const char *name, size_t num_elems,
     uint64_t i1 = riscv_read_minstret();                                       \
     uint64_t cycles = c1 - c0;                                                 \
     uint64_t insts = i1 - i0;                                                  \
-    SKL_TEST_PERF_REPORT(NAME, (size_t)(NUM_ELEMS), (bool)(WARMUP), cycles,    \
-                         insts);                                               \
+    SKL_TEST_PERF_REPORT(NAME, cycles, insts, (size_t)(NUM_ELEMS));            \
   } while (0)
 #else
 #define SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, WARMUP, FUNC, ...) ((void)0)

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -11,6 +11,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/* Extract the test name from SKL_TEST_NAME as a string. */
+#define SKL_TEST_NAME_STR(NAME) #NAME
+#define DECL_SKL_TEST_NAME(NAME) const char *skl_test_name = SKL_TEST_NAME_STR(NAME);
+DECL_SKL_TEST_NAME(SKL_TEST_NAME)
+
 #if __riscv_xlen == 32
 #define RISCV_READ_COUNTER_FUNC(COUNTER)                                       \
   static inline uint64_t riscv_read_m##COUNTER(void) {                         \

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -107,40 +107,40 @@ static inline void report_perf_epc(const char *name, size_t num_elems,
 /**
  * @brief Run a benchmark and report performance.
  *
- * @param name - The name of the benchmark.
- * @param num_elems - The number of elements (application-specific).
- * @param warmup - Whether to run a warmup iteration.
- * @param func - The function to benchmark (will be applied to __VA_ARGS__).
+ * @param NAME - The name of the benchmark.
+ * @param NUM_ELEMS - The number of elements (application-specific).
+ * @param WARMUP - Whether to run a warmup iteration.
+ * @param FUNC - The function to benchmark (will be applied to __VA_ARGS__).
  * @param ... - The arguments to pass to the function.
  *
  * This macro is a wrapper around riscv_read_mcycle() and
  * riscv_read_minstret() to measure the performance of a function.
  *
- * If warmup is true, run the function once before timing to warm up caches.
- * Usually warmup is set to SKL_TEST_WARMUP, which is 1 by default.
+ * If WARMUP is true, run the function once before timing to warm up caches.
+ * Usually WARMUP is set to SKL_TEST_WARMUP, which is 1 by default.
  *
  * If ENABLE_BENCHMARK is not defined, this macro does nothing.
  */
 #if defined(ENABLE_BENCHMARK)
-#define SKL_BENCHMARK_RUN(name, num_elems, warmup, func, ...)                  \
+#define SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, WARMUP, FUNC, ...)                  \
   do {                                                                         \
-    if (warmup) {                                                              \
-      func(__VA_ARGS__);                                                       \
+    if (WARMUP) {                                                              \
+      FUNC(__VA_ARGS__);                                                       \
     }                                                                          \
     riscv_fence();                                                             \
     uint64_t c0 = riscv_read_mcycle();                                         \
     uint64_t i0 = riscv_read_minstret();                                       \
-    func(__VA_ARGS__);                                                         \
+    FUNC(__VA_ARGS__);                                                         \
     riscv_fence();                                                             \
     uint64_t c1 = riscv_read_mcycle();                                         \
     uint64_t i1 = riscv_read_minstret();                                       \
     uint64_t cycles = c1 - c0;                                                 \
     uint64_t insts = i1 - i0;                                                  \
-    SKL_TEST_PERF_REPORT(name, (size_t)(num_elems), (bool)(warmup), cycles,    \
+    SKL_TEST_PERF_REPORT(NAME, (size_t)(NUM_ELEMS), (bool)(WARMUP), cycles,    \
                          insts);                                               \
   } while (0)
 #else
-#define SKL_BENCHMARK_RUN(name, num_elems, warmup, func, ...) ((void)0)
+#define SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, WARMUP, FUNC, ...) ((void)0)
 #endif
 
 /**

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -85,7 +85,6 @@ static inline void report_perf_epc(const char *name, size_t num_elems,
   printf("%15s : ", name);
   print_float(ipe);
   printf(" insts / element  (%" PRIu64 " insts)\n", insts);
-  printf("\n");
 }
 
 /**

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -6,6 +6,7 @@
 #include <float.h>
 #include <inttypes.h>
 #include <math.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -47,7 +48,20 @@ static inline void print_float(float x) {
   printf("%d.%04d", i, f);
 }
 
-// Output performance result for throughput (elements/cycle) kernel
+/**
+ * @brief Output performance results in throughput and latency.
+ *
+ * @param name The name of the function.
+ * @param cycles The number of cycles of execution.
+ * @param insts The number of instructions executed.
+ * @param num_elems The number of elements (application-specific)
+ *
+ * Writes a performance report to stdout in the following format:
+ * ```
+ * SIFIVE <name> latency: <cycles> cycles
+ * SIFIVE <name> throughput: <epc> elements/cycle
+ * ```
+ */
 static inline void report_perf_epc(const char *name, uint64_t cycles,
                                    uint64_t insts, size_t num_elems) {
   float epc = (float)num_elems / (float)cycles;
@@ -59,6 +73,47 @@ static inline void report_perf_epc(const char *name, uint64_t cycles,
   print_float(ipe);
   printf(" insts / element  (%" PRIu64 " insts)\n", insts);
 }
+
+/**
+ * @brief Run a benchmark and report performance.
+ *
+ * @param num_elems - The number of elements (application-specific).
+ * @param warmup - Whether to run a warmup iteration.
+ * @param func - The name of the function to benchmark.
+ * @param ... - The arguments to pass to the function.
+ *
+ * This macro is a wrapper around riscv_read_mcycle() and
+ * riscv_read_minstret() to measure the performance of a function.
+ *
+ * If warmup is true, run the function once before timing to warm up caches.
+ *
+ * If ENABLE_BENCHMARK is not defined, this macro does nothing.
+ */
+#if defined(ENABLE_BENCHMARK)
+#define SKL_BENCHMARK_RUN(num_elems, warmup, func, ...)                     \
+  do {                                                                         \
+    printf("SKL Benchmark %s (%zu elements):\n", #func, (size_t)num_elems);     \
+    if (warmup) {                                                              \
+      func(__VA_ARGS__);                                                       \
+    }                                                                          \
+    riscv_fence();                                                             \
+    uint64_t c0 = riscv_read_mcycle();                                         \
+    uint64_t i0 = riscv_read_minstret();                                       \
+    func(__VA_ARGS__);                                                         \
+    riscv_fence();                                                             \
+    uint64_t c1 = riscv_read_mcycle();                                         \
+    uint64_t i1 = riscv_read_minstret();                                       \
+    uint64_t cycles = c1 - c0;                                                 \
+    uint64_t insts = i1 - i0;                                                  \
+    printf("SIFIVE %s latency: %" PRIu64 " cycles\n", #func, cycles);           \
+    printf("SIFIVE %s instructions: %" PRIu64 " instructions\n", #func, insts); \
+    printf("SIFIVE %s throughput: ", #func);                                    \
+    print_float((float)num_elems / (float)cycles);                             \
+    printf(" elements/cycle\n");                                               \
+  } while (0)
+#else
+#define SKL_BENCHMARK_RUN(num_elems, warmup, func, ...) ((void)0)
+#endif
 
 /**
  * @brief Macro to check a requirement and set status to 1 if not met.


### PR DESCRIPTION
# What this PR does

It defines three macros:
* `SKL_BENCHMARK_RUN`, to replace benchmark boilerplate and report performance in a unified way.
* `SKL_TEST_PERF_REPORT`, to allow customization of the performance reporting function called by `SKL_BENCHMARK_RUN`. By default set to `report_perf_epc`.
* `SKL_TEST_WARMUP`, to be used by benchmarks to request a warmup run before making any measurements. By default set to `1` (true).

As a test and usage example, the gelu_f32 test replaces the performance measurement and reporting boilerplate by the `SKL_BENCHMARK_RUN` macro.

This is purely a refactoring PR: no functional change is expected. More details follw.

## Shared benchmark macro
In @ericlove 's
> Assuming most benchmarks have a common pattern (some "number of elements", a need to print cycle/instruction counts, and throughput based on size), this PR introduces the `SKL_BENCHMARK_RUN` macro:

```c
/**
 * @brief Run a benchmark and report performance.
 *
 * @param NAME - The name of the benchmark.
 * @param NUM_ELEMS - The number of elements (application-specific).
 * @param WARMUP - Whether to run a warmup iteration.
 * @param FUNC - The function to benchmark (will be applied to __VA_ARGS__).
 * @param ... - The arguments to pass to the function.
 *
 * This macro is a wrapper around riscv_read_mcycle() and
 * riscv_read_minstret() to measure the performance of a function.
 *
 * If WARMUP is true, run the function once before timing to warm up caches.
 * Usually WARMUP is set to SKL_TEST_WARMUP, which is 1 by default.
 *
 * If ENABLE_BENCHMARK is not defined, this macro does nothing.
 */
#if defined(ENABLE_BENCHMARK)
#define SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, WARMUP, FUNC, ...)                  \
```

> It uses the `__VA_ARGS__` feature to forward all necessary arguments to the function-under-test, but prepends them with an element count (defined however makes sense for the benchmark) a name for use in the printout, and a boolean switch to enable/disable warmup (mostly set to a configurable macro `SKL_TEST_WARMUP` analogous to `SKL_TEST_MIN_F32` etc.).

## Common Benchmark Output Format

The `SKL_BENCHMARK_RUN` macro calls a configurable reporting function, set by `SKL_TEST_PERF_REPORT`. It defaults to the existing `report_perf_epc`, whose signature _is planned to be_ expanded to match that of the outer macro.

The configurability will allow SKL users to adjust the output as necessary.

# Motivation

The goals of this effort are twofold:
* to clean-up and unify SKL kernel benchmarks.
* to provide a way for users of the SKL project to customize performance reporting.

# How this was tested

The new macro replaces the boilerplate in the FP32 GELU test as a first example of how it may be used in other SKL kernel tests. Concretely this PR can be tested with the following commands:

```shell
cmake -B build -G Ninja --toolchain cmake/riscv.cmake -DSKL_BUILD_BENCHMARKS=ON
cmake --build build
ctest --test-dir build -R gelu_f32 -V
```