### PR TITLE
[GEMM] Add remaining tilings for bf16 Xsfmm GEMM

### DIFF
--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -1230,13 +1230,33 @@ SKL_FUNC void skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f(
                    :
                    : "vtype", "vl");
 
-  size_t num_processed_by_2tm2tn_m = (m / (2 * ete)) * 2 * ete;
-  size_t num_processed_by_2tm2tn_n = (n / (2 * ete)) * 2 * ete;
-
   size_t i = 0;
-  for (; i < num_processed_by_2tm2tn_m; i += 2 * ete) {
+  for (; i + 4 * ete <= m; i += 4 * ete) {
     size_t j = 0;
-    for (; j < num_processed_by_2tm2tn_n; j += 2 * ete) {
+    for (; j + 2 * ete <= n; j += 2 * ete) {
+      skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+          ete, ete, k, a + i, csa, ete, b + j, rsb, ete, c + i * rsc + j, rsc,
+          ete * rsc, ete, accum);
+      skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+          ete, ete, k, a + i + 2 * ete, csa, ete, b + j, rsb, ete,
+          c + (i + 2 * ete) * rsc + j, rsc, ete * rsc, ete, accum);
+    }
+    while (j < n) {
+      size_t tn = 0;
+      __asm__ volatile("sf.vsettnt %0, %1, e16alt, w2"
+                       : "=r"(tn)
+                       : "r"(n - j)
+                       : "vtype", "vl");
+      skl_gemm_4tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
+          ete, tn, k, a + i, csa, ete, b + j, rsb, c + i * rsc + j, rsc,
+          ete * rsc, accum);
+      j += tn;
+    }
+  }
+
+  if (i + 2 * ete <= m) {
+    size_t j = 0;
+    for (; j + 2 * ete <= n; j += 2 * ete) {
       skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
           ete, ete, k, a + i, csa, ete, b + j, rsb, ete, c + i * rsc + j, rsc,
           ete * rsc, ete, accum);
@@ -1247,13 +1267,12 @@ SKL_FUNC void skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f(
                        : "=r"(tn)
                        : "r"(n - j)
                        : "vtype", "vl");
-      skl_gemm_1tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
-          ete, tn, k, a + i, csa, b + j, rsb, c + i * rsc + j, rsc, accum);
-      skl_gemm_1tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
-          ete, tn, k, a + i + ete, csa, b + j, rsb, c + (i + ete) * rsc + j,
-          rsc, accum);
+      skl_gemm_2tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
+          ete, tn, k, a + i, csa, ete, b + j, rsb, c + i * rsc + j, rsc,
+          ete * rsc, accum);
       j += tn;
     }
+    i += 2 * ete;
   }
 
   while (i < m) {
@@ -1264,6 +1283,23 @@ SKL_FUNC void skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f(
                      : "r"(m - i)
                      : "vtype", "vl");
     size_t j = 0;
+    for (; j + 4 * ete <= n; j += 4 * ete) {
+      skl_gemm_1tm4tn_a1b01_bf16c_bf16cp_f32rcp_xsfmm32a16f(
+          tm, ete, k, a + i, csa, b + j, rsb, ete, c + i * rsc + j, rsc, ete,
+          accum);
+    }
+    if (j + 3 * ete <= n) {
+      skl_gemm_1tm3tn_a1b01_bf16c_bf16cp_f32rcp_xsfmm32a16f(
+          tm, ete, k, a + i, csa, b + j, rsb, ete, c + i * rsc + j, rsc, ete,
+          accum);
+      j += 3 * ete;
+    }
+    if (j + 2 * ete <= n) {
+      skl_gemm_1tm2tn_a1b01_bf16c_bf16cp_f32rcp_xsfmm32a16f(
+          tm, ete, k, a + i, csa, b + j, rsb, ete, c + i * rsc + j, rsc, ete,
+          accum);
+      j += 2 * ete;
+    }
     while (j < n) {
       size_t tn = 0;
       __asm__ volatile("sf.vsettnt %0, %1, e16alt, w2"
@@ -1276,6 +1312,7 @@ SKL_FUNC void skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f(
     }
     i += tm;
   }
+
   __asm__ volatile("sf.vtdiscard");
 }
 
@@ -1294,37 +1331,67 @@ SKL_FUNC void skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
                    :
                    : "vtype", "vl");
 
-  size_t num_processed_by_2tm2tn_m1 = (m1 / 2) * 2;
-  size_t num_processed_by_2tm2tn_n1 = (n1 / 2) * 2;
-
   size_t i = 0;
-  for (; i < num_processed_by_2tm2tn_m1; i += 2) {
+  for (; i + 4 <= m1; i += 4) {
     size_t j = 0;
-    for (; j < num_processed_by_2tm2tn_n1; j += 2) {
+    for (; j + 2 <= n1; j += 2) {
+      skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+          ete, ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete,
+          csb1, c_pack + i * rsc1 + j * csc1, ete, rsc1, csc1, accum);
+      skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+          ete, ete, k, a_pack + (i + 2) * rsa1, ete, rsa1, b_pack + j * csb1,
+          ete, csb1, c_pack + (i + 2) * rsc1 + j * csc1, ete, rsc1, csc1,
+          accum);
+    }
+    if (j < n1) {
+      skl_gemm_4tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
+          ete, ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete,
+          c_pack + i * rsc1 + j * csc1, ete, rsc1, accum);
+    }
+  }
+
+  if (i + 2 <= m1) {
+    size_t j = 0;
+    for (; j + 2 <= n1; j += 2) {
       skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
           ete, ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete,
           csb1, c_pack + i * rsc1 + j * csc1, ete, rsc1, csc1, accum);
     }
-    while (j < n1) {
+    if (j < n1) {
+      skl_gemm_2tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
+          ete, ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete,
+          c_pack + i * rsc1 + j * csc1, ete, rsc1, accum);
+    }
+    i += 2;
+  }
+
+  if (i < m1) {
+    size_t j = 0;
+    for (; j + 4 <= n1; j += 4) {
+      skl_gemm_1tm4tn_a1b01_bf16c_bf16cp_f32rcp_xsfmm32a16f(
+          ete, ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete, csb1,
+          c_pack + i * rsc1 + j * csc1, ete, csc1, accum);
+    }
+    switch (n1 - j) {
+    case 3:
+      skl_gemm_1tm3tn_a1b01_bf16c_bf16cp_f32rcp_xsfmm32a16f(
+          ete, ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete, csb1,
+          c_pack + i * rsc1 + j * csc1, ete, csc1, accum);
+      break;
+    case 2:
+      skl_gemm_1tm2tn_a1b01_bf16c_bf16cp_f32rcp_xsfmm32a16f(
+          ete, ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete, csb1,
+          c_pack + i * rsc1 + j * csc1, ete, csc1, accum);
+      break;
+    case 1:
       skl_gemm_1tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
           ete, ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete,
           c_pack + i * rsc1 + j * csc1, ete, accum);
-      skl_gemm_1tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
-          ete, ete, k, a_pack + (i + 1) * rsa1, ete, b_pack + j * csb1, ete,
-          c_pack + (i + 1) * rsc1 + j * csc1, ete, accum);
-      j += 1;
+      break;
+    default:
+      break;
     }
   }
 
