### PR TITLE
[GEMM] Add remaining tilings for f8 Xsfmm GEMM

### DIFF
--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -169,14 +169,12 @@ SKL_FUNC_PRIVATE void skl_gemm_1tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 SKL_XSFMM_NEW
 SKL_FUNC_PRIVATE void
 skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
-    size_t tn, size_t k, const uint8_t *a, size_t rsa, const uint8_t *b,
-    size_t rsb0, size_t csb1, float *c, size_t rsc0, size_t tsc1, bool accum,
-    bool bta) {
+    size_t tm, size_t tn, size_t k, const uint8_t *a, size_t rsa,
+    const uint8_t *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
+    size_t tsc1, bool accum, bool bta) {
   // We can use the same inner loop code for both values of bta by computing A^T
   // * B0 and A^T * B1 and then transposing the result if bta == true.
   // The active tile state has shape tm0 x tn0.
-  size_t tm = tn;
-
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -249,10 +247,12 @@ skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
         "beq %[k], %[i1], 1f\n"
 
         // k == 3
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
         "add %[a0_0], %[a0_0], %[sa]\n"
         "vle8.v v2, (%[a0_1])\n"
         "vle8.v v4, (%[a0_0])\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "vle8.v v8, (%[b0_0])\n"
         "add %[b0_0], %[b0_0], %[sb]\n"
@@ -270,8 +270,10 @@ skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
         "j 2f\n"
 
         "0:\n" // k == 2
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
         "vle8.v v2, (%[a0_1])\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "vle8.v v8, (%[b0_0])\n"
         "vle8.v v10, (%[b0_1])\n"
@@ -285,7 +287,9 @@ skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
         "j 2f\n"
 
         "1:\n" // k == 1
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "vle8.v v8, (%[b0_0])\n"
 
@@ -309,6 +313,7 @@ skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
                      "sf.vsettm x0, %[tm0]\n"
                      "sf.vsettk x0, %[k]\n"
 
+                     "sf.vsettn x0, %[tm0]\n"
                      "vle8.v v0, (%[a0_0])\n"
                      "add %[a0_0], %[a0_0], %[sa]\n"
                      "vle8.v v2, (%[a0_1])\n"
@@ -317,6 +322,7 @@ skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
                      "add %[a0_0], %[a0_0], %[sa]\n"
                      "vle8.v v6, (%[a0_1])\n"
                      "add %[a0_1], %[a0_1], %[sa]\n"
+                     "sf.vsettn x0, %[tn0]\n"
 
                      "vle8.v v8, (%[b0_0])\n"
                      "add %[b0_0], %[b0_0], %[sb]\n"
@@ -353,6 +359,7 @@ skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 
                      "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
 
+                     "sf.vsettn x0, %[tm0]\n"
                      "vle8.v v0, (%[a0_0])\n"
                      "add %[a0_0], %[a0_0], %[sa]\n"
                      "vle8.v v2, (%[a0_1])\n"
@@ -361,6 +368,7 @@ skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
                      "add %[a0_0], %[a0_0], %[sa]\n"
                      "vle8.v v6, (%[a0_1])\n"
                      "add %[a0_1], %[a0_1], %[sa]\n"
+                     "sf.vsettn x0, %[tn0]\n"
 
                      "bgeu %[k], %[i8], 0b\n"
 
@@ -389,10 +397,12 @@ skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 
                      "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
 
+                     "sf.vsettn x0, %[tm0]\n"
                      "vle8.v v0, (%[a0_0])\n"
                      "add %[a0_0], %[a0_0], %[sa]\n"
                      "vle8.v v2, (%[a0_1])\n"
                      "vle8.v v4, (%[a0_0])\n"
+                     "sf.vsettn x0, %[tn0]\n"
 
                      "vle8.v v16, (%[b1_0])\n"
                      "add %[b1_0], %[b1_0], %[sb]\n"
@@ -410,8 +420,10 @@ skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 
                      "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
 
+                     "sf.vsettn x0, %[tm0]\n"
                      "vle8.v v0, (%[a0_0])\n"
                      "vle8.v v2, (%[a0_1])\n"
+                     "sf.vsettn x0, %[tn0]\n"
 
                      "vle8.v v16, (%[b1_0])\n"
                      "vle8.v v18, (%[b1_1])\n"
@@ -426,7 +438,9 @@ skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 
                      "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
 
+                     "sf.vsettn x0, %[tm0]\n"
                      "vle8.v v0, (%[a0_0])\n"
+                     "sf.vsettn x0, %[tn0]\n"
 
                      "vle8.v v16, (%[b1_0])\n"
 
@@ -1323,10 +1337,11 @@ skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
  */
 SKL_XSFMM_NEW
 SKL_FUNC_PRIVATE void skl_gemm_1tm2tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
-    size_t tn, size_t k, const uint8_t *a, size_t csa, const uint8_t *b,
-    size_t rsb0, size_t csb1, float *c, size_t rsc0, size_t csc1, bool accum) {
+    size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa,
+    const uint8_t *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
+    size_t csc1, bool accum) {
   skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
-      tn, k, a, csa, b, rsb0, csb1, c, rsc0, csc1, accum, false);
+      tm, tn, k, a, csa, b, rsb0, csb1, c, rsc0, csc1, accum, false);
 }
 
 /* Process 2 (= 2 x 1) contiguous tm x tn tiles of c.
@@ -1334,11 +1349,11 @@ SKL_FUNC_PRIVATE void skl_gemm_1tm2tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
  */
 SKL_XSFMM_NEW
 SKL_FUNC_PRIVATE void skl_gemm_2tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
-    size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
+    size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
     const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
   skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
-      tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+      tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
 }
 
 /* Process 3 (= 1 x 3) contiguous tm x tn tiles of c.
@@ -1893,7 +1908,7 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
     }
     if (j < n1) {
       skl_gemm_2tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
-          ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete,
+          ete, ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete,
           c_pack + i * rsc1 + j * csc1, ete, rsc1, accum);
     }
     i += 2;
@@ -1914,7 +1929,7 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
       break;
     case 2:
       skl_gemm_1tm2tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
-          ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete, csb1,
+          ete, ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete, csb1,
           c_pack + i * rsc1 + j * csc1, ete, csc1, accum);
       break;
     case 1:

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -495,14 +495,12 @@ skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 SKL_XSFMM_NEW
 SKL_FUNC_PRIVATE void
 skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
-    size_t tn, size_t k, const uint8_t *a, size_t rsa, const uint8_t *b,
-    size_t rsb0, size_t csb1, float *c, size_t rsc0, size_t tsc1, bool accum,
-    bool bta) {
+    size_t tm, size_t tn, size_t k, const uint8_t *a, size_t rsa,
+    const uint8_t *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
+    size_t tsc1, bool accum, bool bta) {
   // We can use the same inner loop code for both values of bta by computing A^T
   // * B0 and A^T * B1 and then transposing the result if bta == true.
   // The active tile state has shape tm0 x tn0.
-  size_t tm = tn;
-
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -585,10 +583,12 @@ skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
                      "beq %[k], %[i1], 1f\n"
 
                      // k == 3
+                     "sf.vsettn x0, %[tm0]\n"
                      "vle8.v v0, (%[a0_0])\n"
                      "add %[a0_0], %[a0_0], %[sa]\n"
                      "vle8.v v2, (%[a0_1])\n"
                      "vle8.v v4, (%[a0_0])\n"
+                     "sf.vsettn x0, %[tn0]\n"
 
                      "vle8.v v8, (%[b0_0])\n"
                      "add %[b0_0], %[b0_0], %[sb]\n"
@@ -613,8 +613,10 @@ skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
                      "j 2f\n"
 
                      "0:\n" // k == 2
+                     "sf.vsettn x0, %[tm0]\n"
                      "vle8.v v0, (%[a0_0])\n"
                      "vle8.v v2, (%[a0_1])\n"
+                     "sf.vsettn x0, %[tn0]\n"
 
                      "vle8.v v8, (%[b0_0])\n"
                      "vle8.v v10, (%[b0_1])\n"
@@ -633,7 +635,9 @@ skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
                      "j 2f\n"
 
                      "1:\n" // k == 1
+                     "sf.vsettn x0, %[tm0]\n"
                      "vle8.v v0, (%[a0_0])\n"
+                     "sf.vsettn x0, %[tn0]\n"
 
                      "vle8.v v8, (%[b0_0])\n"
 
@@ -663,6 +667,7 @@ skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
         "sf.vsettm x0, %[tm0]\n"
         "sf.vsettk x0, %[k]\n"
 
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
         "add %[a0_0], %[a0_0], %[sa]\n"
         "vle8.v v2, (%[a0_1])\n"
@@ -671,6 +676,7 @@ skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
         "add %[a0_0], %[a0_0], %[sa]\n"
         "vle8.v v6, (%[a0_1])\n"
         "add %[a0_1], %[a0_1], %[sa]\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "vle8.v v8, (%[b0_0])\n"
         "add %[b0_0], %[b0_0], %[sb]\n"
@@ -718,6 +724,7 @@ skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 
         "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
 
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
         "add %[a0_0], %[a0_0], %[sa]\n"
         "vle8.v v2, (%[a0_1])\n"
@@ -726,6 +733,7 @@ skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
         "add %[a0_0], %[a0_0], %[sa]\n"
         "vle8.v v6, (%[a0_1])\n"
         "add %[a0_1], %[a0_1], %[sa]\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "bgeu %[k], %[i8], 0b\n"
 
@@ -765,10 +773,12 @@ skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 
         "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
 
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
         "add %[a0_0], %[a0_0], %[sa]\n"
         "vle8.v v2, (%[a0_1])\n"
         "vle8.v v4, (%[a0_0])\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "vle8.v v16, (%[b1_0])\n"
         "add %[b1_0], %[b1_0], %[sb]\n"
@@ -793,8 +803,10 @@ skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 
         "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
 
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
         "vle8.v v2, (%[a0_1])\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "vle8.v v16, (%[b1_0])\n"
         "vle8.v v18, (%[b1_1])\n"
@@ -814,7 +826,9 @@ skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 
         "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
 
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "vle8.v v16, (%[b1_0])\n"
 
@@ -1361,10 +1375,11 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
  */
 SKL_XSFMM_NEW
 SKL_FUNC_PRIVATE void skl_gemm_1tm3tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
