### PR TITLE
Add `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Build artifacts
+/build/
+/build-*/
+/build_*/
+/doc/html/


### PR DESCRIPTION
Adding a `.gitignore` file, starting with ignoring build artifacts like `build*` directories and Doxygen-built documentation.