### PR TITLE
[GEMM] Convert `gemm_1x2m8x2_f32_f32_f32_zve32f_x390` to inline assembly

### DIFF
--- a/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
+++ b/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
@@ -46,8 +46,8 @@ SKL_FUNC_PRIVATE void
 skl_gemm_1x2m8x2_f32_f32_f32_zve32f_x390(size_t n, size_t k, float alpha,
                                          const float *a, const float *b,
                                          size_t rsb, float beta, float *c) {
-  size_t jj_vl = __riscv_vsetvlmax_e32m8();
-  size_t jj_vl_0 = __riscv_vsetvlmax_e32m8();
+  size_t jj_vl;
+  size_t jj_vl_0;
   size_t ii;
   size_t jj;
   size_t kk_peel;

--- a/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
+++ b/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
@@ -194,67 +194,6 @@ skl_gemm_1x2m8x2_f32_f32_f32_zve32f_x390(size_t n, size_t k, float alpha,
             [c_store_0] "r"(c + (((ii + 0) * 1) + ((jj + jj_vl) * 1)))
           : "vtype", "vl", "memory");
     }
-    for (jj0 = jj; jj0 < n; jj0 = jj0 + (jj_vl + jj_vl_0)) {
-      jj_vl = __riscv_vsetvl_e32m8(n - jj0);
-      for (kk_peel = 0; ((kk_peel + 1) <= k) && (kk_peel < (0 + (1 * 1)));
-           kk_peel = kk_peel + 1) {
-        __asm__ volatile(
-            "\n\t"
-            "flw %[a0], 0(%[a_load_3]) \n\t"
-            "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
-            "vle32.v %[b0], (%[b_load_7]) \n\t"
-            "vfmul.vf %[acc], %[b0], %[a0] \n\t"
-            : [a0] "=&f"(a0), [b0] "=&vr"(b0), [acc] "=vr"(acc)
-            : [a_load_3] "r"(a + (((ii + 0) * 1) + ((kk_peel + 0) * 1))),
-              [jj_vl_in] "r"(jj_vl),
-              [b_load_7] "r"(b + (((kk_peel + 0) * rsb) + ((jj0 + 0) * 1)))
-            : "vtype", "vl", "memory");
-      }
-      for (kk = kk_peel; (kk + 2) <= k; kk = kk + 2) {
-        __asm__ volatile(
-            "\n\t"
-            "flw %[a00], 0(%[a_load_4]) \n\t"
-            "flw %[a01], 4(%[a_load_4]) \n\t"
-            "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
-            "vle32.v %[b00_1], (%[b_load_8]) \n\t"
-            "vfmacc.vf %[acc], %[a00], %[b00_1] \n\t"
-            "vle32.v %[b01_1], (%[b_load_9]) \n\t"
-            "vfmacc.vf %[acc], %[a01], %[b01_1] \n\t"
-            : [a00] "=&f"(a00), [b00_1] "=&vr"(b00_1), [acc] "+&vr"(acc),
-              [a01] "=&f"(a01), [b01_1] "=&vr"(b01_1)
-            : [a_load_4] "r"(a + (((ii + 0) * 1) + ((kk + 0) * 1))),
-              [jj_vl_in] "r"(jj_vl),
-              [b_load_8] "r"(b + (((kk + 0) * rsb) + ((jj0 + 0) * 1))),
-              [b_load_9] "r"(b + (((kk + 1) * rsb) + ((jj0 + 0) * 1)))
-            : "vtype", "vl", "memory");
-      }
-      for (kk0 = kk; (kk0 + 1) <= k; kk0 = kk0 + 1) {
-        __asm__ volatile(
-            "\n\t"
-            "flw %[a0], 0(%[a_load_6]) \n\t"
-            "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
-            "vle32.v %[b0], (%[b_load_10]) \n\t"
-            "vfmacc.vf %[acc], %[a0], %[b0] \n\t"
-            : [a0] "=&f"(a0), [b0] "=&vr"(b0), [acc] "+vr"(acc)
-            : [a_load_6] "r"(a + (((ii + 0) * 1) + ((kk0 + 0) * 1))),
-              [jj_vl_in] "r"(jj_vl),
-              [b_load_10] "r"(b + (((kk0 + 0) * rsb) + ((jj0 + 0) * 1)))
-            : "vtype", "vl", "memory");
-      }
-      __asm__ volatile(
-          "\n\t"
-          "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
-          "vle32.v %[c0], (%[c_load_1]) \n\t"
-          "vfmul.vf %[c0], %[c0], %[beta0] \n\t"
-          "vfmacc.vf %[c0], %[alpha0], %[acc] \n\t"
-          "vse32.v %[c0], (%[c_store_1]) \n\t"
-          : [c0] "=&vr"(c0)
-          : [jj_vl_in] "r"(jj_vl),
-            [c_load_1] "r"(c + (((ii + 0) * 1) + ((jj0 + 0) * 1))),
-            [beta0] "f"(beta0), [alpha0] "f"(alpha0), [acc] "vr"(acc),
-            [c_store_1] "r"(c + (((ii + 0) * 1) + ((jj0 + 0) * 1)))
-          : "vtype", "vl", "memory");
-    }
   }
 }
 