-    size_t tn, size_t k, const uint8_t *a, size_t csa, const uint8_t *b,
-    size_t rsb0, size_t csb1, float *c, size_t rsc0, size_t csc1, bool accum) {
+    size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa,
+    const uint8_t *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
+    size_t csc1, bool accum) {
   skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
-      tn, k, a, csa, b, rsb0, csb1, c, rsc0, csc1, accum, false);
+      tm, tn, k, a, csa, b, rsb0, csb1, c, rsc0, csc1, accum, false);
 }
 
 /* Process 3 (= 3 x 1) contiguous tm x tn tiles of c.
@@ -1372,11 +1387,11 @@ SKL_FUNC_PRIVATE void skl_gemm_1tm3tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
  */
 SKL_XSFMM_NEW
 SKL_FUNC_PRIVATE void skl_gemm_3tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
-    size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
+    size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
     const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
   skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
-      tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+      tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
 }
 
 /* Process 4 (= 1 x 4) contiguous tm x tn tiles of c.
@@ -1924,7 +1939,7 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
     switch (n1 - j) {
     case 3:
       skl_gemm_1tm3tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
-          ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete, csb1,
+          ete, ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete, csb1,
           c_pack + i * rsc1 + j * csc1, ete, csc1, accum);
       break;
     case 2:

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -1866,37 +1866,66 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
   size_t ete = 0; // Effective tile edge length (always TE for TEW=32).
   __asm__ volatile("sf.vsettnt %0, x0, e8, w4" : "=r"(ete) : : "vtype", "vl");
 
-  size_t num_processed_by_2tm2tn_m1 = (m1 / 2) * 2;
-  size_t num_processed_by_2tm2tn_n1 = (n1 / 2) * 2;
-
   size_t i = 0;
-  for (; i < num_processed_by_2tm2tn_m1; i += 2) {
+  for (; i + 4 <= m1; i += 4) {
     size_t j = 0;
-    for (; j < num_processed_by_2tm2tn_n1; j += 2) {
+    for (; j + 2 <= n1; j += 2) {
+      skl_gemm_2tm2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
+          ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete, csb1,
+          c_pack + i * rsc1 + j * csc1, ete, rsc1, csc1, accum);
+      skl_gemm_2tm2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
+          ete, k, a_pack + (i + 2) * rsa1, ete, rsa1, b_pack + j * csb1, ete,
+          csb1, c_pack + (i + 2) * rsc1 + j * csc1, ete, rsc1, csc1, accum);
+    }
+    if (j < n1) {
+      skl_gemm_4tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
+          ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete,
+          c_pack + i * rsc1 + j * csc1, ete, rsc1, accum);
+    }
+  }
+
+  if (i + 2 <= m1) {
+    size_t j = 0;
+    for (; j + 2 <= n1; j += 2) {
       skl_gemm_2tm2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
           ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete, csb1,
           c_pack + i * rsc1 + j * csc1, ete, rsc1, csc1, accum);
     }
-    while (j < n1) {
+    if (j < n1) {
+      skl_gemm_2tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
+          ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete,
+          c_pack + i * rsc1 + j * csc1, ete, rsc1, accum);
+    }
+    i += 2;
+  }
+
+  if (i < m1) {
+    size_t j = 0;
+    for (; j + 4 <= n1; j += 4) {
+      skl_gemm_1tm4tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
+          ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete, csb1,
+          c_pack + i * rsc1 + j * csc1, ete, csc1, accum);
+    }
+    switch (n1 - j) {
+    case 3:
+      skl_gemm_1tm3tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
+          ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete, csb1,
+          c_pack + i * rsc1 + j * csc1, ete, csc1, accum);
+      break;
+    case 2:
+      skl_gemm_1tm2tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
+          ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete, csb1,
+          c_pack + i * rsc1 + j * csc1, ete, csc1, accum);
+      break;
+    case 1:
       skl_gemm_1tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
           ete, ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete,
           c_pack + i * rsc1 + j * csc1, ete, accum);
-      skl_gemm_1tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
-          ete, ete, k, a_pack + (i + 1) * rsa1, ete, b_pack + j * csb1, ete,
-          c_pack + (i + 1) * rsc1 + j * csc1, ete, accum);
-      j += 1;
+      break;
+    default:
+      break;
     }
   }
 
-  while (i < m1) {
-    size_t j = 0;
-    while (j < n1) {
-      skl_gemm_1tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
-          ete, ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete,
-          c_pack + i * rsc1 + j * csc1, ete, accum);
-      j += 1;
-    }
-    i += 1;
-  }
   __asm__ volatile("sf.vtdiscard");
 }

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -1434,11 +1434,11 @@ SKL_FUNC_PRIVATE void skl_gemm_4tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
 
 /* Process 4 (= 2 x 2) contiguous tn x tn tiles of c. tn must be <= TE. */
 SKL_XSFMM_NEW
-SKL_FUNC_PRIVATE void skl_gemm_2tm2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
+SKL_FUNC_PRIVATE void skl_gemm_2tn2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
     size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
     const uint8_t *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
     size_t rsc1, size_t csc1, bool accum) {
-  /* Avoiding sf.vsettm instructions in the inner loop slightly improves
+  /* Avoiding sf.vsettn instructions in the inner loop slightly improves
    * performance but requires tm == tn. */
   size_t tm = tn;
 
@@ -1854,10 +1854,10 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
   for (; i + 4 * ete <= m; i += 4 * ete) {
     size_t j = 0;
     for (; j + 2 * ete <= n; j += 2 * ete) {
-      skl_gemm_2tm2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
+      skl_gemm_2tn2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
           ete, k, a + i, csa, ete, b + j, rsb, ete, c + i * rsc + j, rsc,
           ete * rsc, ete, accum);
-      skl_gemm_2tm2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
+      skl_gemm_2tn2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
           ete, k, a + i + 2 * ete, csa, ete, b + j, rsb, ete,
           c + (i + 2 * ete) * rsc + j, rsc, ete * rsc, ete, accum);
     }
@@ -1877,7 +1877,7 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
   if (i + 2 * ete <= m) {
     size_t j = 0;
     for (; j + 2 * ete <= n; j += 2 * ete) {
-      skl_gemm_2tm2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
+      skl_gemm_2tn2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
           ete, k, a + i, csa, ete, b + j, rsb, ete, c + i * rsc + j, rsc,
           ete * rsc, ete, accum);
     }
@@ -1952,10 +1952,10 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
   for (; i + 4 <= m1; i += 4) {
     size_t j = 0;
     for (; j + 2 <= n1; j += 2) {
-      skl_gemm_2tm2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
+      skl_gemm_2tn2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
           ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete, csb1,
           c_pack + i * rsc1 + j * csc1, ete, rsc1, csc1, accum);
-      skl_gemm_2tm2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
+      skl_gemm_2tn2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
           ete, k, a_pack + (i + 2) * rsa1, ete, rsa1, b_pack + j * csb1, ete,
           csb1, c_pack + (i + 2) * rsc1 + j * csc1, ete, rsc1, csc1, accum);
     }