-  while (i < m1) {
-    size_t j = 0;
-    while (j < n1) {
-      skl_gemm_1tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
-          ete, ete, k, a_pack + i * rsa1, ete, b_pack + j * csb1, ete,
-          c_pack + i * rsc1 + j * csc1, ete, accum);
-      j += 1;
-    }
-    i += 1;
-  }
   __asm__ volatile("sf.vtdiscard");
 }

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -1124,7 +1124,7 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
 
         "beqz %[k], 2f\n"
 
-        // k % 4 == 1
+        // k % 2 == 1
         "vle16.v v0, (%[a0_0])\n"
 
         "sf.mm.f.f mt8, v8, v16\n"
@@ -1145,7 +1145,7 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
         "sf.mm.f.f mt12, v8, v24\n"
         "j 3f\n"
 
-        "2:\n" // k % 4 == 0
+        "2:\n" // k % 2 == 0
         "sf.mm.f.f mt8, v8, v16\n"
         "sf.mm.f.f mt12, v8, v24\n"
 

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -948,7 +948,7 @@ SKL_FUNC_PRIVATE void skl_gemm_4tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
 
 /* Process 4 (= 2 x 2) contiguous tn x tn tiles of c. tn must be <= TE. */
 SKL_XSFMM_NEW
-SKL_FUNC_PRIVATE void skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+SKL_FUNC_PRIVATE void skl_gemm_2tn2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
     size_t tn, size_t k, const __bf16 *a, size_t csa0, size_t rsa1,
     const __bf16 *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
     size_t rsc1, size_t csc1, bool accum) {
@@ -1220,10 +1220,10 @@ SKL_FUNC void skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f(
   for (; i + 4 * ete <= m; i += 4 * ete) {
     size_t j = 0;
     for (; j + 2 * ete <= n; j += 2 * ete) {
-      skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+      skl_gemm_2tn2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
           ete, k, a + i, csa, ete, b + j, rsb, ete, c + i * rsc + j, rsc,
           ete * rsc, ete, accum);
-      skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+      skl_gemm_2tn2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
           ete, k, a + i + 2 * ete, csa, ete, b + j, rsb, ete,
           c + (i + 2 * ete) * rsc + j, rsc, ete * rsc, ete, accum);
     }
@@ -1243,7 +1243,7 @@ SKL_FUNC void skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f(
   if (i + 2 * ete <= m) {
     size_t j = 0;
     for (; j + 2 * ete <= n; j += 2 * ete) {
-      skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+      skl_gemm_2tn2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
           ete, k, a + i, csa, ete, b + j, rsb, ete, c + i * rsc + j, rsc,
           ete * rsc, ete, accum);
     }
@@ -1321,10 +1321,10 @@ SKL_FUNC void skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
   for (; i + 4 <= m1; i += 4) {
     size_t j = 0;
     for (; j + 2 <= n1; j += 2) {
-      skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+      skl_gemm_2tn2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
           ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete, csb1,
           c_pack + i * rsc1 + j * csc1, ete, rsc1, csc1, accum);
-      skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+      skl_gemm_2tn2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
           ete, k, a_pack + (i + 2) * rsa1, ete, rsa1, b_pack + j * csb1, ete,
           csb1, c_pack + (i + 2) * rsc1 + j * csc1, ete, rsc1, csc1, accum);
     }
@@ -1338,7 +1338,7 @@ SKL_FUNC void skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
   if (i + 2 <= m1) {
     size_t j = 0;
     for (; j + 2 <= n1; j += 2) {
-      skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+      skl_gemm_2tn2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
           ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete, csb1,
           c_pack + i * rsc1 + j * csc1, ete, rsc1, csc1, accum);
     }

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -894,8 +894,10 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
     size_t tm, size_t tn, size_t k, const __bf16 *a, size_t csa0, size_t rsa1,
     const __bf16 *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
+  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm2tn_2tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 3 (= 1 x 3) contiguous tm x tn tiles of c.
@@ -914,12 +916,15 @@ SKL_FUNC_PRIVATE void skl_gemm_1tm3tn_a1b01_bf16c_bf16cp_f32rcp_xsfmm32a16f(
  * tm and tn must be <= TE.
  */
 SKL_XSFMM_NEW
-SKL_FUNC_PRIVATE void skl_gemm_3tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
+__attribute__((unused)) SKL_FUNC_PRIVATE void
+skl_gemm_3tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
     size_t tm, size_t tn, size_t k, const __bf16 *a, size_t csa0, size_t rsa1,
     const __bf16 *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
+  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm3tn_3tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 1 x 4) contiguous tm x tn tiles of c.
@@ -942,8 +947,10 @@ SKL_FUNC_PRIVATE void skl_gemm_4tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
     size_t tm, size_t tn, size_t k, const __bf16 *a, size_t csa0, size_t rsa1,
     const __bf16 *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
+  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm4tn_4tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 2 x 2) contiguous tn x tn tiles of c. tn must be <= TE. */

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -946,14 +946,16 @@ SKL_FUNC_PRIVATE void skl_gemm_4tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
 }
 
-/* Process 4 (= 2 x 2) contiguous tm x tn tiles of c.
- * tm and tn must be <= TE.
- */
+/* Process 4 (= 2 x 2) contiguous tn x tn tiles of c. tn must be <= TE. */
 SKL_XSFMM_NEW
 SKL_FUNC_PRIVATE void skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
