### PR TITLE
Use shared macro for OFP4 and OFP8 conversion benchmarks

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -27,6 +27,7 @@ Each datatype is represented in the `<types>` field with a string generally foll
 
 | `<type>` | Description | C Type |
 |----------|-------------|---------|
+| `f4e2m1` | 4-bit OFP4 E2M1 floating point | `uint8_t` |
 | `f8e4m3` | 8-bit OFP8 E4M3 floating point | `uint8_t` |
 | `bf16` | 16-bit bfloat16 floating point | `__bf16` |
 | `f16`  | 16-bit IEEE half-precision floating point | `_Float16` |

--- a/test/cvt/cvt_ofp_zvfofp4min.c
+++ b/test/cvt/cvt_ofp_zvfofp4min.c
@@ -32,13 +32,7 @@ __attribute__((aligned(ALIGN))) uint8_t out_ofp8[NUM_ELEMS];
 
 #if defined(ENABLE_TEST)
 __attribute__((aligned(ALIGN))) uint8_t ref_ofp8[NUM_ELEMS];
-#endif
 
-#if defined(ENABLE_BENCHMARK)
-uint64_t c0, c1, i0, i1; // Cycle and instruction counts
-#endif
-
-#if defined(ENABLE_TEST)
 static void cvt_ofp4x2_f8e4m3(uint8_t in, uint8_t *out0, uint8_t *out1) {
 
   uint8_t in_0 = in & 0xFU;
@@ -82,19 +76,6 @@ static int check_error_ofp8(const char *name, const uint8_t *res,
 #define TEST_LABEL(S) #S ":\n"
 #define PRINT_TEST_NAME(S) printf(TEST_LABEL(S));
 
-#if defined(ENABLE_BENCHMARK)
-#define MEASURE_PERF_WCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE)                   \
-  /* Measure 2nd run after caches warmed */                                    \
-  riscv_fence();                                                               \
-  c0 = riscv_read_mcycle(), i0 = riscv_read_minstret();                        \
-  FUNCTION(out_##OUT_TYPE, in_##IN_TYPE, NUM_ELEMS);                           \
-  riscv_fence();                                                               \
-  c1 = riscv_read_mcycle(), i1 = riscv_read_minstret();                        \
-  report_perf_epc(#NAME, c1 - c0, i1 - i0, NUM_ELEMS);
-#else
-#define MEASURE_PERF_WCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE)
-#endif
-
 #if defined(ENABLE_TEST)
 #define GENERATE_GOLDEN_WCVT(NAME, IN_TYPE, OUT_TYPE)                          \
   golden_##NAME(ref_##OUT_TYPE, in_##IN_TYPE, NUM_ELEMS);
@@ -111,8 +92,8 @@ static int check_error_ofp8(const char *name, const uint8_t *res,
 
 #define RUN_WCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE)                            \
   memset(out_##OUT_TYPE, 0, NUM_ELEMS * sizeof(*out_##OUT_TYPE));              \
-  FUNCTION(out_##OUT_TYPE, in_##IN_TYPE, NUM_ELEMS);                           \
-  MEASURE_PERF_WCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE);                        \
+  SKL_BENCHMARK_RUN(#NAME, NUM_ELEMS, SKL_TEST_WARMUP, FUNCTION,               \
+                    out_##OUT_TYPE, in_##IN_TYPE, NUM_ELEMS);                  \
   GENERATE_GOLDEN_WCVT(NAME, IN_TYPE, OUT_TYPE);                               \
   CHECK_RESULT(NAME, IN_TYPE, OUT_TYPE);
 

--- a/test/cvt/cvt_ofp_zvfofp8min.c
+++ b/test/cvt/cvt_ofp_zvfofp8min.c
@@ -68,10 +68,6 @@ __attribute__((aligned(ALIGN))) __bf16 ref_bf16[NUM_ELEMS];
 
 __attribute__((unused)) static float scaling_factor = 1.0f;
 
-#if defined(ENABLE_BENCHMARK)
-static uint64_t c0, c1, i0, i1; // Cycle and instruction counts
-#endif
-
 #if defined(ENABLE_TEST)
 
 #if defined(RUN_F32_E4M3)
@@ -184,32 +180,6 @@ check_error_bf16(const char *name, const __bf16 *res, const __bf16 *ref) {
 #define TEST_LABEL(S) #S ":\n"
 #define PRINT_TEST_NAME(S) printf(TEST_LABEL(S));
 
-#if defined(ENABLE_BENCHMARK)
-#define MEASURE_PERF_NCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE)                   \
-  /* Measure 2nd run after caches warmed */                                    \
-  riscv_fence();                                                               \
-  c0 = riscv_read_mcycle(), i0 = riscv_read_minstret();                        \
-  FUNCTION(out_##OUT_TYPE, in_##IN_TYPE, scaling_factor, NUM_ELEMS);           \
-  riscv_fence();                                                               \
-  c1 = riscv_read_mcycle(), i1 = riscv_read_minstret();                        \
-  report_perf_epc(#NAME, c1 - c0, i1 - i0, NUM_ELEMS);
-#else
-#define MEASURE_PERF_NCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE)
-#endif
-
-#if defined(ENABLE_BENCHMARK)
-#define MEASURE_PERF_WCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE)                   \
-  /* Measure 2nd run after caches warmed */                                    \
-  riscv_fence();                                                               \
-  c0 = riscv_read_mcycle(), i0 = riscv_read_minstret();                        \
-  FUNCTION(out_##OUT_TYPE, in_##IN_TYPE, NUM_ELEMS);                           \
-  riscv_fence();                                                               \
-  c1 = riscv_read_mcycle(), i1 = riscv_read_minstret();                        \
-  report_perf_epc(#NAME, c1 - c0, i1 - i0, NUM_ELEMS);
-#else
-#define MEASURE_PERF_WCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE)
-#endif
-
 #if defined(ENABLE_TEST)
 #define GENERATE_GOLDEN_NCVT(NAME, IN_TYPE, OUT_TYPE)                          \
   golden_##NAME(ref_##OUT_TYPE, in_##IN_TYPE, scaling_factor, NUM_ELEMS);
@@ -233,15 +203,15 @@ check_error_bf16(const char *name, const __bf16 *res, const __bf16 *ref) {
 
 #define RUN_NCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE)                            \
   memset(out_##OUT_TYPE, 0, NUM_ELEMS * sizeof(*out_##OUT_TYPE));              \
-  FUNCTION(out_##OUT_TYPE, in_##IN_TYPE, scaling_factor, NUM_ELEMS);           \
-  MEASURE_PERF_NCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE);                        \
+  SKL_BENCHMARK_RUN(#NAME, NUM_ELEMS, SKL_TEST_WARMUP, FUNCTION,               \
+                    out_##OUT_TYPE, in_##IN_TYPE, scaling_factor, NUM_ELEMS);  \
   GENERATE_GOLDEN_NCVT(NAME, IN_TYPE, OUT_TYPE);                               \
   CHECK_RESULT(NAME, IN_TYPE, OUT_TYPE);
 
 #define RUN_WCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE)                            \
   memset(out_##OUT_TYPE, 0, NUM_ELEMS * sizeof(*out_##OUT_TYPE));              \
-  FUNCTION(out_##OUT_TYPE, in_##IN_TYPE, NUM_ELEMS);                           \
-  MEASURE_PERF_WCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE);                        \
+  SKL_BENCHMARK_RUN(#NAME, NUM_ELEMS, SKL_TEST_WARMUP, FUNCTION,               \
+                    out_##OUT_TYPE, in_##IN_TYPE, NUM_ELEMS);                  \
   GENERATE_GOLDEN_WCVT(NAME, IN_TYPE, OUT_TYPE);                               \
   CHECK_RESULT(NAME, IN_TYPE, OUT_TYPE);
 

--- a/test/cvt/cvt_ofp_zvfofp8min_zvfbfmin.c
+++ b/test/cvt/cvt_ofp_zvfofp8min_zvfbfmin.c
@@ -52,10 +52,6 @@ __attribute__((aligned(ALIGN))) uint8_t ref_ofp8[NUM_ELEMS];
 
 static float scaling_factor = 1.0f;
 
-#if defined(ENABLE_BENCHMARK)
-static uint64_t c0, c1, i0, i1; // Cycle and instruction counts
-#endif
-
 #if defined(ENABLE_TEST)
 static void golden_cvt_bf16_f8e4m3_scale(uint8_t *pDst, const __bf16 *pSrc,
                                          float scaling_factor, size_t n) {
@@ -140,19 +136,6 @@ static int check_error_ofp8(const char *name, const uint8_t *res,
 #define TEST_LABEL(S) #S ":\n"
 #define PRINT_TEST_NAME(S) printf(TEST_LABEL(S));
 
-#if defined(ENABLE_BENCHMARK)
-#define MEASURE_PERF_NCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE)                   \
-  /* Measure 2nd run after caches warmed */                                    \
-  riscv_fence();                                                               \
-  c0 = riscv_read_mcycle(), i0 = riscv_read_minstret();                        \
-  FUNCTION(out_##OUT_TYPE, in_##IN_TYPE, scaling_factor, NUM_ELEMS);           \
-  riscv_fence();                                                               \
-  c1 = riscv_read_mcycle(), i1 = riscv_read_minstret();                        \
-  report_perf_epc(#NAME, c1 - c0, i1 - i0, NUM_ELEMS);
-#else
-#define MEASURE_PERF_NCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE)
-#endif
-
 #if defined(ENABLE_TEST)
 #define GENERATE_GOLDEN_NCVT(NAME, IN_TYPE, OUT_TYPE)                          \
   golden_##NAME(ref_##OUT_TYPE, in_##IN_TYPE, scaling_factor, NUM_ELEMS);
@@ -169,8 +152,8 @@ static int check_error_ofp8(const char *name, const uint8_t *res,
 
 #define RUN_NCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE)                            \
   memset(out_##OUT_TYPE, 0, NUM_ELEMS * sizeof(*out_##OUT_TYPE));              \
-  FUNCTION(out_##OUT_TYPE, in_##IN_TYPE, scaling_factor, NUM_ELEMS);           \
-  MEASURE_PERF_NCVT(FUNCTION, NAME, IN_TYPE, OUT_TYPE);                        \
+  SKL_BENCHMARK_RUN(#NAME, NUM_ELEMS, SKL_TEST_WARMUP, FUNCTION,               \
+                    out_##OUT_TYPE, in_##IN_TYPE, scaling_factor, NUM_ELEMS);  \
   GENERATE_GOLDEN_NCVT(NAME, IN_TYPE, OUT_TYPE);                               \
   CHECK_RESULT(NAME, IN_TYPE, OUT_TYPE);
 


### PR DESCRIPTION
This PR makes OFP4 and OFP8 conversion benchmarks use the `SKL_BENCHMARK_RUN` macro introduced in #11. It can be tested with a toolchain that supports Zvfofp4min and Zvfofp8min by un-commenting the [extensions](https://github.com/sifive/skl/blob/a77b0ca686e32a6662d72f8da247b6f403525809/cmake/riscv.cmake#L28-L29) in the `cmake/riscv.cmake` toolchain file.
The output of `ctest` should remain broadly the same (modulo cycles and instret counter values) whatever the combination of `SKL_BUILD_TESTS` and `SKL_BUILD_BENCHMARKS` is.