@@ -1969,7 +1969,7 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
   if (i + 2 <= m1) {
     size_t j = 0;
     for (; j + 2 <= n1; j += 2) {
-      skl_gemm_2tm2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
+      skl_gemm_2tn2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
           ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete, csb1,
           c_pack + i * rsc1 + j * csc1, ete, rsc1, csc1, accum);
     }

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -862,6 +862,462 @@ skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
                    : "vtype", "vl", "memory");
 }
 
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void
+skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
+    size_t tn, size_t k, const uint8_t *a, size_t rsa, const uint8_t *b,
+    size_t rsb0, size_t csb1, float *c, size_t rsc0, size_t tsc1, bool accum,
+    bool bta) {
+  // We can use the same inner loop code for both values of bta by computing A^T
+  // * B0 and A^T * B1 and then transposing the result if bta == true.
+  // The active tile state has shape tm0 x tn0.
+  size_t tm = tn;
+
+  if (tm == 0 || tn == 0) {
+    return;
+  }
+
+  const size_t kShiftTile = 27;
+  const size_t kShiftPattern = 24;
+  const size_t kRowInc = 1;
+
+  const size_t tm0 = bta ? tn : tm;
+  const size_t tn0 = bta ? tm : tn;
+  const size_t tss_pattern = bta ? (size_t)(1) << kShiftPattern : 0;
+  const size_t mt0 = 0 | tss_pattern;
+  const size_t mt4 = (size_t)(4) << kShiftTile | tss_pattern;
+  const size_t mt8 = (size_t)(8) << kShiftTile | tss_pattern;
+  const size_t mt12 = (size_t)(12) << kShiftTile | tss_pattern;
+
+  float *c0 = c;
+  float *c1 = c0 + tsc1;
+  float *c2 = c0 + 2 * tsc1;
+  float *c3 = c0 + 3 * tsc1;
+
+  /* Load or zero-initialize tiles. */
+  size_t mt0_load = mt0;
+  size_t mt4_load = mt4;
+  size_t mt8_load = mt8;
+  size_t mt12_load = mt12;
+
+  float *c0_load = c0;
+  float *c1_load = c1;
+  float *c2_load = c2;
+  float *c3_load = c3;
+  size_t i = 0;
+  __asm__ volatile(
+      "bnez %[accum], 0f\n"
+      "sf.vsettnt x0, %[tn0], e32, w1\n"
+      "sf.vsettm x0, %[tm0]\n"
+
+      "sf.vtzero.t mt0\n"
+      "sf.vtzero.t mt4\n"
+      "sf.vtzero.t mt8\n"
+      "sf.vtzero.t mt12\n"
+      "j 2f\n"
+      "0:\n"
+      "sf.vsettnt x0, %[tn], e32, w1\n"
+      "1:\n"
+      "addi %[i], %[i], 1\n"
+      "sf.vlte32 %[mt0], (%[c0])\n"
+      "add %[mt0], %[mt0], %[kRowInc]\n"
+      "add %[c0], %[c0], %[sc]\n"
+      "sf.vlte32 %[mt4], (%[c1])\n"
+      "add %[mt4], %[mt4], %[kRowInc]\n"
+      "add %[c1], %[c1], %[sc]\n"
+      "sf.vlte32 %[mt8], (%[c2])\n"
+      "add %[mt8], %[mt8], %[kRowInc]\n"
+      "add %[c2], %[c2], %[sc]\n"
+      "sf.vlte32 %[mt12], (%[c3])\n"
+      "add %[mt12], %[mt12], %[kRowInc]\n"
+      "add %[c3], %[c3], %[sc]\n"
+      "bltu %[i], %[tm], 1b\n"
+      "2:\n"
+      : [mt0] "+&r"(mt0_load), [mt4] "+&r"(mt4_load), [mt8] "+&r"(mt8_load),
+        [mt12] "+&r"(mt12_load), [c0] "+&r"(c0_load), [c1] "+&r"(c1_load),
+        [c2] "+&r"(c2_load), [c3] "+&r"(c3_load), [i] "+&r"(i)
+      : [accum] "r"(accum), [kRowInc] "rI"(kRowInc),
+        [sc] "r"(rsc0 * sizeof(float)), [tm] "r"(tm), [tn] "r"(tn),
+        [tm0] "r"(tm0), [tn0] "r"(tn0)
+      : "vtype", "vl", "memory");
+
+  /* Accumulate matrix product into tiles. */
+  // a0_{0,1} are used to load a 2 x tm submatrix of A,
+  // b0_{0,1} are used to load a 2 x tn submatrix of B,
+  // and similarly for b1_{0,1}, b2_{0,1}, b3_{0,1}.
+  const uint8_t *a0_0 = a;
+  const uint8_t *a0_1 = a0_0 + rsa;
+  const uint8_t *b0_0 = b;
+  const uint8_t *b0_1 = b0_0 + rsb0;
+  const uint8_t *b1_0 = b0_0 + csb1;
+  const uint8_t *b1_1 = b1_0 + rsb0;
+  const uint8_t *b2_0 = b0_0 + 2 * csb1;
+  const uint8_t *b2_1 = b2_0 + rsb0;
+  const uint8_t *b3_0 = b0_0 + 3 * csb1;
+  const uint8_t *b3_1 = b3_0 + rsb0;
+  if (k < 4) {
+    __asm__ volatile(
+        "beqz %[k], 2f\n"
+
+        "sf.vsettnt x0, %[tn0], e8, w4\n"
+        "sf.vsettm x0, %[tm0]\n"
+        "sf.vsettk x0, %[k]\n"
+
+        "beq %[k], %[i2], 0f\n"
+        "beq %[k], %[i1], 1f\n"
+
+        // k == 3
+        "vle8.v v0, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle8.v v2, (%[a0_1])\n"
+        "vle8.v v4, (%[a0_0])\n"
+
+        "vle8.v v8, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle8.v v10, (%[b0_1])\n"
+        "vle8.v v12, (%[b0_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v16, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle8.v v18, (%[b1_1])\n"
+        "vle8.v v20, (%[b1_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+        "vle8.v v8, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle8.v v10, (%[b2_1])\n"
+        "vle8.v v12, (%[b2_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+
+        "vle8.v v16, (%[b3_0])\n"
+        "add %[b3_0], %[b3_0], %[sb]\n"
+        "vle8.v v18, (%[b3_1])\n"
+        "vle8.v v20, (%[b3_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+        "j 2f\n"
+
+        "0:\n" // k == 2
+        "vle8.v v0, (%[a0_0])\n"
+        "vle8.v v2, (%[a0_1])\n"
+
+        "vle8.v v8, (%[b0_0])\n"
+        "vle8.v v10, (%[b0_1])\n"
+
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v16, (%[b1_0])\n"
+        "vle8.v v18, (%[b1_1])\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+        "vle8.v v8, (%[b2_0])\n"
+        "vle8.v v10, (%[b2_1])\n"
+
+        "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+
+        "vle8.v v16, (%[b3_0])\n"
+        "vle8.v v18, (%[b3_1])\n"
+
+        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+        "j 2f\n"
+
+        "1:\n" // k == 1
+        "vle8.v v0, (%[a0_0])\n"
+
+        "vle8.v v8, (%[b0_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v16, (%[b1_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+        "vle8.v v8, (%[b2_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+
+        "vle8.v v16, (%[b3_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+        "2:\n"
+        : [a0_0] "+&r"(a0_0), [b0_0] "+&r"(b0_0), [b1_0] "+&r"(b1_0),
+          [b2_0] "+&r"(b2_0), [b3_0] "+&r"(b3_0)
+        : [a0_1] "r"(a0_1), [b0_1] "r"(b0_1), [b1_1] "r"(b1_1),
+          [b2_1] "r"(b2_1), [b3_1] "r"(b3_1),
+          [sa] "r"(2 * rsa * sizeof(uint8_t)),
+          [sb] "r"(2 * rsb0 * sizeof(uint8_t)), [tm0] "r"(tm0), [tn0] "r"(tn0),
+          [k] "r"(k), [i1] "r"(1), [i2] "r"(2)
+        : "v0", "v1", "v2", "v3", "v4", "v5", "v8", "v9", "v10", "v11", "v12",
+          "v13", "v16", "v17", "v18", "v19", "v20", "v21", "vtype", "vl",
+          "memory");
+  } else {
+    __asm__ volatile(
+        "sf.vsettnt x0, %[tn0], e8, w4\n"
+        "sf.vsettm x0, %[tm0]\n"
+        "sf.vsettk x0, %[k]\n"
+
+        "vle8.v v0, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle8.v v2, (%[a0_1])\n"
+        "add %[a0_1], %[a0_1], %[sa]\n"
+        "vle8.v v4, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle8.v v6, (%[a0_1])\n"
+        "add %[a0_1], %[a0_1], %[sa]\n"
+
+        "vle8.v v8, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle8.v v10, (%[b0_1])\n"
+        "add %[b0_1], %[b0_1], %[sb]\n"
+        "vle8.v v12, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle8.v v14, (%[b0_1])\n"
+        "add %[b0_1], %[b0_1], %[sb]\n"
+
+        "bltu %[k], %[i8], 1f\n"
+
+        "0:\n"
+        "addi %[k], %[k], -4\n"
+        "vle8.v v16, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle8.v v18, (%[b1_1])\n"
+        "add %[b1_1], %[b1_1], %[sb]\n"
+        "vle8.v v20, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle8.v v22, (%[b1_1])\n"
+        "add %[b1_1], %[b1_1], %[sb]\n"
+
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v8, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle8.v v10, (%[b2_1])\n"
+        "add %[b2_1], %[b2_1], %[sb]\n"
+        "vle8.v v12, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle8.v v14, (%[b2_1])\n"
+        "add %[b2_1], %[b2_1], %[sb]\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+        "vle8.v v16, (%[b3_0])\n"
+        "add %[b3_0], %[b3_0], %[sb]\n"
+        "vle8.v v18, (%[b3_1])\n"
+        "add %[b3_1], %[b3_1], %[sb]\n"
+        "vle8.v v20, (%[b3_0])\n"
+        "add %[b3_0], %[b3_0], %[sb]\n"
+        "vle8.v v22, (%[b3_1])\n"
+        "add %[b3_1], %[b3_1], %[sb]\n"
+
+        "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+
+        "vle8.v v8, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle8.v v10, (%[b0_1])\n"
+        "add %[b0_1], %[b0_1], %[sb]\n"
+        "vle8.v v12, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle8.v v14, (%[b0_1])\n"
+        "add %[b0_1], %[b0_1], %[sb]\n"
+
+        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+
+        "vle8.v v0, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle8.v v2, (%[a0_1])\n"
+        "add %[a0_1], %[a0_1], %[sa]\n"
+        "vle8.v v4, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle8.v v6, (%[a0_1])\n"
+        "add %[a0_1], %[a0_1], %[sa]\n"
+
+        "bgeu %[k], %[i8], 0b\n"
+
+        "1:\n"
+        "addi %[k], %[k], -4\n"
+        "vle8.v v16, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle8.v v18, (%[b1_1])\n"
+        "add %[b1_1], %[b1_1], %[sb]\n"
+        "vle8.v v20, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle8.v v22, (%[b1_1])\n"
+        "add %[b1_1], %[b1_1], %[sb]\n"
+
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v8, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle8.v v10, (%[b2_1])\n"
+        "add %[b2_1], %[b2_1], %[sb]\n"
+        "vle8.v v12, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle8.v v14, (%[b2_1])\n"
+        "add %[b2_1], %[b2_1], %[sb]\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+        "vle8.v v16, (%[b3_0])\n"
+        "add %[b3_0], %[b3_0], %[sb]\n"
+        "vle8.v v18, (%[b3_1])\n"
+        "add %[b3_1], %[b3_1], %[sb]\n"
+        "vle8.v v20, (%[b3_0])\n"
+        "add %[b3_0], %[b3_0], %[sb]\n"
+        "vle8.v v22, (%[b3_1])\n"
+        "add %[b3_1], %[b3_1], %[sb]\n"
+
+        "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+
+        "beq %[k], %[i2], 2f\n"
+        "beq %[k], %[i1], 3f\n"
+        "beqz %[k], 4f\n"
+
+        // k % 4 == 3
+        "vle8.v v8, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle8.v v10, (%[b0_1])\n"
+        "vle8.v v12, (%[b0_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+
+        "vle8.v v0, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle8.v v2, (%[a0_1])\n"
+        "vle8.v v4, (%[a0_0])\n"
+
+        "vle8.v v16, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle8.v v18, (%[b1_1])\n"
+        "vle8.v v20, (%[b1_0])\n"
+
+        "sf.vsettk x0, %[k]\n"
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v8, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle8.v v10, (%[b2_1])\n"
+        "vle8.v v12, (%[b2_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+        "vle8.v v16, (%[b3_0])\n"
+        "add %[b3_0], %[b3_0], %[sb]\n"
+        "vle8.v v18, (%[b3_1])\n"
+        "vle8.v v20, (%[b3_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+        "j 5f\n"
+
+        "2:\n" // k % 4 == 2
+        "vle8.v v8, (%[b0_0])\n"
+        "vle8.v v10, (%[b0_1])\n"
+
+        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+
+        "vle8.v v0, (%[a0_0])\n"
+        "vle8.v v2, (%[a0_1])\n"
+
+        "vle8.v v16, (%[b1_0])\n"
+        "vle8.v v18, (%[b1_1])\n"
+
+        "sf.vsettk x0, %[k]\n"
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v8, (%[b2_0])\n"
+        "vle8.v v10, (%[b2_1])\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+        "vle8.v v16, (%[b3_0])\n"
+        "vle8.v v18, (%[b3_1])\n"
+
+        "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+        "j 5f\n"
+
+        "3:\n" // k % 4 == 1
+        "vle8.v v8, (%[b0_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+
+        "vle8.v v0, (%[a0_0])\n"
+
+        "vle8.v v16, (%[b1_0])\n"
+
+        "sf.vsettk x0, %[k]\n"
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v8, (%[b2_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+        "vle8.v v16, (%[b3_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+        "j 5f\n"
+
+        "4:\n" // k % 4 == 0
+        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+
+        "5:\n"
+        : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
+          [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
+          [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [b3_0] "+&r"(b3_0),
+          [b3_1] "+&r"(b3_1), [k] "+&r"(k)
+        : [sa] "r"(2 * rsa * sizeof(uint8_t)),
+          [sb] "r"(2 * rsb0 * sizeof(uint8_t)), [tm0] "r"(tm0), [tn0] "r"(tn0),
+          [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
+        : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+          "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
+          "v21", "v22", "v23", "vtype", "vl", "memory");
+  }
+
+  /* Store tiles to memory. */
+  size_t mt0_store = mt0;
+  size_t mt4_store = mt4;
+  size_t mt8_store = mt8;
+  size_t mt12_store = mt12;
+
+  float *c0_store = c0;
+  float *c1_store = c1;
+  float *c2_store = c2;
+  float *c3_store = c3;
+  i = 0;
+  __asm__ volatile(
+      "sf.vsettnt x0, %[tn], e32, w1\n"
+
+      "0:\n"
+      "addi %[i], %[i], 1\n"
+      "sf.vste32 %[mt0], (%[c0])\n"
+      "add %[mt0], %[mt0], %[kRowInc]\n"
+      "add %[c0], %[c0], %[sc]\n"
+      "sf.vste32 %[mt4], (%[c1])\n"
+      "add %[mt4], %[mt4], %[kRowInc]\n"
+      "add %[c1], %[c1], %[sc]\n"
+      "sf.vste32 %[mt8], (%[c2])\n"
+      "add %[mt8], %[mt8], %[kRowInc]\n"
+      "add %[c2], %[c2], %[sc]\n"
+      "sf.vste32 %[mt12], (%[c3])\n"
+      "add %[mt12], %[mt12], %[kRowInc]\n"
+      "add %[c3], %[c3], %[sc]\n"
+      "bltu %[i], %[tm], 0b\n"
+
+      "sf.vtdiscard"
+      : [mt0] "+&r"(mt0_store), [mt4] "+&r"(mt4_store), [mt8] "+&r"(mt8_store),
+        [mt12] "+&r"(mt12_store), [c0] "+&r"(c0_store), [c1] "+&r"(c1_store),
+        [c2] "+&r"(c2_store), [c3] "+&r"(c3_store), [i] "+&r"(i)
+      : [kRowInc] "rI"(kRowInc), [sc] "r"(rsc0 * sizeof(float)), [tm] "r"(tm),
+        [tn] "r"(tn)
+      : "vtype", "vl", "memory");
+}
+
 /* Process 2 (= 1 x 2) contiguous tm x tn tiles of c.
  * tm and tn must be <= TE.
  */
@@ -905,6 +1361,29 @@ SKL_FUNC_PRIVATE void skl_gemm_3tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
     const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
   skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
+      tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+}
+
+/* Process 4 (= 1 x 4) contiguous tm x tn tiles of c.
+ * tm and tn must be <= TE.
+ */
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_1tm4tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
+    size_t tn, size_t k, const uint8_t *a, size_t csa, const uint8_t *b,
+    size_t rsb0, size_t csb1, float *c, size_t rsc0, size_t csc1, bool accum) {
+  skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
+      tn, k, a, csa, b, rsb0, csb1, c, rsc0, csc1, accum, false);
+}
+
+/* Process 4 (= 4 x 1) contiguous tm x tn tiles of c.
+ * tm and tn must be <= TE.
+ */
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_4tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
+    size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
+    const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
+    bool accum) {
+  skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
       tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
 }
 

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -893,14 +893,12 @@ skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 SKL_XSFMM_NEW
 SKL_FUNC_PRIVATE void
 skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
-    size_t tn, size_t k, const uint8_t *a, size_t rsa, const uint8_t *b,
-    size_t rsb0, size_t csb1, float *c, size_t rsc0, size_t tsc1, bool accum,
-    bool bta) {
+    size_t tm, size_t tn, size_t k, const uint8_t *a, size_t rsa,
+    const uint8_t *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
+    size_t tsc1, bool accum, bool bta) {
   // We can use the same inner loop code for both values of bta by computing A^T
   // * B0 and A^T * B1 and then transposing the result if bta == true.
   // The active tile state has shape tm0 x tn0.
-  size_t tm = tn;
-
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -995,10 +993,12 @@ skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
         "beq %[k], %[i1], 1f\n"
 
         // k == 3
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
         "add %[a0_0], %[a0_0], %[sa]\n"
         "vle8.v v2, (%[a0_1])\n"
         "vle8.v v4, (%[a0_0])\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "vle8.v v8, (%[b0_0])\n"
         "add %[b0_0], %[b0_0], %[sb]\n"
@@ -1030,8 +1030,10 @@ skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
         "j 2f\n"
 
         "0:\n" // k == 2
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
         "vle8.v v2, (%[a0_1])\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "vle8.v v8, (%[b0_0])\n"
         "vle8.v v10, (%[b0_1])\n"
@@ -1055,7 +1057,9 @@ skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
         "j 2f\n"
 
         "1:\n" // k == 1
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "vle8.v v8, (%[b0_0])\n"
 
@@ -1089,6 +1093,7 @@ skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
         "sf.vsettm x0, %[tm0]\n"
         "sf.vsettk x0, %[k]\n"
 
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
         "add %[a0_0], %[a0_0], %[sa]\n"
         "vle8.v v2, (%[a0_1])\n"
@@ -1097,6 +1102,7 @@ skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
         "add %[a0_0], %[a0_0], %[sa]\n"
         "vle8.v v6, (%[a0_1])\n"
         "add %[a0_1], %[a0_1], %[sa]\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "vle8.v v8, (%[b0_0])\n"
         "add %[b0_0], %[b0_0], %[sb]\n"
@@ -1155,6 +1161,7 @@ skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 
         "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
 
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
         "add %[a0_0], %[a0_0], %[sa]\n"
         "vle8.v v2, (%[a0_1])\n"
@@ -1163,6 +1170,7 @@ skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
         "add %[a0_0], %[a0_0], %[sa]\n"
         "vle8.v v6, (%[a0_1])\n"
         "add %[a0_1], %[a0_1], %[sa]\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "bgeu %[k], %[i8], 0b\n"
 
@@ -1213,10 +1221,12 @@ skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 
         "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
 
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
         "add %[a0_0], %[a0_0], %[sa]\n"
         "vle8.v v2, (%[a0_1])\n"
         "vle8.v v4, (%[a0_0])\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "vle8.v v16, (%[b1_0])\n"
         "add %[b1_0], %[b1_0], %[sb]\n"
@@ -1248,8 +1258,10 @@ skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 
         "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
 
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
         "vle8.v v2, (%[a0_1])\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "vle8.v v16, (%[b1_0])\n"
         "vle8.v v18, (%[b1_1])\n"
@@ -1274,7 +1286,9 @@ skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 
         "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
 
+        "sf.vsettn x0, %[tm0]\n"
         "vle8.v v0, (%[a0_0])\n"
+        "sf.vsettn x0, %[tn0]\n"
 
         "vle8.v v16, (%[b1_0])\n"
 
@@ -1399,10 +1413,11 @@ SKL_FUNC_PRIVATE void skl_gemm_3tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
  */
 SKL_XSFMM_NEW
 SKL_FUNC_PRIVATE void skl_gemm_1tm4tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
-    size_t tn, size_t k, const uint8_t *a, size_t csa, const uint8_t *b,
-    size_t rsb0, size_t csb1, float *c, size_t rsc0, size_t csc1, bool accum) {
+    size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa,
+    const uint8_t *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
+    size_t csc1, bool accum) {
   skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
-      tn, k, a, csa, b, rsb0, csb1, c, rsc0, csc1, accum, false);
+      tm, tn, k, a, csa, b, rsb0, csb1, c, rsc0, csc1, accum, false);
 }
 
 /* Process 4 (= 4 x 1) contiguous tm x tn tiles of c.
@@ -1410,11 +1425,11 @@ SKL_FUNC_PRIVATE void skl_gemm_1tm4tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
  */
 SKL_XSFMM_NEW
 SKL_FUNC_PRIVATE void skl_gemm_4tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