-    size_t tm, size_t tn, size_t k, const __bf16 *a, size_t csa0, size_t rsa1,
+    size_t tn, size_t k, const __bf16 *a, size_t csa0, size_t rsa1,
     const __bf16 *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
     size_t rsc1, size_t csc1, bool accum) {
+  /* Avoiding sf.vsettn instructions in the inner loop slightly improves
+   * performance but requires tm == tn. */
+  size_t tm = tn;
+
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -1035,10 +1037,8 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
                      "sf.vsettk x0, %[k]\n"
 
                      // k == 1
-                     "sf.vsettn x0, %[tm]\n"
                      "vle16.v v0, (%[a0_0])\n"
 
-                     "sf.vsettn x0, %[tn]\n"
                      "vle16.v v16, (%[b0_0])\n"
 
                      "sf.mm.f.f mt0, v0, v16\n"
@@ -1047,10 +1047,8 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
 
                      "sf.mm.f.f mt4, v0, v24\n"
 
-                     "sf.vsettn x0, %[tm]\n"
                      "vle16.v v8, (%[a1_0])\n"
 
-                     "sf.vsettn x0, %[tn]\n"
                      "sf.mm.f.f mt8, v8, v16\n"
                      "sf.mm.f.f mt12, v8, v24\n"
 
@@ -1072,12 +1070,10 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
         "vle16.v v20, (%[b0_1])\n"
         "add %[b0_1], %[b0_1], %[sb]\n"
 
-        "sf.vsettn x0, %[tm]\n"
         "vle16.v v0, (%[a0_0])\n"
         "add %[a0_0], %[a0_0], %[sa]\n"
         "vle16.v v4, (%[a0_1])\n"
         "add %[a0_1], %[a0_1], %[sa]\n"
-        "sf.vsettn x0, %[tn]\n"
 
         "bltu %[k], %[i4], 1f\n"
 
@@ -1090,21 +1086,17 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
 
         "sf.mm.f.f mt0, v0, v16\n"
 
-        "sf.vsettn x0, %[tm]\n"
         "vle16.v v8, (%[a1_0])\n"
         "add %[a1_0], %[a1_0], %[sa]\n"
         "vle16.v v12, (%[a1_1])\n"
         "add %[a1_1], %[a1_1], %[sa]\n"
-        "sf.vsettn x0, %[tn]\n"
 
         "sf.mm.f.f mt4, v0, v24\n"
 
-        "sf.vsettn x0, %[tm]\n"
         "vle16.v v0, (%[a0_0])\n"
         "add %[a0_0], %[a0_0], %[sa]\n"
         "vle16.v v4, (%[a0_1])\n"
         "add %[a0_1], %[a0_1], %[sa]\n"
-        "sf.vsettn x0, %[tn]\n"
 
         "sf.mm.f.f mt8, v8, v16\n"
 
@@ -1124,20 +1116,16 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
 
         "sf.mm.f.f mt0, v0, v16\n"
 
-        "sf.vsettn x0, %[tm]\n"
         "vle16.v v8, (%[a1_0])\n"
         "add %[a1_0], %[a1_0], %[sa]\n"
         "vle16.v v12, (%[a1_1])\n"
-        "sf.vsettn x0, %[tn]\n"
 
         "sf.mm.f.f mt4, v0, v24\n"
 
         "beqz %[k], 2f\n"
 
         // k % 4 == 1
-        "sf.vsettn x0, %[tm]\n"
         "vle16.v v0, (%[a0_0])\n"
-        "sf.vsettn x0, %[tn]\n"
 
         "sf.mm.f.f mt8, v8, v16\n"
 
@@ -1150,9 +1138,7 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
         "sf.vsettk x0, %[k]\n"
         "sf.mm.f.f mt0, v0, v16\n"
 
-        "sf.vsettn x0, %[tm]\n"
         "vle16.v v8, (%[a1_0])\n"
-        "sf.vsettn x0, %[tn]\n"
 
         "sf.mm.f.f mt4, v0, v24\n"
         "sf.mm.f.f mt8, v8, v16\n"
@@ -1235,10 +1221,10 @@ SKL_FUNC void skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f(
     size_t j = 0;
     for (; j + 2 * ete <= n; j += 2 * ete) {
       skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
-          ete, ete, k, a + i, csa, ete, b + j, rsb, ete, c + i * rsc + j, rsc,
+          ete, k, a + i, csa, ete, b + j, rsb, ete, c + i * rsc + j, rsc,
           ete * rsc, ete, accum);
       skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
-          ete, ete, k, a + i + 2 * ete, csa, ete, b + j, rsb, ete,
+          ete, k, a + i + 2 * ete, csa, ete, b + j, rsb, ete,
           c + (i + 2 * ete) * rsc + j, rsc, ete * rsc, ete, accum);
     }
     while (j < n) {
@@ -1258,7 +1244,7 @@ SKL_FUNC void skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f(
     size_t j = 0;
     for (; j + 2 * ete <= n; j += 2 * ete) {
       skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
-          ete, ete, k, a + i, csa, ete, b + j, rsb, ete, c + i * rsc + j, rsc,
+          ete, k, a + i, csa, ete, b + j, rsb, ete, c + i * rsc + j, rsc,
           ete * rsc, ete, accum);
     }
     while (j < n) {
@@ -1336,12 +1322,11 @@ SKL_FUNC void skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
     size_t j = 0;
     for (; j + 2 <= n1; j += 2) {
       skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
-          ete, ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete,
-          csb1, c_pack + i * rsc1 + j * csc1, ete, rsc1, csc1, accum);
+          ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete, csb1,
+          c_pack + i * rsc1 + j * csc1, ete, rsc1, csc1, accum);
       skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
-          ete, ete, k, a_pack + (i + 2) * rsa1, ete, rsa1, b_pack + j * csb1,
-          ete, csb1, c_pack + (i + 2) * rsc1 + j * csc1, ete, rsc1, csc1,
-          accum);
+          ete, k, a_pack + (i + 2) * rsa1, ete, rsa1, b_pack + j * csb1, ete,
+          csb1, c_pack + (i + 2) * rsc1 + j * csc1, ete, rsc1, csc1, accum);
     }
     if (j < n1) {
       skl_gemm_4tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
@@ -1354,8 +1339,8 @@ SKL_FUNC void skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
     size_t j = 0;
     for (; j + 2 <= n1; j += 2) {
       skl_gemm_2tm2tn_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
-          ete, ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete,
-          csb1, c_pack + i * rsc1 + j * csc1, ete, rsc1, csc1, accum);
+          ete, k, a_pack + i * rsa1, ete, rsa1, b_pack + j * csb1, ete, csb1,
+          c_pack + i * rsc1 + j * csc1, ete, rsc1, csc1, accum);
     }
     if (j < n1) {
       skl_gemm_2tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -119,6 +119,833 @@ SKL_FUNC_PRIVATE void skl_gemm_1tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
       : "vtype", "vl", "memory");
 }
 