--- a/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
+++ b/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
@@ -53,7 +53,6 @@ skl_gemm_1x2m8x2_f32_f32_f32_zve32f_x390(size_t n, size_t k, float alpha,
   size_t kk_peel;
   size_t kk;
   size_t kk0;
-  size_t jj0;
   float alpha0;
   float beta0;
   float a0;
@@ -67,10 +66,6 @@ skl_gemm_1x2m8x2_f32_f32_f32_zve32f_x390(size_t n, size_t k, float alpha,
   float a01;
   vfloat32m8_t c00;
   vfloat32m8_t c01;
-  vfloat32m8_t b0;
-  vfloat32m8_t acc;
-  vfloat32m8_t b00_1;
-  vfloat32m8_t b01_1;
   vfloat32m8_t c0;
   alpha0 = alpha;
   beta0 = beta;

--- a/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
+++ b/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
@@ -46,41 +46,41 @@ SKL_FUNC_PRIVATE void
 skl_gemm_1x2m8x2_f32_f32_f32_zve32f_x390(size_t n, size_t k, float alpha,
                                          const float *a, const float *b,
                                          size_t rsb, float beta, float *c) {
-  size_t jj_vl;
-  size_t jj_vl_0;
+  size_t jj_vl = __riscv_vsetvlmax_e32m8();
+  size_t jj_vl_0 = __riscv_vsetvlmax_e32m8();
   size_t ii;
   size_t jj;
   size_t kk_peel;
   size_t kk;
   size_t kk0;
   size_t jj0;
-  float _alpha;
-  float _beta;
+  float alpha0;
+  float beta0;
   float a0;
-  vfloat32m8_t b00;
-  vfloat32m8_t b01;
+  vfloat32m8_t b00_0;
+  vfloat32m8_t b01_0;
   vfloat32m8_t acc0;
   vfloat32m8_t acc1;
   float a00;
-  float a01;
   vfloat32m8_t b000;
-  vfloat32m8_t b010;
   vfloat32m8_t b001;
-  vfloat32m8_t b011;
+  float a01;
   vfloat32m8_t c00;
   vfloat32m8_t c01;
   vfloat32m8_t b0;
   vfloat32m8_t acc;
+  vfloat32m8_t b00_1;
+  vfloat32m8_t b01_1;
   vfloat32m8_t c0;
-  _alpha = alpha;
-  _beta = beta;
+  alpha0 = alpha;
+  beta0 = beta;
   if (k == 0) {
     for (ii = 0; (ii + 1) <= 1; ii = ii + 1) {
       for (jj = 0; jj < n; jj = jj + jj_vl) {
         jj_vl = __riscv_vsetvl_e32m1(n - jj);
         c0 =
             __riscv_vle32_v_f32m8(c + (((ii + 0) * 1) + ((jj + 0) * 1)), jj_vl);
-        c0 = __riscv_vfmul_vf_f32m8(c0, _beta, jj_vl);
+        c0 = __riscv_vfmul_vf_f32m8(c0, beta0, jj_vl);
         __riscv_vse32_v_f32m8(c + (((ii + 0) * 1) + ((jj + 0) * 1)), c0, jj_vl);
       }
     }
@@ -92,70 +92,168 @@ skl_gemm_1x2m8x2_f32_f32_f32_zve32f_x390(size_t n, size_t k, float alpha,
       jj_vl_0 = __riscv_vsetvl_e32m8((n - jj) - jj_vl);
       for (kk_peel = 0; ((kk_peel + 1) <= k) && (kk_peel < (0 + (1 * 1)));
            kk_peel = kk_peel + 1) {
-        a0 = a[((ii + 0) * 1) + ((kk_peel + 0) * 1)];
-        b00 = __riscv_vle32_v_f32m8(
-            b + (((kk_peel + 0) * rsb) + ((jj + 0) * 1)), jj_vl);
-        b01 = __riscv_vle32_v_f32m8(
-            b + (((kk_peel + 0) * rsb) + ((jj + jj_vl) * 1)), jj_vl_0);
-        acc0 = __riscv_vfmul_vf_f32m8(b00, a0, jj_vl);
-        acc1 = __riscv_vfmul_vf_f32m8(b01, a0, jj_vl_0);
+        __asm__ volatile(
+            "\n\t"
+            "flw %[a0], 0(%[a_load]) \n\t"
+            "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+            "vle32.v %[b00_0], (%[b_load]) \n\t"
+            "vsetvli zero, %[jj_vl_0_in], e32, m8, ta, ma \n\t"
+            "vle32.v %[b01_0], (%[b_load_0]) \n\t"
+            "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+            "vfmul.vf %[acc0], %[b00_0], %[a0] \n\t"
+            "vsetvli zero, %[jj_vl_0_in], e32, m8, ta, ma \n\t"
+            "vfmul.vf %[acc1], %[b01_0], %[a0] \n\t"
+            : [a0] "=&f"(a0), [b00_0] "=&vr"(b00_0), [b01_0] "=&vr"(b01_0),
+              [acc0] "=&vr"(acc0), [acc1] "=vr"(acc1)
+            : [a_load] "r"(a + (((ii + 0) * 1) + ((kk_peel + 0) * 1))),
+              [jj_vl_in] "r"(jj_vl),
+              [b_load] "r"(b + (((kk_peel + 0) * rsb) + ((jj + 0) * 1))),
+              [jj_vl_0_in] "r"(jj_vl_0),
+              [b_load_0] "r"(b + (((kk_peel + 0) * rsb) + ((jj + jj_vl) * 1)))
+            : "vtype", "vl", "memory");
       }
       for (kk = kk_peel; (kk + 2) <= k; kk = kk + 2) {
-        a00 = a[((ii + 0) * 1) + ((kk + 0) * 1)];
-        a01 = a[((ii + 0) * 1) + ((kk + 1) * 1)];
-        skl_instruction_schedule_barrier();
-        b000 = __riscv_vle32_v_f32m8(b + (((kk + 0) * rsb) + ((jj + 0) * 1)),
-                                     jj_vl);
-        b010 = __riscv_vle32_v_f32m8(
-            b + (((kk + 0) * rsb) + ((jj + jj_vl) * 1)), jj_vl_0);
-        acc0 = __riscv_vfmacc_vf_f32m8(acc0, a00, b000, jj_vl);
-        acc1 = __riscv_vfmacc_vf_f32m8(acc1, a00, b010, jj_vl_0);
-        b001 = __riscv_vle32_v_f32m8(b + (((kk + 1) * rsb) + ((jj + 0) * 1)),
-                                     jj_vl);
-        b011 = __riscv_vle32_v_f32m8(
-            b + (((kk + 1) * rsb) + ((jj + jj_vl) * 1)), jj_vl_0);
-        acc0 = __riscv_vfmacc_vf_f32m8(acc0, a01, b001, jj_vl);
-        acc1 = __riscv_vfmacc_vf_f32m8(acc1, a01, b011, jj_vl_0);
+        __asm__ volatile(
+            "\n\t"
+            "flw %[a00], 0(%[a_load_0]) \n\t"
+            "flw %[a01], 4(%[a_load_0]) \n\t"
+            "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+            "vle32.v %[b000], (%[b_load_1]) \n\t"
+            "vsetvli zero, %[jj_vl_0_in], e32, m8, ta, ma \n\t"
+            "vle32.v %[b001], (%[b_load_2]) \n\t"
+            "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+            "vfmacc.vf %[acc0], %[a00], %[b000] \n\t"
+            "vsetvli zero, %[jj_vl_0_in], e32, m8, ta, ma \n\t"
+            "vfmacc.vf %[acc1], %[a00], %[b001] \n\t"
+            "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+            "vle32.v %[b000], (%[b_load_3]) \n\t"
+            "vsetvli zero, %[jj_vl_0_in], e32, m8, ta, ma \n\t"
+            "vle32.v %[b001], (%[b_load_4]) \n\t"
+            "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+            "vfmacc.vf %[acc0], %[a01], %[b000] \n\t"
+            "vsetvli zero, %[jj_vl_0_in], e32, m8, ta, ma \n\t"
+            "vfmacc.vf %[acc1], %[a01], %[b001] \n\t"
+            : [a00] "=&f"(a00), [b000] "=&vr"(b000), [b001] "=&vr"(b001),
+              [acc0] "+&vr"(acc0), [acc1] "+&vr"(acc1), [a01] "=&f"(a01)
+            : [a_load_0] "r"(a + (((ii + 0) * 1) + ((kk + 0) * 1))),
+              [jj_vl_in] "r"(jj_vl),
+              [b_load_1] "r"(b + (((kk + 0) * rsb) + ((jj + 0) * 1))),
+              [jj_vl_0_in] "r"(jj_vl_0),
+              [b_load_2] "r"(b + (((kk + 0) * rsb) + ((jj + jj_vl) * 1))),
+              [b_load_3] "r"(b + (((kk + 1) * rsb) + ((jj + 0) * 1))),
+              [b_load_4] "r"(b + (((kk + 1) * rsb) + ((jj + jj_vl) * 1)))
+            : "vtype", "vl", "memory");
       }
       for (kk0 = kk; (kk0 + 1) <= k; kk0 = kk0 + 1) {
-        a0 = a[((ii + 0) * 1) + ((kk0 + 0) * 1)];
-        b00 = __riscv_vle32_v_f32m8(b + (((kk0 + 0) * rsb) + ((jj + 0) * 1)),
-                                    jj_vl);
-        b01 = __riscv_vle32_v_f32m8(
-            b + (((kk0 + 0) * rsb) + ((jj + jj_vl) * 1)), jj_vl_0);
-        acc0 = __riscv_vfmacc_vf_f32m8(acc0, a0, b00, jj_vl);
-        acc1 = __riscv_vfmacc_vf_f32m8(acc1, a0, b01, jj_vl_0);
+        __asm__ volatile(
+            "\n\t"
+            "flw %[a0], 0(%[a_load_2]) \n\t"
+            "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+            "vle32.v %[b00_0], (%[b_load_5]) \n\t"
+            "vsetvli zero, %[jj_vl_0_in], e32, m8, ta, ma \n\t"
+            "vle32.v %[b01_0], (%[b_load_6]) \n\t"
+            "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+            "vfmacc.vf %[acc0], %[a0], %[b00_0] \n\t"
+            "vsetvli zero, %[jj_vl_0_in], e32, m8, ta, ma \n\t"
+            "vfmacc.vf %[acc1], %[a0], %[b01_0] \n\t"
+            : [a0] "=&f"(a0), [b00_0] "=&vr"(b00_0), [b01_0] "=&vr"(b01_0),
+              [acc0] "+&vr"(acc0), [acc1] "+vr"(acc1)
+            : [a_load_2] "r"(a + (((ii + 0) * 1) + ((kk0 + 0) * 1))),
+              [jj_vl_in] "r"(jj_vl),
+              [b_load_5] "r"(b + (((kk0 + 0) * rsb) + ((jj + 0) * 1))),
+              [jj_vl_0_in] "r"(jj_vl_0),
+              [b_load_6] "r"(b + (((kk0 + 0) * rsb) + ((jj + jj_vl) * 1)))
+            : "vtype", "vl", "memory");
       }
-      c00 = __riscv_vle32_v_f32m8(c + (((ii + 0) * 1) + ((jj + 0) * 1)), jj_vl);
-      c01 = __riscv_vle32_v_f32m8(c + (((ii + 0) * 1) + ((jj + jj_vl) * 1)),
-                                  jj_vl_0);
-      c00 = __riscv_vfmul_vf_f32m8(c00, _beta, jj_vl);
-      c01 = __riscv_vfmul_vf_f32m8(c01, _beta, jj_vl_0);
-      c00 = __riscv_vfmacc_vf_f32m8(c00, _alpha, acc0, jj_vl);
-      c01 = __riscv_vfmacc_vf_f32m8(c01, _alpha, acc1, jj_vl_0);
-      __riscv_vse32_v_f32m8(c + (((ii + 0) * 1) + ((jj + 0) * 1)), c00, jj_vl);
-      __riscv_vse32_v_f32m8(c + (((ii + 0) * 1) + ((jj + jj_vl) * 1)), c01,
-                            jj_vl_0);
+      __asm__ volatile(
+          "\n\t"
+          "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+          "vle32.v %[c00], (%[c_load]) \n\t"
+          "vsetvli zero, %[jj_vl_0_in], e32, m8, ta, ma \n\t"
+          "vle32.v %[c01], (%[c_load_0]) \n\t"
+          "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+          "vfmul.vf %[c00], %[c00], %[beta0] \n\t"
+          "vsetvli zero, %[jj_vl_0_in], e32, m8, ta, ma \n\t"
+          "vfmul.vf %[c01], %[c01], %[beta0] \n\t"
+          "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+          "vfmacc.vf %[c00], %[alpha0], %[acc0] \n\t"
+          "vsetvli zero, %[jj_vl_0_in], e32, m8, ta, ma \n\t"
+          "vfmacc.vf %[c01], %[alpha0], %[acc1] \n\t"
+          "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+          "vse32.v %[c00], (%[c_store]) \n\t"
+          "vsetvli zero, %[jj_vl_0_in], e32, m8, ta, ma \n\t"
+          "vse32.v %[c01], (%[c_store_0]) \n\t"
+          : [c00] "=&vr"(c00), [c01] "=&vr"(c01)
+          : [jj_vl_in] "r"(jj_vl),
+            [c_load] "r"(c + (((ii + 0) * 1) + ((jj + 0) * 1))),
+            [jj_vl_0_in] "r"(jj_vl_0),
+            [c_load_0] "r"(c + (((ii + 0) * 1) + ((jj + jj_vl) * 1))),
+            [beta0] "f"(beta0), [alpha0] "f"(alpha0), [acc0] "vr"(acc0),
+            [acc1] "vr"(acc1),
+            [c_store] "r"(c + (((ii + 0) * 1) + ((jj + 0) * 1))),
+            [c_store_0] "r"(c + (((ii + 0) * 1) + ((jj + jj_vl) * 1)))
+          : "vtype", "vl", "memory");
     }
     for (jj0 = jj; jj0 < n; jj0 = jj0 + (jj_vl + jj_vl_0)) {
       jj_vl = __riscv_vsetvl_e32m8(n - jj0);
       for (kk_peel = 0; ((kk_peel + 1) <= k) && (kk_peel < (0 + (1 * 1)));
            kk_peel = kk_peel + 1) {
-        a0 = a[((ii + 0) * 1) + ((kk_peel + 0) * 1)];
-        b0 = __riscv_vle32_v_f32m8(
-            b + (((kk_peel + 0) * rsb) + ((jj0 + 0) * 1)), jj_vl);
-        acc = __riscv_vfmul_vf_f32m8(b0, a0, jj_vl);
+        __asm__ volatile(
+            "\n\t"
+            "flw %[a0], 0(%[a_load_3]) \n\t"
+            "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+            "vle32.v %[b0], (%[b_load_7]) \n\t"
+            "vfmul.vf %[acc], %[b0], %[a0] \n\t"
+            : [a0] "=&f"(a0), [b0] "=&vr"(b0), [acc] "=vr"(acc)
+            : [a_load_3] "r"(a + (((ii + 0) * 1) + ((kk_peel + 0) * 1))),
+              [jj_vl_in] "r"(jj_vl),
+              [b_load_7] "r"(b + (((kk_peel + 0) * rsb) + ((jj0 + 0) * 1)))
+            : "vtype", "vl", "memory");
       }
-      for (kk = kk_peel; (kk + 1) <= k; kk = kk + 1) {
-        a0 = a[((ii + 0) * 1) + ((kk + 0) * 1)];
-        b0 = __riscv_vle32_v_f32m8(b + (((kk + 0) * rsb) + ((jj0 + 0) * 1)),
-                                   jj_vl);
-        acc = __riscv_vfmacc_vf_f32m8(acc, a0, b0, jj_vl);
+      for (kk = kk_peel; (kk + 2) <= k; kk = kk + 2) {
+        __asm__ volatile(
+            "\n\t"
+            "flw %[a00], 0(%[a_load_4]) \n\t"
+            "flw %[a01], 4(%[a_load_4]) \n\t"
+            "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+            "vle32.v %[b00_1], (%[b_load_8]) \n\t"
+            "vfmacc.vf %[acc], %[a00], %[b00_1] \n\t"
+            "vle32.v %[b01_1], (%[b_load_9]) \n\t"
+            "vfmacc.vf %[acc], %[a01], %[b01_1] \n\t"
+            : [a00] "=&f"(a00), [b00_1] "=&vr"(b00_1), [acc] "+&vr"(acc),
+              [a01] "=&f"(a01), [b01_1] "=&vr"(b01_1)
+            : [a_load_4] "r"(a + (((ii + 0) * 1) + ((kk + 0) * 1))),
+              [jj_vl_in] "r"(jj_vl),
+              [b_load_8] "r"(b + (((kk + 0) * rsb) + ((jj0 + 0) * 1))),
+              [b_load_9] "r"(b + (((kk + 1) * rsb) + ((jj0 + 0) * 1)))
+            : "vtype", "vl", "memory");
       }
-      c0 = __riscv_vle32_v_f32m8(c + (((ii + 0) * 1) + ((jj0 + 0) * 1)), jj_vl);
-      c0 = __riscv_vfmul_vf_f32m8(c0, _beta, jj_vl);
-      c0 = __riscv_vfmacc_vf_f32m8(c0, _alpha, acc, jj_vl);
-      __riscv_vse32_v_f32m8(c + (((ii + 0) * 1) + ((jj0 + 0) * 1)), c0, jj_vl);
+      for (kk0 = kk; (kk0 + 1) <= k; kk0 = kk0 + 1) {
+        __asm__ volatile(
+            "\n\t"
+            "flw %[a0], 0(%[a_load_6]) \n\t"
+            "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+            "vle32.v %[b0], (%[b_load_10]) \n\t"
+            "vfmacc.vf %[acc], %[a0], %[b0] \n\t"
+            : [a0] "=&f"(a0), [b0] "=&vr"(b0), [acc] "+vr"(acc)
+            : [a_load_6] "r"(a + (((ii + 0) * 1) + ((kk0 + 0) * 1))),
+              [jj_vl_in] "r"(jj_vl),
+              [b_load_10] "r"(b + (((kk0 + 0) * rsb) + ((jj0 + 0) * 1)))
+            : "vtype", "vl", "memory");
+      }
+      __asm__ volatile(
+          "\n\t"
+          "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+          "vle32.v %[c0], (%[c_load_1]) \n\t"
+          "vfmul.vf %[c0], %[c0], %[beta0] \n\t"
+          "vfmacc.vf %[c0], %[alpha0], %[acc] \n\t"
+          "vse32.v %[c0], (%[c_store_1]) \n\t"
+          : [c0] "=&vr"(c0)
+          : [jj_vl_in] "r"(jj_vl),
+            [c_load_1] "r"(c + (((ii + 0) * 1) + ((jj0 + 0) * 1))),
+            [beta0] "f"(beta0), [alpha0] "f"(alpha0), [acc] "vr"(acc),
+            [c_store_1] "r"(c + (((ii + 0) * 1) + ((jj0 + 0) * 1)))
+          : "vtype", "vl", "memory");
     }
   }
 }


### PR DESCRIPTION
This converts the `gemm_1x2m8x2_f32_f32_f32_zve32f_x390` kernel from RVV intrinsics to inline assembly to obtain a fixed instruction schedule. I used the same schedule as the existing one and observed no significant difference in performance between the two versions.

I also deleted the `jj0` "fixup" loop since it's unnecessary with the previous VLA vectorized loop.