-    size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
+    size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
     const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
   skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
-      tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+      tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
 }
 
 /* Process 4 (= 2 x 2) contiguous tn x tn tiles of c. tn must be <= TE. */
@@ -1909,7 +1924,7 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
     }
     if (j < n1) {
       skl_gemm_4tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
-          ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete,
+          ete, ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete,
           c_pack + i * rsc1 + j * csc1, ete, rsc1, accum);
     }
   }
@@ -1933,7 +1948,7 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
     size_t j = 0;
     for (; j + 4 <= n1; j += 4) {
       skl_gemm_1tm4tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
-          ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete, csb1,
+          ete, ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete, csb1,
           c_pack + i * rsc1 + j * csc1, ete, csc1, accum);
     }
     switch (n1 - j) {

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -1380,8 +1380,10 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
     size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
     const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
+  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 3 (= 1 x 3) contiguous tm x tn tiles of c.
@@ -1400,12 +1402,15 @@ SKL_FUNC_PRIVATE void skl_gemm_1tm3tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
  * tm and tn must be <= TE.
  */
 SKL_XSFMM_NEW
-SKL_FUNC_PRIVATE void skl_gemm_3tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
+__attribute__((unused)) SKL_FUNC_PRIVATE void
+skl_gemm_3tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
     size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
     const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
+  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 1 x 4) contiguous tm x tn tiles of c.
@@ -1428,8 +1433,10 @@ SKL_FUNC_PRIVATE void skl_gemm_4tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
     size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
     const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