+/* C consists of two tm x tn row major tiles C0 and C1. Each tile's row stride
+ * is rsc0, and the distance from C0 to C1 in elements is tsc1. A is a row major
+ * matrix with k rows and row stride rsa. B consists of two row major tiles B0
+ * and B1. Each tile has k rows and row stride rsb0, and the distance from B0 to
+ * B1 in elements is csb1. If bta == true, this routine computes C0 = B0^T * A,
+ * C1 = B1^T * A. Otherwise, it computes C0 = A^T * B0, C1 = A^T * B1.
+ */
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_1tm2tn_2tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
+    size_t tm, size_t tn, size_t k, const __bf16 *a, size_t rsa,
+    const __bf16 *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
+    size_t tsc1, bool accum, bool bta) {
+  // We can use the same inner loop code for both values of bta by computing A^T
+  // * B0 and A^T * B1 and then transposing the result if bta == true.
+  // The active tile state has shape tm0 x tn0.
+  if (tm == 0 || tn == 0) {
+    return;
+  }
+
+  const size_t kShiftTile = 27;
+  const size_t kShiftPattern = 24;
+  const size_t kRowInc = 1;
+
+  const size_t tm0 = bta ? tn : tm;
+  const size_t tn0 = bta ? tm : tn;
+  const size_t tss_pattern = bta ? (size_t)(1) << kShiftPattern : 0;
+  const size_t mt0 = 0 | tss_pattern;
+  const size_t mt4 = (size_t)(4) << kShiftTile | tss_pattern;
+
+  float *c0 = c;
+  float *c1 = c0 + tsc1;
+
+  /* Load or zero-initialize tiles. */
+  size_t mt0_load = mt0;
+  size_t mt4_load = mt4;
+
+  float *c0_load = c0;
+  float *c1_load = c1;
+  size_t i = 0;
+  __asm__ volatile("bnez %[accum], 0f\n"
+                   "sf.vsettnt x0, %[tn0], e32, w1\n"
+                   "sf.vsettm x0, %[tm0]\n"
+
+                   "sf.vtzero.t mt0\n"
+                   "sf.vtzero.t mt4\n"
+                   "j 2f\n"
+                   "0:\n"
+                   "sf.vsettnt x0, %[tn], e32, w1\n"
+                   "1:\n"
+                   "addi %[i], %[i], 1\n"
+                   "sf.vlte32 %[mt0], (%[c0])\n"
+                   "add %[mt0], %[mt0], %[kRowInc]\n"
+                   "add %[c0], %[c0], %[sc]\n"
+                   "sf.vlte32 %[mt4], (%[c1])\n"
+                   "add %[mt4], %[mt4], %[kRowInc]\n"
+                   "add %[c1], %[c1], %[sc]\n"
+                   "bltu %[i], %[tm], 1b\n"
+                   "2:\n"
+                   : [mt0] "+&r"(mt0_load), [mt4] "+&r"(mt4_load),
+                     [c0] "+&r"(c0_load), [c1] "+&r"(c1_load), [i] "+&r"(i)
+                   : [accum] "r"(accum), [kRowInc] "rI"(kRowInc),
+                     [sc] "r"(rsc0 * sizeof(float)), [tm] "r"(tm), [tn] "r"(tn),
+                     [tm0] "r"(tm0), [tn0] "r"(tn0)
+                   : "vtype", "vl", "memory");
+
+  /* Accumulate matrix product into tiles. */
+  // a0_{0,1} are used to load a 2 x tm submatrix of A,
+  // b0_{0,1} are used to load a 2 x tn submatrix of B,
+  // and similarly for a1_{0,1} and b1_{0,1}.
+  const __bf16 *a0_0 = a;
+  const __bf16 *a0_1 = a0_0 + rsa;
+  const __bf16 *b0_0 = b;
+  const __bf16 *b0_1 = b0_0 + rsb0;
+  const __bf16 *b1_0 = b0_0 + csb1;
+  const __bf16 *b1_1 = b1_0 + rsb0;
+
+  if (k < 2) {
+    __asm__ volatile("beqz %[k], 0f\n"
+
+                     "sf.vsettnt x0, %[tn0], e16alt, w2\n"
+                     "sf.vsettm x0, %[tm0]\n"
+                     "sf.vsettk x0, %[k]\n"
+
+                     // k == 1
+                     "sf.vsettn x0, %[tm0]\n"
+                     "vle16.v v0, (%[a0_0])\n"
+                     "sf.vsettn x0, %[tn0]\n"
+
+                     "vle16.v v8, (%[b0_0])\n"
+
+                     "sf.mm.f.f mt0, v0, v8\n"
+
+                     "vle16.v v16, (%[b1_0])\n"
+
+                     "sf.mm.f.f mt4, v0, v16\n"
+
+                     "0:\n"
+                     :
+                     : [a0_0] "r"(a0_0), [b0_0] "r"(b0_0), [b1_0] "r"(b1_0),
+                       [tm0] "r"(tm0), [tn0] "r"(tn0), [k] "r"(k)
+                     : "v0", "v1", "v2", "v3", "v8", "v9", "v10", "v11", "v16",
+                       "v17", "v18", "v19", "vtype", "vl", "memory");
+  } else {
+    __asm__ volatile("sf.vsettnt x0, %[tn0], e16alt, w2\n"
+                     "sf.vsettm x0, %[tm0]\n"
+                     "sf.vsettk x0, %[k]\n"
+
+                     "sf.vsettn x0, %[tm0]\n"
+                     "vle16.v v0, (%[a0_0])\n"
+                     "add %[a0_0], %[a0_0], %[sa]\n"
+                     "vle16.v v4, (%[a0_1])\n"
+                     "add %[a0_1], %[a0_1], %[sa]\n"
+                     "sf.vsettn x0, %[tn0]\n"
+
+                     "vle16.v v8, (%[b0_0])\n"
+                     "add %[b0_0], %[b0_0], %[sb]\n"
+                     "vle16.v v12, (%[b0_1])\n"
+                     "add %[b0_1], %[b0_1], %[sb]\n"
+
+                     "bltu %[k], %[i4], 1f\n"
+
+                     "0:\n"
+                     "addi %[k], %[k], -2\n"
+                     "vle16.v v16, (%[b1_0])\n"
+                     "add %[b1_0], %[b1_0], %[sb]\n"
+                     "vle16.v v20, (%[b1_1])\n"
+                     "add %[b1_1], %[b1_1], %[sb]\n"
+
+                     "sf.mm.f.f mt0, v0, v8\n"
+
+                     "vle16.v v8, (%[b0_0])\n"
+                     "add %[b0_0], %[b0_0], %[sb]\n"
+                     "vle16.v v12, (%[b0_1])\n"
+                     "add %[b0_1], %[b0_1], %[sb]\n"
+
+                     "sf.mm.f.f mt4, v0, v16\n"
+
+                     "sf.vsettn x0, %[tm0]\n"
+                     "vle16.v v0, (%[a0_0])\n"
+                     "add %[a0_0], %[a0_0], %[sa]\n"
+                     "vle16.v v4, (%[a0_1])\n"
+                     "add %[a0_1], %[a0_1], %[sa]\n"
+                     "sf.vsettn x0, %[tn0]\n"
+
+                     "bgeu %[k], %[i4], 0b\n"
+
+                     "1:\n"
+                     "addi %[k], %[k], -2\n"
+                     "vle16.v v16, (%[b1_0])\n"
+                     "add %[b1_0], %[b1_0], %[sb]\n"
+                     "vle16.v v20, (%[b1_1])\n"
+                     "add %[b1_1], %[b1_1], %[sb]\n"
+
+                     "sf.mm.f.f mt0, v0, v8\n"
+
+                     "beqz %[k], 2f\n"
+
+                     // k % 2 == 1
+                     "vle16.v v8, (%[b0_0])\n"
+
+                     "sf.mm.f.f mt4, v0, v16\n"
+
+                     "sf.vsettn x0, %[tm0]\n"
+                     "vle16.v v0, (%[a0_0])\n"
+                     "sf.vsettn x0, %[tn0]\n"
+
+                     "vle16.v v16, (%[b1_0])\n"
+
+                     "sf.vsettk x0, %[k]\n"
+                     "sf.mm.f.f mt0, v0, v8\n"
+                     "sf.mm.f.f mt4, v0, v16\n"
+                     "j 3f\n"
+
+                     "2:\n" // k % 2 == 0
+                     "sf.mm.f.f mt4, v0, v16\n"
+
+                     "3:\n"
+                     : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1),
+                       [b0_0] "+&r"(b0_0), [b0_1] "+&r"(b0_1),
+                       [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1), [k] "+&r"(k)
+                     : [sa] "r"(2 * rsa * sizeof(__bf16)),
+                       [sb] "r"(2 * rsb0 * sizeof(__bf16)), [tm0] "r"(tm0),
+                       [tn0] "r"(tn0), [i4] "r"(4)
+                     : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8",
+                       "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16",
+                       "v17", "v18", "v19", "v20", "v21", "v22", "v23", "vtype",
+                       "vl", "memory");
+  }
+
+  /* Store tiles to memory. */
+  size_t mt0_store = mt0;
+  size_t mt4_store = mt4;
+
+  float *c0_store = c0;
+  float *c1_store = c1;
+  i = 0;
+  __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
+
+                   "0:\n"
+                   "addi %[i], %[i], 1\n"
+                   "sf.vste32 %[mt0], (%[c0])\n"
+                   "add %[mt0], %[mt0], %[kRowInc]\n"
+                   "add %[c0], %[c0], %[sc]\n"
+                   "sf.vste32 %[mt4], (%[c1])\n"
+                   "add %[mt4], %[mt4], %[kRowInc]\n"
+                   "add %[c1], %[c1], %[sc]\n"
+                   "bltu %[i], %[tm], 0b\n"
+
+                   "sf.vtdiscard"
+                   : [mt0] "+&r"(mt0_store), [mt4] "+&r"(mt4_store),
+                     [c0] "+&r"(c0_store), [c1] "+&r"(c1_store), [i] "+&r"(i)
+                   : [kRowInc] "rI"(kRowInc), [sc] "r"(rsc0 * sizeof(float)),
+                     [tm] "r"(tm), [tn] "r"(tn)
+                   : "vtype", "vl", "memory");
+}
+
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_1tm3tn_3tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
+    size_t tm, size_t tn, size_t k, const __bf16 *a, size_t rsa,
+    const __bf16 *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
+    size_t tsc1, bool accum, bool bta) {
+  // We can use the same inner loop code for both values of bta by computing A^T
+  // * B0 and A^T * B1 and then transposing the result if bta == true.
+  // The active tile state has shape tm0 x tn0.
+  if (tm == 0 || tn == 0) {
+    return;
+  }
+
+  const size_t kShiftTile = 27;
+  const size_t kShiftPattern = 24;
+  const size_t kRowInc = 1;
+
+  const size_t tm0 = bta ? tn : tm;
+  const size_t tn0 = bta ? tm : tn;
+  const size_t tss_pattern = bta ? (size_t)(1) << kShiftPattern : 0;
+  const size_t mt0 = 0 | tss_pattern;
+  const size_t mt4 = (size_t)(4) << kShiftTile | tss_pattern;
+  const size_t mt8 = (size_t)(8) << kShiftTile | tss_pattern;
+
+  float *c0 = c;
+  float *c1 = c0 + tsc1;
+  float *c2 = c0 + 2 * tsc1;
+
+  /* Load or zero-initialize tiles. */
+  size_t mt0_load = mt0;
+  size_t mt4_load = mt4;
+  size_t mt8_load = mt8;
+
+  float *c0_load = c0;
+  float *c1_load = c1;
+  float *c2_load = c2;
+  size_t i = 0;
+  __asm__ volatile("bnez %[accum], 0f\n"
+                   "sf.vsettnt x0, %[tn0], e32, w1\n"
+                   "sf.vsettm x0, %[tm0]\n"
+
+                   "sf.vtzero.t mt0\n"
+                   "sf.vtzero.t mt4\n"
+                   "sf.vtzero.t mt8\n"
+                   "j 2f\n"
+                   "0:\n"
+                   "sf.vsettnt x0, %[tn], e32, w1\n"
+                   "1:\n"
+                   "addi %[i], %[i], 1\n"
+                   "sf.vlte32 %[mt0], (%[c0])\n"
+                   "add %[mt0], %[mt0], %[kRowInc]\n"
+                   "add %[c0], %[c0], %[sc]\n"
+                   "sf.vlte32 %[mt4], (%[c1])\n"
+                   "add %[mt4], %[mt4], %[kRowInc]\n"
+                   "add %[c1], %[c1], %[sc]\n"
+                   "sf.vlte32 %[mt8], (%[c2])\n"
+                   "add %[mt8], %[mt8], %[kRowInc]\n"
+                   "add %[c2], %[c2], %[sc]\n"
+                   "bltu %[i], %[tm], 1b\n"
+                   "2:\n"
+                   : [mt0] "+&r"(mt0_load), [mt4] "+&r"(mt4_load),
+                     [mt8] "+&r"(mt8_load), [c0] "+&r"(c0_load),
+                     [c1] "+&r"(c1_load), [c2] "+&r"(c2_load), [i] "+&r"(i)
+                   : [accum] "r"(accum), [kRowInc] "rI"(kRowInc),
+                     [sc] "r"(rsc0 * sizeof(float)), [tm] "r"(tm), [tn] "r"(tn),
+                     [tm0] "r"(tm0), [tn0] "r"(tn0)
+                   : "vtype", "vl", "memory");
+
+  /* Accumulate matrix product into tiles. */
+  // a0_{0,1} are used to load a 2 x tm submatrix of A,
+  // b0_{0,1} are used to load a 2 x tn submatrix of B,
+  // and similarly for a1_{0,1} and b1_{0,1}.
+  const __bf16 *a0_0 = a;
+  const __bf16 *a0_1 = a0_0 + rsa;
+  const __bf16 *b0_0 = b;
+  const __bf16 *b0_1 = b0_0 + rsb0;
+  const __bf16 *b1_0 = b0_0 + csb1;
+  const __bf16 *b1_1 = b1_0 + rsb0;
+  const __bf16 *b2_0 = b0_0 + 2 * csb1;
+  const __bf16 *b2_1 = b2_0 + rsb0;
+
+  if (k < 2) {
+    __asm__ volatile(
+        "beqz %[k], 0f\n"
+
+        "sf.vsettnt x0, %[tn0], e16alt, w2\n"
+        "sf.vsettm x0, %[tm0]\n"
+        "sf.vsettk x0, %[k]\n"
+
+        // k == 1
+        "sf.vsettn x0, %[tm0]\n"
+        "vle16.v v0, (%[a0_0])\n"
+        "sf.vsettn x0, %[tn0]\n"
+
+        "vle16.v v8, (%[b0_0])\n"
+
+        "sf.mm.f.f mt0, v0, v8\n"
+
+        "vle16.v v16, (%[b1_0])\n"
+
+        "sf.mm.f.f mt4, v0, v16\n"
+
+        "vle16.v v24, (%[b2_0])\n"
+
+        "sf.mm.f.f mt8, v0, v24\n"
+
+        "0:\n"
+        :
+        : [a0_0] "r"(a0_0), [b0_0] "r"(b0_0), [b1_0] "r"(b1_0),
+          [b2_0] "r"(b2_0), [tm0] "r"(tm0), [tn0] "r"(tn0), [k] "r"(k)
+        : "v0", "v1", "v2", "v3", "v8", "v9", "v10", "v11", "v16", "v17", "v18",
+          "v19", "v24", "v25", "v26", "v27", "vtype", "vl", "memory");
+  } else {
+    __asm__ volatile(
+        "sf.vsettnt x0, %[tn0], e16alt, w2\n"
+        "sf.vsettm x0, %[tm0]\n"
+        "sf.vsettk x0, %[k]\n"
+
+        "sf.vsettn x0, %[tm0]\n"
+        "vle16.v v0, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle16.v v4, (%[a0_1])\n"
+        "add %[a0_1], %[a0_1], %[sa]\n"
+        "sf.vsettn x0, %[tn0]\n"
+
+        "vle16.v v8, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle16.v v12, (%[b0_1])\n"
+        "add %[b0_1], %[b0_1], %[sb]\n"
+
+        "bltu %[k], %[i4], 1f\n"
+
+        "0:\n"
+        "addi %[k], %[k], -2\n"
+        "vle16.v v16, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle16.v v20, (%[b1_1])\n"
+        "add %[b1_1], %[b1_1], %[sb]\n"
+
+        "sf.mm.f.f mt0, v0, v8\n"
+
+        "vle16.v v24, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle16.v v28, (%[b2_1])\n"
+        "add %[b2_1], %[b2_1], %[sb]\n"
+
+        "sf.mm.f.f mt4, v0, v16\n"
+
+        "vle16.v v8, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle16.v v12, (%[b0_1])\n"
+        "add %[b0_1], %[b0_1], %[sb]\n"
+
+        "sf.mm.f.f mt8, v0, v24\n"
+
+        "sf.vsettn x0, %[tm0]\n"
+        "vle16.v v0, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle16.v v4, (%[a0_1])\n"
+        "add %[a0_1], %[a0_1], %[sa]\n"
+        "sf.vsettn x0, %[tn0]\n"
+
+        "bgeu %[k], %[i4], 0b\n"
+
+        "1:\n"
+        "addi %[k], %[k], -2\n"
+        "vle16.v v16, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle16.v v20, (%[b1_1])\n"
+        "add %[b1_1], %[b1_1], %[sb]\n"
+
+        "sf.mm.f.f mt0, v0, v8\n"
+
+        "vle16.v v24, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle16.v v28, (%[b2_1])\n"
+        "add %[b2_1], %[b2_1], %[sb]\n"
+
+        "sf.mm.f.f mt4, v0, v16\n"
+
+        "beqz %[k], 2f\n"
+
+        // k % 2 == 1
+        "vle16.v v8, (%[b0_0])\n"
+
+        "sf.mm.f.f mt8, v0, v24\n"
+
+        "sf.vsettn x0, %[tm0]\n"
+        "vle16.v v0, (%[a0_0])\n"
+        "sf.vsettn x0, %[tn0]\n"
+
+        "vle16.v v16, (%[b1_0])\n"
+
+        "sf.vsettk x0, %[k]\n"
+        "sf.mm.f.f mt0, v0, v8\n"
+
+        "vle16.v v24, (%[b2_0])\n"
+
+        "sf.mm.f.f mt4, v0, v16\n"
+        "sf.mm.f.f mt8, v0, v24\n"
+        "j 3f\n"
+
+        "2:\n" // k % 2 == 0
+        "sf.mm.f.f mt8, v0, v24\n"
+
+        "3:\n"
+        : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
+          [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
+          [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [k] "+&r"(k)
+        : [sa] "r"(2 * rsa * sizeof(__bf16)),
+          [sb] "r"(2 * rsb0 * sizeof(__bf16)), [tm0] "r"(tm0), [tn0] "r"(tn0),
+          [i4] "r"(4)
+        : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+          "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
+          "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30",
+          "v31", "vtype", "vl", "memory");
+  }
+
+  /* Store tiles to memory. */
+  size_t mt0_store = mt0;
+  size_t mt4_store = mt4;
+  size_t mt8_store = mt8;
+
+  float *c0_store = c0;
+  float *c1_store = c1;
+  float *c2_store = c2;
+  i = 0;
+  __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
+
+                   "0:\n"
+                   "addi %[i], %[i], 1\n"
+                   "sf.vste32 %[mt0], (%[c0])\n"
+                   "add %[mt0], %[mt0], %[kRowInc]\n"
+                   "add %[c0], %[c0], %[sc]\n"
+                   "sf.vste32 %[mt4], (%[c1])\n"
+                   "add %[mt4], %[mt4], %[kRowInc]\n"
+                   "add %[c1], %[c1], %[sc]\n"
+                   "sf.vste32 %[mt8], (%[c2])\n"
+                   "add %[mt8], %[mt8], %[kRowInc]\n"
+                   "add %[c2], %[c2], %[sc]\n"
+                   "bltu %[i], %[tm], 0b\n"
+
+                   "sf.vtdiscard"
+                   : [mt0] "+&r"(mt0_store), [mt4] "+&r"(mt4_store),
+                     [mt8] "+&r"(mt8_store), [c0] "+&r"(c0_store),
+                     [c1] "+&r"(c1_store), [c2] "+&r"(c2_store), [i] "+&r"(i)
+                   : [kRowInc] "rI"(kRowInc), [sc] "r"(rsc0 * sizeof(float)),
+                     [tm] "r"(tm), [tn] "r"(tn)
+                   : "vtype", "vl", "memory");
+}
+
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_1tm4tn_4tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
+    size_t tm, size_t tn, size_t k, const __bf16 *a, size_t rsa,
+    const __bf16 *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
+    size_t tsc1, bool accum, bool bta) {
+  // We can use the same inner loop code for both values of bta by computing A^T
+  // * B0 and A^T * B1 and then transposing the result if bta == true.
+  // The active tile state has shape tm0 x tn0.
+  if (tm == 0 || tn == 0) {
+    return;
+  }
+
+  const size_t kShiftTile = 27;
+  const size_t kShiftPattern = 24;
+  const size_t kRowInc = 1;
+
+  const size_t tm0 = bta ? tn : tm;
+  const size_t tn0 = bta ? tm : tn;
+  const size_t tss_pattern = bta ? (size_t)(1) << kShiftPattern : 0;
+  const size_t mt0 = 0 | tss_pattern;
+  const size_t mt4 = (size_t)(4) << kShiftTile | tss_pattern;
+  const size_t mt8 = (size_t)(8) << kShiftTile | tss_pattern;
+  const size_t mt12 = (size_t)(12) << kShiftTile | tss_pattern;
+
+  float *c0 = c;
+  float *c1 = c0 + tsc1;
+  float *c2 = c0 + 2 * tsc1;
+  float *c3 = c0 + 3 * tsc1;
+
+  /* Load or zero-initialize tiles. */
+  size_t mt0_load = mt0;
+  size_t mt4_load = mt4;
+  size_t mt8_load = mt8;
+  size_t mt12_load = mt12;
+
+  float *c0_load = c0;
+  float *c1_load = c1;
+  float *c2_load = c2;
+  float *c3_load = c3;
+  size_t i = 0;
+  __asm__ volatile(
+      "bnez %[accum], 0f\n"
+      "sf.vsettnt x0, %[tn0], e32, w1\n"
+      "sf.vsettm x0, %[tm0]\n"
+
+      "sf.vtzero.t mt0\n"
+      "sf.vtzero.t mt4\n"
+      "sf.vtzero.t mt8\n"
+      "sf.vtzero.t mt12\n"
+      "j 2f\n"
+      "0:\n"
+      "sf.vsettnt x0, %[tn], e32, w1\n"
+      "1:\n"
+      "addi %[i], %[i], 1\n"
+      "sf.vlte32 %[mt0], (%[c0])\n"
+      "add %[mt0], %[mt0], %[kRowInc]\n"
+      "add %[c0], %[c0], %[sc]\n"
+      "sf.vlte32 %[mt4], (%[c1])\n"
+      "add %[mt4], %[mt4], %[kRowInc]\n"
+      "add %[c1], %[c1], %[sc]\n"
+      "sf.vlte32 %[mt8], (%[c2])\n"
+      "add %[mt8], %[mt8], %[kRowInc]\n"
+      "add %[c2], %[c2], %[sc]\n"
+      "sf.vlte32 %[mt12], (%[c3])\n"
+      "add %[mt12], %[mt12], %[kRowInc]\n"
+      "add %[c3], %[c3], %[sc]\n"
+      "bltu %[i], %[tm], 1b\n"
+      "2:\n"
+      : [mt0] "+&r"(mt0_load), [mt4] "+&r"(mt4_load), [mt8] "+&r"(mt8_load),
+        [mt12] "+&r"(mt12_load), [c0] "+&r"(c0_load), [c1] "+&r"(c1_load),
+        [c2] "+&r"(c2_load), [c3] "+&r"(c3_load), [i] "+&r"(i)
+      : [accum] "r"(accum), [kRowInc] "rI"(kRowInc),
+        [sc] "r"(rsc0 * sizeof(float)), [tm] "r"(tm), [tn] "r"(tn),
+        [tm0] "r"(tm0), [tn0] "r"(tn0)
+      : "vtype", "vl", "memory");
+
+  /* Accumulate matrix product into tiles. */
+  // a0_{0,1} are used to load a 2 x tm submatrix of A,
+  // b0_{0,1} are used to load a 2 x tn submatrix of B,
+  // and similarly for a1_{0,1} and b1_{0,1}.
+  const __bf16 *a0_0 = a;
+  const __bf16 *a0_1 = a0_0 + rsa;
+  const __bf16 *b0_0 = b;
+  const __bf16 *b0_1 = b0_0 + rsb0;
+  const __bf16 *b1_0 = b0_0 + csb1;
+  const __bf16 *b1_1 = b1_0 + rsb0;
+  const __bf16 *b2_0 = b0_0 + 2 * csb1;
+  const __bf16 *b2_1 = b2_0 + rsb0;
+  const __bf16 *b3_0 = b0_0 + 3 * csb1;
+  const __bf16 *b3_1 = b3_0 + rsb0;
+
+  if (k < 2) {
+    __asm__ volatile("beqz %[k], 0f\n"
+
+                     "sf.vsettnt x0, %[tn0], e16alt, w2\n"
+                     "sf.vsettm x0, %[tm0]\n"
+                     "sf.vsettk x0, %[k]\n"
+
+                     // k == 1
+                     "sf.vsettn x0, %[tm0]\n"
+                     "vle16.v v0, (%[a0_0])\n"
+                     "sf.vsettn x0, %[tn0]\n"
+
+                     "vle16.v v8, (%[b0_0])\n"
+
+                     "sf.mm.f.f mt0, v0, v8\n"
+
+                     "vle16.v v16, (%[b1_0])\n"
+
+                     "sf.mm.f.f mt4, v0, v16\n"
+
+                     "vle16.v v8, (%[b2_0])\n"
+
+                     "sf.mm.f.f mt8, v0, v8\n"
+
+                     "vle16.v v16, (%[b3_0])\n"
+
+                     "sf.mm.f.f mt12, v0, v16\n"
+
+                     "0:\n"
+                     :
+                     : [a0_0] "r"(a0_0), [b0_0] "r"(b0_0), [b1_0] "r"(b1_0),
+                       [b2_0] "r"(b2_0), [b3_0] "r"(b3_0), [tm0] "r"(tm0),
+                       [tn0] "r"(tn0), [k] "r"(k)
+                     : "v0", "v1", "v2", "v3", "v8", "v9", "v10", "v11", "v16",
+                       "v17", "v18", "v19", "vtype", "vl", "memory");
+  } else {
+    __asm__ volatile(
+        "sf.vsettnt x0, %[tn0], e16alt, w2\n"
+        "sf.vsettm x0, %[tm0]\n"
+        "sf.vsettk x0, %[k]\n"
+
+        "sf.vsettn x0, %[tm0]\n"
+        "vle16.v v0, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle16.v v4, (%[a0_1])\n"
+        "add %[a0_1], %[a0_1], %[sa]\n"
+        "sf.vsettn x0, %[tn0]\n"
+
+        "vle16.v v8, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle16.v v12, (%[b0_1])\n"
+        "add %[b0_1], %[b0_1], %[sb]\n"
+
+        "bltu %[k], %[i4], 1f\n"
+
+        "0:\n"
+        "addi %[k], %[k], -2\n"
+        "vle16.v v16, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle16.v v20, (%[b1_1])\n"
+        "add %[b1_1], %[b1_1], %[sb]\n"
+
+        "sf.mm.f.f mt0, v0, v8\n"
+
+        "vle16.v v8, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle16.v v12, (%[b2_1])\n"
+        "add %[b2_1], %[b2_1], %[sb]\n"
+
+        "sf.mm.f.f mt4, v0, v16\n"
+
+        "vle16.v v16, (%[b3_0])\n"
+        "add %[b3_0], %[b3_0], %[sb]\n"
+        "vle16.v v20, (%[b3_1])\n"
+        "add %[b3_1], %[b3_1], %[sb]\n"
+
+        "sf.mm.f.f mt8, v0, v8\n"
+
+        "vle16.v v8, (%[b0_0])\n"
+        "add %[b0_0], %[b0_0], %[sb]\n"
+        "vle16.v v12, (%[b0_1])\n"
+        "add %[b0_1], %[b0_1], %[sb]\n"
+
+        "sf.mm.f.f mt12, v0, v16\n"
+
+        "sf.vsettn x0, %[tm0]\n"
+        "vle16.v v0, (%[a0_0])\n"
+        "add %[a0_0], %[a0_0], %[sa]\n"
+        "vle16.v v4, (%[a0_1])\n"
+        "add %[a0_1], %[a0_1], %[sa]\n"
+        "sf.vsettn x0, %[tn0]\n"
+
+        "bgeu %[k], %[i4], 0b\n"
+
+        "1:\n"
+        "addi %[k], %[k], -2\n"
+        "vle16.v v16, (%[b1_0])\n"
+        "add %[b1_0], %[b1_0], %[sb]\n"
+        "vle16.v v20, (%[b1_1])\n"
+        "add %[b1_1], %[b1_1], %[sb]\n"
+
+        "sf.mm.f.f mt0, v0, v8\n"
+
+        "vle16.v v8, (%[b2_0])\n"
+        "add %[b2_0], %[b2_0], %[sb]\n"
+        "vle16.v v12, (%[b2_1])\n"
+        "add %[b2_1], %[b2_1], %[sb]\n"
+
+        "sf.mm.f.f mt4, v0, v16\n"
+
+        "vle16.v v16, (%[b3_0])\n"
+        "add %[b3_0], %[b3_0], %[sb]\n"
+        "vle16.v v20, (%[b3_1])\n"
+        "add %[b3_1], %[b3_1], %[sb]\n"
+
+        "sf.mm.f.f mt8, v0, v8\n"
+
+        "beqz %[k], 2f\n"
+
+        // k % 2 == 1
+        "vle16.v v8, (%[b0_0])\n"
+
+        "sf.mm.f.f mt12, v0, v16\n"
+
+        "sf.vsettn x0, %[tm0]\n"
+        "vle16.v v0, (%[a0_0])\n"
+        "sf.vsettn x0, %[tn0]\n"
+
+        "vle16.v v16, (%[b1_0])\n"
+
+        "sf.vsettk x0, %[k]\n"
+        "sf.mm.f.f mt0, v0, v8\n"
+
+        "vle16.v v8, (%[b2_0])\n"
+
+        "sf.mm.f.f mt4, v0, v16\n"
+
+        "vle16.v v16, (%[b3_0])\n"
+
+        "sf.mm.f.f mt8, v0, v8\n"
+        "sf.mm.f.f mt12, v0, v16\n"
+        "j 3f\n"
+
+        "2:\n" // k % 2 == 0
+        "sf.mm.f.f mt12, v0, v16\n"
+
+        "3:\n"
+        : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
+          [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
+          [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [b3_0] "+&r"(b3_0),
+          [b3_1] "+&r"(b3_1), [k] "+&r"(k)
+        : [sa] "r"(2 * rsa * sizeof(__bf16)),
+          [sb] "r"(2 * rsb0 * sizeof(__bf16)), [tm0] "r"(tm0), [tn0] "r"(tn0),
+          [i4] "r"(4)
+        : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+          "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
+          "v21", "v22", "v23", "vtype", "vl", "memory");
+  }
+
+  /* Store tiles to memory. */
+  size_t mt0_store = mt0;
+  size_t mt4_store = mt4;
+  size_t mt8_store = mt8;
+  size_t mt12_store = mt12;
+
+  float *c0_store = c0;
+  float *c1_store = c1;
+  float *c2_store = c2;
+  float *c3_store = c3;
+  i = 0;
+  __asm__ volatile(
+      "sf.vsettnt x0, %[tn], e32, w1\n"
+
+      "0:\n"
+      "addi %[i], %[i], 1\n"
+      "sf.vste32 %[mt0], (%[c0])\n"
+      "add %[mt0], %[mt0], %[kRowInc]\n"
+      "add %[c0], %[c0], %[sc]\n"
+      "sf.vste32 %[mt4], (%[c1])\n"
+      "add %[mt4], %[mt4], %[kRowInc]\n"
+      "add %[c1], %[c1], %[sc]\n"
+      "sf.vste32 %[mt8], (%[c2])\n"
+      "add %[mt8], %[mt8], %[kRowInc]\n"
+      "add %[c2], %[c2], %[sc]\n"
+      "sf.vste32 %[mt12], (%[c3])\n"
+      "add %[mt12], %[mt12], %[kRowInc]\n"
+      "add %[c3], %[c3], %[sc]\n"
+      "bltu %[i], %[tm], 0b\n"
+
+      "sf.vtdiscard"
+      : [mt0] "+&r"(mt0_store), [mt4] "+&r"(mt4_store), [mt8] "+&r"(mt8_store),
+        [mt12] "+&r"(mt12_store), [c0] "+&r"(c0_store), [c1] "+&r"(c1_store),
+        [c2] "+&r"(c2_store), [c3] "+&r"(c3_store), [i] "+&r"(i)
+      : [kRowInc] "rI"(kRowInc), [sc] "r"(rsc0 * sizeof(float)), [tm] "r"(tm),
+        [tn] "r"(tn)
+      : "vtype", "vl", "memory");
+}
+
+/* Process 2 (= 1 x 2) contiguous tm x tn tiles of c.
+ * tm and tn must be <= TE.
+ */
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_1tm2tn_a1b01_bf16c_bf16cp_f32rcp_xsfmm32a16f(
+    size_t tm, size_t tn, size_t k, const __bf16 *a, size_t csa,
+    const __bf16 *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
+    size_t csc1, bool accum) {
+  skl_gemm_1tm2tn_2tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
+      tm, tn, k, a, csa, b, rsb0, csb1, c, rsc0, csc1, accum, false);
+}
+
+/* Process 2 (= 2 x 1) contiguous tm x tn tiles of c.
+ * tm and tn must be <= TE.
+ */
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_2tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
+    size_t tm, size_t tn, size_t k, const __bf16 *a, size_t csa0, size_t rsa1,
+    const __bf16 *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
+    bool accum) {
+  skl_gemm_1tm2tn_2tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
+      tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+}
+
+/* Process 3 (= 1 x 3) contiguous tm x tn tiles of c.
+ * tm and tn must be <= TE.
+ */
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_1tm3tn_a1b01_bf16c_bf16cp_f32rcp_xsfmm32a16f(
+    size_t tm, size_t tn, size_t k, const __bf16 *a, size_t csa,
+    const __bf16 *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
+    size_t csc1, bool accum) {
+  skl_gemm_1tm3tn_3tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
+      tm, tn, k, a, csa, b, rsb0, csb1, c, rsc0, csc1, accum, false);
+}
+
+/* Process 3 (= 3 x 1) contiguous tm x tn tiles of c.
+ * tm and tn must be <= TE.
+ */
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_3tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
+    size_t tm, size_t tn, size_t k, const __bf16 *a, size_t csa0, size_t rsa1,
+    const __bf16 *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
+    bool accum) {
+  skl_gemm_1tm3tn_3tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
+      tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+}
+
+/* Process 4 (= 1 x 4) contiguous tm x tn tiles of c.
+ * tm and tn must be <= TE.
+ */
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_1tm4tn_a1b01_bf16c_bf16cp_f32rcp_xsfmm32a16f(
+    size_t tm, size_t tn, size_t k, const __bf16 *a, size_t csa,
+    const __bf16 *b, size_t rsb0, size_t csb1, float *c, size_t rsc0,
+    size_t csc1, bool accum) {
+  skl_gemm_1tm4tn_4tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
+      tm, tn, k, a, csa, b, rsb0, csb1, c, rsc0, csc1, accum, false);
+}
+
+/* Process 4 (= 4 x 1) contiguous tm x tn tiles of c.
+ * tm and tn must be <= TE.
+ */
+SKL_XSFMM_NEW
+SKL_FUNC_PRIVATE void skl_gemm_4tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
+    size_t tm, size_t tn, size_t k, const __bf16 *a, size_t csa0, size_t rsa1,
+    const __bf16 *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
+    bool accum) {
+  skl_gemm_1tm4tn_4tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
+      tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
+}
+
 /* Process 4 (= 2 x 2) contiguous tm x tn tiles of c.
  * tm and tn must be <= TE.
  */


### PR DESCRIPTION
This PR adds 1xn and nx1 bf16 Xsfmm GEMM kernels and updates the outer loop code to utilize these in place of the 1x1 kernel where possible for improved performance.