+  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 2 x 2) contiguous tn x tn tiles of c. tn must be <= TE. */

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -478,6 +478,390 @@ skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
                    : "vtype", "vl", "memory");
 }
 
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void
+skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
+    size_t tn, size_t k, const uint8_t *a, size_t rsa, const uint8_t *b,
+    size_t rsb0, size_t csb1, float *c, size_t rsc0, size_t tsc1, bool accum,
+    bool bta) {
+  // We can use the same inner loop code for both values of bta by computing A^T
+  // * B0 and A^T * B1 and then transposing the result if bta == true.
+  // The active tile state has shape tm0 x tn0.
+  size_t tm = tn;
+
+  if (tm == 0 || tn == 0) {
+    return;
+  }
+
+  const size_t kShiftTile = 27;
+  const size_t kShiftPattern = 24;
+  const size_t kRowInc = 1;
+
+  const size_t tm0 = bta ? tn : tm;
+  const size_t tn0 = bta ? tm : tn;
+  const size_t tss_pattern = bta ? (size_t)(1) << kShiftPattern : 0;
+  const size_t mt0 = 0 | tss_pattern;
+  const size_t mt4 = (size_t)(4) << kShiftTile | tss_pattern;
+  const size_t mt8 = (size_t)(8) << kShiftTile | tss_pattern;
+
+  float *c0 = c;
+  float *c1 = c0 + tsc1;
+  float *c2 = c0 + 2 * tsc1;
+
+  /* Load or zero-initialize tiles. */
+  size_t mt0_load = mt0;
+  size_t mt4_load = mt4;
+  size_t mt8_load = mt8;
+
+  float *c0_load = c0;
+  float *c1_load = c1;
+  float *c2_load = c2;
+  size_t i = 0;
+  __asm__ volatile("bnez %[accum], 0f\n"
+                   "sf.vsettnt x0, %[tn0], e32, w1\n"
+                   "sf.vsettm x0, %[tm0]\n"
+
+                   "sf.vtzero.t mt0\n"
+                   "sf.vtzero.t mt4\n"
+                   "sf.vtzero.t mt8\n"
+                   "j 2f\n"
+                   "0:\n"
+                   "sf.vsettnt x0, %[tn], e32, w1\n"
+                   "1:\n"
+                   "addi %[i], %[i], 1\n"
+                   "sf.vlte32 %[mt0], (%[c0])\n"
+                   "add %[mt0], %[mt0], %[kRowInc]\n"
+                   "add %[c0], %[c0], %[sc]\n"
+                   "sf.vlte32 %[mt4], (%[c1])\n"
+                   "add %[mt4], %[mt4], %[kRowInc]\n"
+                   "add %[c1], %[c1], %[sc]\n"
+                   "sf.vlte32 %[mt8], (%[c2])\n"
+                   "add %[mt8], %[mt8], %[kRowInc]\n"
+                   "add %[c2], %[c2], %[sc]\n"
+                   "bltu %[i], %[tm], 1b\n"
+                   "2:\n"
+                   : [mt0] "+&r"(mt0_load), [mt4] "+&r"(mt4_load),
+                     [mt8] "+&r"(mt8_load), [c0] "+&r"(c0_load),
+                     [c1] "+&r"(c1_load), [c2] "+&r"(c2_load), [i] "+&r"(i)
+                   : [accum] "r"(accum), [kRowInc] "rI"(kRowInc),
+                     [sc] "r"(rsc0 * sizeof(float)), [tm] "r"(tm), [tn] "r"(tn),
+                     [tm0] "r"(tm0), [tn0] "r"(tn0)
+                   : "vtype", "vl", "memory");
+
+  /* Accumulate matrix product into tiles. */
+  // a0_{0,1} are used to load a 2 x tm submatrix of A,
+  // b0_{0,1} are used to load a 2 x tn submatrix of B,
+  // and similarly for b1_{0,1}, b2_{0,1}.
+  const uint8_t *a0_0 = a;
+  const uint8_t *a0_1 = a0_0 + rsa;
+  const uint8_t *b0_0 = b;
+  const uint8_t *b0_1 = b0_0 + rsb0;
+  const uint8_t *b1_0 = b0_0 + csb1;
+  const uint8_t *b1_1 = b1_0 + rsb0;
+  const uint8_t *b2_0 = b0_0 + 2 * csb1;
+  const uint8_t *b2_1 = b2_0 + rsb0;
+  if (k < 4) {
+    __asm__ volatile("beqz %[k], 2f\n"
+
+                     "sf.vsettnt x0, %[tn0], e8, w4\n"
+                     "sf.vsettm x0, %[tm0]\n"
+                     "sf.vsettk x0, %[k]\n"
+
+                     "beq %[k], %[i2], 0f\n"
+                     "beq %[k], %[i1], 1f\n"
+
+                     // k == 3
+                     "vle8.v v0, (%[a0_0])\n"
+                     "add %[a0_0], %[a0_0], %[sa]\n"
+                     "vle8.v v2, (%[a0_1])\n"
+                     "vle8.v v4, (%[a0_0])\n"
+
+                     "vle8.v v8, (%[b0_0])\n"
+                     "add %[b0_0], %[b0_0], %[sb]\n"
+                     "vle8.v v10, (%[b0_1])\n"
+                     "vle8.v v12, (%[b0_0])\n"
+
+                     "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+                     "vle8.v v16, (%[b1_0])\n"
+                     "add %[b1_0], %[b1_0], %[sb]\n"
+                     "vle8.v v18, (%[b1_1])\n"
+                     "vle8.v v20, (%[b1_0])\n"
+
+                     "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+                     "vle8.v v24, (%[b2_0])\n"
+                     "add %[b2_0], %[b2_0], %[sb]\n"
+                     "vle8.v v26, (%[b2_1])\n"
+                     "vle8.v v28, (%[b2_0])\n"
+
+                     "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+                     "j 2f\n"
+
+                     "0:\n" // k == 2
+                     "vle8.v v0, (%[a0_0])\n"
+                     "vle8.v v2, (%[a0_1])\n"
+
+                     "vle8.v v8, (%[b0_0])\n"
+                     "vle8.v v10, (%[b0_1])\n"
+
+                     "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+                     "vle8.v v16, (%[b1_0])\n"
+                     "vle8.v v18, (%[b1_1])\n"
+
+                     "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+                     "vle8.v v24, (%[b2_0])\n"
+                     "vle8.v v26, (%[b2_1])\n"
+
+                     "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+                     "j 2f\n"
+
+                     "1:\n" // k == 1
+                     "vle8.v v0, (%[a0_0])\n"
+
+                     "vle8.v v8, (%[b0_0])\n"
+
+                     "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+                     "vle8.v v16, (%[b1_0])\n"
+
+                     "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+                     "vle8.v v24, (%[b2_0])\n"
+
+                     "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+                     "2:\n"
+                     : [a0_0] "+&r"(a0_0), [b0_0] "+&r"(b0_0),
+                       [b1_0] "+&r"(b1_0), [b2_0] "+&r"(b2_0)
+                     : [a0_1] "r"(a0_1), [b0_1] "r"(b0_1), [b1_1] "r"(b1_1),
+                       [b2_1] "r"(b2_1), [sa] "r"(2 * rsa * sizeof(uint8_t)),
+                       [sb] "r"(2 * rsb0 * sizeof(uint8_t)), [tm0] "r"(tm0),
+                       [tn0] "r"(tn0), [k] "r"(k), [i1] "r"(1), [i2] "r"(2)
+                     : "v0", "v1", "v2", "v3", "v4", "v5", "v8", "v9", "v10",
+                       "v11", "v12", "v13", "v16", "v17", "v18", "v19", "v20",
+                       "v21", "v24", "v25", "v26", "v27", "v28", "v29", "vtype",
+                       "vl", "memory");
+  } else {
+    __asm__ volatile(
+        "sf.vsettnt x0, %[tn0], e8, w4\n"
+        "sf.vsettm x0, %[tm0]\n"
+        "sf.vsettk x0, %[k]\n"
+
+        "vle8.v v0, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle8.v v2, (%[a0_1])\n"
+        "add %[a0_1], %[a0_1], %[sa]\n"
+        "vle8.v v4, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle8.v v6, (%[a0_1])\n"
+        "add %[a0_1], %[a0_1], %[sa]\n"
+
+        "vle8.v v8, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle8.v v10, (%[b0_1])\n"
+        "add %[b0_1], %[b0_1], %[sb]\n"
+        "vle8.v v12, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle8.v v14, (%[b0_1])\n"
+        "add %[b0_1], %[b0_1], %[sb]\n"
+
+        "bltu %[k], %[i8], 1f\n"
+
+        "0:\n"
+        "addi %[k], %[k], -4\n"
+        "vle8.v v16, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle8.v v18, (%[b1_1])\n"
+        "add %[b1_1], %[b1_1], %[sb]\n"
+        "vle8.v v20, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle8.v v22, (%[b1_1])\n"
+        "add %[b1_1], %[b1_1], %[sb]\n"
+
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v24, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle8.v v26, (%[b2_1])\n"
+        "add %[b2_1], %[b2_1], %[sb]\n"
+        "vle8.v v28, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle8.v v30, (%[b2_1])\n"
+        "add %[b2_1], %[b2_1], %[sb]\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+        "vle8.v v8, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle8.v v10, (%[b0_1])\n"
+        "add %[b0_1], %[b0_1], %[sb]\n"
+        "vle8.v v12, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle8.v v14, (%[b0_1])\n"
+        "add %[b0_1], %[b0_1], %[sb]\n"
+
+        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+
+        "vle8.v v0, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle8.v v2, (%[a0_1])\n"
+        "add %[a0_1], %[a0_1], %[sa]\n"
+        "vle8.v v4, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle8.v v6, (%[a0_1])\n"
+        "add %[a0_1], %[a0_1], %[sa]\n"
+
+        "bgeu %[k], %[i8], 0b\n"
+
+        "1:\n"
+        "addi %[k], %[k], -4\n"
+        "vle8.v v16, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle8.v v18, (%[b1_1])\n"
+        "add %[b1_1], %[b1_1], %[sb]\n"
+        "vle8.v v20, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle8.v v22, (%[b1_1])\n"
+        "add %[b1_1], %[b1_1], %[sb]\n"
+
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v24, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle8.v v26, (%[b2_1])\n"
+        "add %[b2_1], %[b2_1], %[sb]\n"
+        "vle8.v v28, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle8.v v30, (%[b2_1])\n"
+        "add %[b2_1], %[b2_1], %[sb]\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+        "beq %[k], %[i2], 2f\n"
+        "beq %[k], %[i1], 3f\n"
+        "beqz %[k], 4f\n"
+
+        // k % 4 == 3
+        "vle8.v v8, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle8.v v10, (%[b0_1])\n"
+        "vle8.v v12, (%[b0_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+
+        "vle8.v v0, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle8.v v2, (%[a0_1])\n"
+        "vle8.v v4, (%[a0_0])\n"
+
+        "vle8.v v16, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle8.v v18, (%[b1_1])\n"
+        "vle8.v v20, (%[b1_0])\n"
+
+        "sf.vsettk x0, %[k]\n"
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v24, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle8.v v26, (%[b2_1])\n"
+        "vle8.v v28, (%[b2_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+        "j 5f\n"
+
+        "2:\n" // k % 4 == 2
+        "vle8.v v8, (%[b0_0])\n"
+        "vle8.v v10, (%[b0_1])\n"
+
+        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+
+        "vle8.v v0, (%[a0_0])\n"
+        "vle8.v v2, (%[a0_1])\n"
+
+        "vle8.v v16, (%[b1_0])\n"
+        "vle8.v v18, (%[b1_1])\n"
+
+        "sf.vsettk x0, %[k]\n"
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v24, (%[b2_0])\n"
+        "vle8.v v26, (%[b2_1])\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+        "j 5f\n"
+
+        "3:\n" // k % 4 == 1
+        "vle8.v v8, (%[b0_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+
+        "vle8.v v0, (%[a0_0])\n"
+
+        "vle8.v v16, (%[b1_0])\n"
+
+        "sf.vsettk x0, %[k]\n"
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v24, (%[b2_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+        "j 5f\n"
+
+        "4:\n" // k % 4 == 0
+        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+
+        "5:\n"
+        : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
+          [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
+          [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [k] "+&r"(k)
+        : [sa] "r"(2 * rsa * sizeof(uint8_t)),
+          [sb] "r"(2 * rsb0 * sizeof(uint8_t)), [tm0] "r"(tm0), [tn0] "r"(tn0),
+          [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
+        : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+          "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
+          "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30",
+          "v31", "vtype", "vl", "memory");
+  }
+
+  /* Store tiles to memory. */
+  size_t mt0_store = mt0;
+  size_t mt4_store = mt4;
+  size_t mt8_store = mt8;
+
+  float *c0_store = c0;
+  float *c1_store = c1;
+  float *c2_store = c2;
+  i = 0;
+  __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
+
+                   "0:\n"
+                   "addi %[i], %[i], 1\n"
+                   "sf.vste32 %[mt0], (%[c0])\n"
+                   "add %[mt0], %[mt0], %[kRowInc]\n"
+                   "add %[c0], %[c0], %[sc]\n"
+                   "sf.vste32 %[mt4], (%[c1])\n"
+                   "add %[mt4], %[mt4], %[kRowInc]\n"
+                   "add %[c1], %[c1], %[sc]\n"
+                   "sf.vste32 %[mt8], (%[c2])\n"
+                   "add %[mt8], %[mt8], %[kRowInc]\n"
+                   "add %[c2], %[c2], %[sc]\n"
+                   "bltu %[i], %[tm], 0b\n"
+
+                   "sf.vtdiscard"
+                   : [mt0] "+&r"(mt0_store), [mt4] "+&r"(mt4_store),
+                     [mt8] "+&r"(mt8_store), [c0] "+&r"(c0_store),
+                     [c1] "+&r"(c1_store), [c2] "+&r"(c2_store), [i] "+&r"(i)
+                   : [kRowInc] "rI"(kRowInc), [sc] "r"(rsc0 * sizeof(float)),
+                     [tm] "r"(tm), [tn] "r"(tn)
+                   : "vtype", "vl", "memory");
+}
+
 /* Process 2 (= 1 x 2) contiguous tm x tn tiles of c.
  * tm and tn must be <= TE.
  */
@@ -498,6 +882,29 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
     const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
   skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
+      tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+}
+
+/* Process 3 (= 1 x 3) contiguous tm x tn tiles of c.
+ * tm and tn must be <= TE.
+ */
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_1tm3tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
+    size_t tn, size_t k, const uint8_t *a, size_t csa, const uint8_t *b,
+    size_t rsb0, size_t csb1, float *c, size_t rsc0, size_t csc1, bool accum) {
+  skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
+      tn, k, a, csa, b, rsb0, csb1, c, rsc0, csc1, accum, false);
+}
+
+/* Process 3 (= 3 x 1) contiguous tm x tn tiles of c.
+ * tm and tn must be <= TE.
+ */
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_3tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
+    size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
+    const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
+    bool accum) {
+  skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
       tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
 }
 

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -159,6 +159,348 @@ SKL_FUNC_PRIVATE void skl_gemm_1tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
       : "vtype", "vl", "memory");
 }
 
+/* C consists of two tm x tn row major tiles C0 and C1. Each tile's row stride
+ * is rsc0, and the distance from C0 to C1 in elements is tsc1. A is a row major
+ * matrix with k rows and row stride rsa. B consists of two row major tiles B0
+ * and B1. Each tile has k rows and row stride rsb0, and the distance from B0 to
+ * B1 in elements is csb1. If bta == true, this routine computes C0 = B0^T * A,
+ * C1 = B1^T * A. Otherwise, it computes C0 = A^T * B0, C1 = A^T * B1.
+ */
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void
+skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
+    size_t tn, size_t k, const uint8_t *a, size_t rsa, const uint8_t *b,
+    size_t rsb0, size_t csb1, float *c, size_t rsc0, size_t tsc1, bool accum,
+    bool bta) {
+  // We can use the same inner loop code for both values of bta by computing A^T
+  // * B0 and A^T * B1 and then transposing the result if bta == true.
+  // The active tile state has shape tm0 x tn0.
+  size_t tm = tn;
+
+  if (tm == 0 || tn == 0) {
+    return;
+  }
+
+  const size_t kShiftTile = 27;
+  const size_t kShiftPattern = 24;
+  const size_t kRowInc = 1;
+
+  const size_t tm0 = bta ? tn : tm;
+  const size_t tn0 = bta ? tm : tn;
+  const size_t tss_pattern = bta ? (size_t)(1) << kShiftPattern : 0;
+  const size_t mt0 = 0 | tss_pattern;
+  const size_t mt4 = (size_t)(4) << kShiftTile | tss_pattern;
+
+  float *c0 = c;
+  float *c1 = c0 + tsc1;
+
+  /* Load or zero-initialize tiles. */
+  size_t mt0_load = mt0;
+  size_t mt4_load = mt4;
+
+  float *c0_load = c0;
+  float *c1_load = c1;
+  size_t i = 0;
+  __asm__ volatile("bnez %[accum], 0f\n"
+                   "sf.vsettnt x0, %[tn0], e32, w1\n"
+                   "sf.vsettm x0, %[tm0]\n"
+
+                   "sf.vtzero.t mt0\n"
+                   "sf.vtzero.t mt4\n"
+                   "j 2f\n"
+                   "0:\n"
+                   "sf.vsettnt x0, %[tn], e32, w1\n"
+                   "1:\n"
+                   "addi %[i], %[i], 1\n"
+                   "sf.vlte32 %[mt0], (%[c0])\n"
+                   "add %[mt0], %[mt0], %[kRowInc]\n"
+                   "add %[c0], %[c0], %[sc]\n"
+                   "sf.vlte32 %[mt4], (%[c1])\n"
+                   "add %[mt4], %[mt4], %[kRowInc]\n"
+                   "add %[c1], %[c1], %[sc]\n"
+                   "bltu %[i], %[tm], 1b\n"
+                   "2:\n"
+                   : [mt0] "+&r"(mt0_load), [mt4] "+&r"(mt4_load),
+                     [c0] "+&r"(c0_load), [c1] "+&r"(c1_load), [i] "+&r"(i)
+                   : [accum] "r"(accum), [kRowInc] "rI"(kRowInc),
+                     [sc] "r"(rsc0 * sizeof(float)), [tm] "r"(tm), [tn] "r"(tn),
+                     [tm0] "r"(tm0), [tn0] "r"(tn0)
+                   : "vtype", "vl", "memory");
+
+  /* Accumulate matrix product into tiles. */
+  // a0_{0,1} are used to load a 2 x tm submatrix of A,
+  // b0_{0,1} are used to load a 2 x tn submatrix of B,
+  // and similarly for b1_{0,1}.
+  const uint8_t *a0_0 = a;
+  const uint8_t *a0_1 = a0_0 + rsa;
+  const uint8_t *b0_0 = b;
+  const uint8_t *b0_1 = b0_0 + rsb0;
+  const uint8_t *b1_0 = b0_0 + csb1;
+  const uint8_t *b1_1 = b1_0 + rsb0;
+  if (k < 4) {
+    __asm__ volatile(
+        "beqz %[k], 2f\n"
+
+        "sf.vsettnt x0, %[tn0], e8, w4\n"
+        "sf.vsettm x0, %[tm0]\n"
+        "sf.vsettk x0, %[k]\n"
+
+        "beq %[k], %[i2], 0f\n"
+        "beq %[k], %[i1], 1f\n"
+
+        // k == 3
+        "vle8.v v0, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle8.v v2, (%[a0_1])\n"
+        "vle8.v v4, (%[a0_0])\n"
+
+        "vle8.v v8, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle8.v v10, (%[b0_1])\n"
+        "vle8.v v12, (%[b0_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v16, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle8.v v18, (%[b1_1])\n"
+        "vle8.v v20, (%[b1_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+        "j 2f\n"
+
+        "0:\n" // k == 2
+        "vle8.v v0, (%[a0_0])\n"
+        "vle8.v v2, (%[a0_1])\n"
+
+        "vle8.v v8, (%[b0_0])\n"
+        "vle8.v v10, (%[b0_1])\n"
+
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v16, (%[b1_0])\n"
+        "vle8.v v18, (%[b1_1])\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+        "j 2f\n"
+
+        "1:\n" // k == 1
+        "vle8.v v0, (%[a0_0])\n"
+
+        "vle8.v v8, (%[b0_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+        "vle8.v v16, (%[b1_0])\n"
+
+        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+        "2:\n"
+        : [a0_0] "+&r"(a0_0), [b0_0] "+&r"(b0_0), [b1_0] "+&r"(b1_0)
+        : [a0_1] "r"(a0_1), [b0_1] "r"(b0_1), [b1_1] "r"(b1_1),
+          [sa] "r"(2 * rsa * sizeof(uint8_t)),
+          [sb] "r"(2 * rsb0 * sizeof(uint8_t)), [tm0] "r"(tm0), [tn0] "r"(tn0),
+          [k] "r"(k), [i1] "r"(1), [i2] "r"(2)
+        : "v0", "v1", "v2", "v3", "v4", "v5", "v8", "v9", "v10", "v11", "v12",
+          "v13", "v16", "v17", "v18", "v19", "v20", "v21", "vtype", "vl",
+          "memory");
+  } else {
+    __asm__ volatile("sf.vsettnt x0, %[tn0], e8, w4\n"
+                     "sf.vsettm x0, %[tm0]\n"
+                     "sf.vsettk x0, %[k]\n"
+
+                     "vle8.v v0, (%[a0_0])\n"
+                     "add %[a0_0], %[a0_0], %[sa]\n"
+                     "vle8.v v2, (%[a0_1])\n"
+                     "add %[a0_1], %[a0_1], %[sa]\n"
+                     "vle8.v v4, (%[a0_0])\n"
+                     "add %[a0_0], %[a0_0], %[sa]\n"
+                     "vle8.v v6, (%[a0_1])\n"
+                     "add %[a0_1], %[a0_1], %[sa]\n"
+
+                     "vle8.v v8, (%[b0_0])\n"
+                     "add %[b0_0], %[b0_0], %[sb]\n"
+                     "vle8.v v10, (%[b0_1])\n"
+                     "add %[b0_1], %[b0_1], %[sb]\n"
+                     "vle8.v v12, (%[b0_0])\n"
+                     "add %[b0_0], %[b0_0], %[sb]\n"
+                     "vle8.v v14, (%[b0_1])\n"
+                     "add %[b0_1], %[b0_1], %[sb]\n"
+
+                     "bltu %[k], %[i8], 1f\n"
+
+                     "0:\n"
+                     "addi %[k], %[k], -4\n"
+                     "vle8.v v16, (%[b1_0])\n"
+                     "add %[b1_0], %[b1_0], %[sb]\n"
+                     "vle8.v v18, (%[b1_1])\n"
+                     "add %[b1_1], %[b1_1], %[sb]\n"
+                     "vle8.v v20, (%[b1_0])\n"
+                     "add %[b1_0], %[b1_0], %[sb]\n"
+                     "vle8.v v22, (%[b1_1])\n"
+                     "add %[b1_1], %[b1_1], %[sb]\n"
+
+                     "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+                     "vle8.v v8, (%[b0_0])\n"
+                     "add %[b0_0], %[b0_0], %[sb]\n"
+                     "vle8.v v10, (%[b0_1])\n"
+                     "add %[b0_1], %[b0_1], %[sb]\n"
+                     "vle8.v v12, (%[b0_0])\n"
+                     "add %[b0_0], %[b0_0], %[sb]\n"
+                     "vle8.v v14, (%[b0_1])\n"
+                     "add %[b0_1], %[b0_1], %[sb]\n"
+
+                     "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+                     "vle8.v v0, (%[a0_0])\n"
+                     "add %[a0_0], %[a0_0], %[sa]\n"
+                     "vle8.v v2, (%[a0_1])\n"
+                     "add %[a0_1], %[a0_1], %[sa]\n"
+                     "vle8.v v4, (%[a0_0])\n"
+                     "add %[a0_0], %[a0_0], %[sa]\n"
+                     "vle8.v v6, (%[a0_1])\n"
+                     "add %[a0_1], %[a0_1], %[sa]\n"
+
+                     "bgeu %[k], %[i8], 0b\n"
+
+                     "1:\n"
+                     "addi %[k], %[k], -4\n"
+                     "vle8.v v16, (%[b1_0])\n"
+                     "add %[b1_0], %[b1_0], %[sb]\n"
+                     "vle8.v v18, (%[b1_1])\n"
+                     "add %[b1_1], %[b1_1], %[sb]\n"
+                     "vle8.v v20, (%[b1_0])\n"
+                     "add %[b1_0], %[b1_0], %[sb]\n"
+                     "vle8.v v22, (%[b1_1])\n"
+                     "add %[b1_1], %[b1_1], %[sb]\n"
+
+                     "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+                     "beq %[k], %[i2], 2f\n"
+                     "beq %[k], %[i1], 3f\n"
+                     "beqz %[k], 4f\n"
+
+                     // k % 4 == 3
+                     "vle8.v v8, (%[b0_0])\n"
+                     "add %[b0_0], %[b0_0], %[sb]\n"
+                     "vle8.v v10, (%[b0_1])\n"
+                     "vle8.v v12, (%[b0_0])\n"
+
+                     "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+                     "vle8.v v0, (%[a0_0])\n"
+                     "add %[a0_0], %[a0_0], %[sa]\n"
+                     "vle8.v v2, (%[a0_1])\n"
+                     "vle8.v v4, (%[a0_0])\n"
+
+                     "vle8.v v16, (%[b1_0])\n"
+                     "add %[b1_0], %[b1_0], %[sb]\n"
+                     "vle8.v v18, (%[b1_1])\n"
+                     "vle8.v v20, (%[b1_0])\n"
+
+                     "sf.vsettk x0, %[k]\n"
+                     "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+                     "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+                     "j 5f\n"
+
+                     "2:\n" // k % 4 == 2
+                     "vle8.v v8, (%[b0_0])\n"
+                     "vle8.v v10, (%[b0_1])\n"
+
+                     "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+                     "vle8.v v0, (%[a0_0])\n"
+                     "vle8.v v2, (%[a0_1])\n"
+
+                     "vle8.v v16, (%[b1_0])\n"
+                     "vle8.v v18, (%[b1_1])\n"
+
+                     "sf.vsettk x0, %[k]\n"
+                     "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+                     "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+                     "j 5f\n"
+
+                     "3:\n" // k % 4 == 1
+                     "vle8.v v8, (%[b0_0])\n"
+
+                     "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+                     "vle8.v v0, (%[a0_0])\n"
+
+                     "vle8.v v16, (%[b1_0])\n"
+
+                     "sf.vsettk x0, %[k]\n"
+                     "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+                     "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+                     "j 5f\n"
+
+                     "4:\n" // k % 4 == 0
+                     "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+                     "5:\n"
+                     : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1),
+                       [b0_0] "+&r"(b0_0), [b0_1] "+&r"(b0_1),
+                       [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1), [k] "+&r"(k)
+                     : [sa] "r"(2 * rsa * sizeof(uint8_t)),
+                       [sb] "r"(2 * rsb0 * sizeof(uint8_t)), [tm0] "r"(tm0),
+                       [tn0] "r"(tn0), [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
+                     : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8",
+                       "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16",
+                       "v17", "v18", "v19", "v20", "v21", "v22", "v23", "vtype",
+                       "vl", "memory");
+  }
+
+  /* Store tiles to memory. */
+  size_t mt0_store = mt0;
+  size_t mt4_store = mt4;
+
+  float *c0_store = c0;
+  float *c1_store = c1;
+  i = 0;
+  __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
+
+                   "0:\n"
+                   "addi %[i], %[i], 1\n"
+                   "sf.vste32 %[mt0], (%[c0])\n"
+                   "add %[mt0], %[mt0], %[kRowInc]\n"
+                   "add %[c0], %[c0], %[sc]\n"
+                   "sf.vste32 %[mt4], (%[c1])\n"
+                   "add %[mt4], %[mt4], %[kRowInc]\n"
+                   "add %[c1], %[c1], %[sc]\n"
+                   "bltu %[i], %[tm], 0b\n"
+
+                   "sf.vtdiscard"
+                   : [mt0] "+&r"(mt0_store), [mt4] "+&r"(mt4_store),
+                     [c0] "+&r"(c0_store), [c1] "+&r"(c1_store), [i] "+&r"(i)
+                   : [kRowInc] "rI"(kRowInc), [sc] "r"(rsc0 * sizeof(float)),
+                     [tm] "r"(tm), [tn] "r"(tn)
+                   : "vtype", "vl", "memory");
+}
+
+/* Process 2 (= 1 x 2) contiguous tm x tn tiles of c.
+ * tm and tn must be <= TE.
+ */
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_1tm2tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
+    size_t tn, size_t k, const uint8_t *a, size_t csa, const uint8_t *b,
+    size_t rsb0, size_t csb1, float *c, size_t rsc0, size_t csc1, bool accum) {
+  skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
+      tn, k, a, csa, b, rsb0, csb1, c, rsc0, csc1, accum, false);
+}
+
+/* Process 2 (= 2 x 1) contiguous tm x tn tiles of c.
+ * tm and tn must be <= TE.
+ */
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_2tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
+    size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
+    const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
+    bool accum) {
+  skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
+      tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+}
+
 /* Process 4 (= 2 x 2) contiguous tn x tn tiles of c. tn must be <= TE. */
 SKL_XSFMM_NEW
 SKL_FUNC_PRIVATE void skl_gemm_2tm2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -1850,13 +1850,33 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
   size_t ete = 0; // Effective tile edge length (always TE for TEW=32).
   __asm__ volatile("sf.vsettnt %0, x0, e8, w4" : "=r"(ete) : : "vtype", "vl");
 
-  size_t num_processed_by_2tm2tn_m = (m / (2 * ete)) * 2 * ete;
-  size_t num_processed_by_2tm2tn_n = (n / (2 * ete)) * 2 * ete;
-
   size_t i = 0;
-  for (; i < num_processed_by_2tm2tn_m; i += 2 * ete) {
+  for (; i + 4 * ete <= m; i += 4 * ete) {
     size_t j = 0;
-    for (; j < num_processed_by_2tm2tn_n; j += 2 * ete) {
+    for (; j + 2 * ete <= n; j += 2 * ete) {
+      skl_gemm_2tm2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
+          ete, k, a + i, csa, ete, b + j, rsb, ete, c + i * rsc + j, rsc,
+          ete * rsc, ete, accum);
+      skl_gemm_2tm2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
+          ete, k, a + i + 2 * ete, csa, ete, b + j, rsb, ete,
+          c + (i + 2 * ete) * rsc + j, rsc, ete * rsc, ete, accum);
+    }
+    while (j < n) {
+      size_t tn = 0;
+      __asm__ volatile("sf.vsettnt %0, %1, e8, w4"
+                       : "=r"(tn)
+                       : "r"(n - j)
+                       : "vtype", "vl");
+      skl_gemm_4tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
+          ete, tn, k, a + i, csa, ete, b + j, rsb, c + i * rsc + j, rsc,
+          ete * rsc, accum);
+      j += tn;
+    }
+  }
+
+  if (i + 2 * ete <= m) {
+    size_t j = 0;
+    for (; j + 2 * ete <= n; j += 2 * ete) {
       skl_gemm_2tm2tn_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
           ete, k, a + i, csa, ete, b + j, rsb, ete, c + i * rsc + j, rsc,
           ete * rsc, ete, accum);
@@ -1867,13 +1887,12 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
                        : "=r"(tn)
                        : "r"(n - j)
                        : "vtype", "vl");
-      skl_gemm_1tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
-          ete, tn, k, a + i, csa, b + j, rsb, c + i * rsc + j, rsc, accum);
-      skl_gemm_1tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
-          ete, tn, k, a + i + ete, csa, b + j, rsb, c + (i + ete) * rsc + j,
-          rsc, accum);
+      skl_gemm_2tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
+          ete, tn, k, a + i, csa, ete, b + j, rsb, c + i * rsc + j, rsc,
+          ete * rsc, accum);
       j += tn;
     }
+    i += 2 * ete;
   }
 
   while (i < m) {
@@ -1884,6 +1903,23 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
                      : "r"(m - i)
                      : "vtype", "vl");
     size_t j = 0;
+    for (; j + 4 * ete <= n; j += 4 * ete) {
+      skl_gemm_1tm4tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
+          tm, ete, k, a + i, csa, b + j, rsb, ete, c + i * rsc + j, rsc, ete,
+          accum);
+    }
+    if (j + 3 * ete <= n) {
+      skl_gemm_1tm3tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
+          tm, ete, k, a + i, csa, b + j, rsb, ete, c + i * rsc + j, rsc, ete,
+          accum);
+      j += 3 * ete;
+    }
+    if (j + 2 * ete <= n) {
+      skl_gemm_1tm2tn_a1b01_f8e4m3c_f8e4m3cp_f32rcp_xsfmm32a8f(
+          tm, ete, k, a + i, csa, b + j, rsb, ete, c + i * rsc + j, rsc, ete,
+          accum);
+      j += 2 * ete;
+    }
     while (j < n) {
       size_t tn = 0;
       __asm__ volatile("sf.vsettnt %0, %1, e8, w4"
@@ -1896,6 +1932,7 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
     }
     i += tm;
   }
+
   __asm__ volatile("sf.vtdiscard");
 }
 


### PR DESCRIPTION
This PR adds 1xn and nx1 f8 Xsfmm GEMM kernels and updates the outer loop code to utilize these in place of the 1x1 kernel where possible for improved performance.