### PR TITLE
[Softmax] Adds 2D kernels.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,17 +9,23 @@
 
 /src/cvt @Harlen126
 /src/depthwise_conv2d @peichialin
+/src/exp @ebavier
+/src/gelu @ebavier
 /src/gemm/rvv @Aaron-Hutchinson
 /src/gemm/scalar @Aaron-Hutchinson @myeh01
 /src/gemm/xsfmm @myeh01
 /src/gemm/xsfvqdotq @france5289 @myeh01 @peichialin
+/src/softmax @ebavier
 /src/transpose/rvv @Aaron-Hutchinson @Harlen126 @peichialin
 /src/transpose/scalar @Aaron-Hutchinson @Harlen126 @myeh01
 /src/transpose/xsfmm @myeh01
 
 /test/cvt @Harlen126
 /test/depthwise_conv2d @peichialin
+/test/exp @ebavier
+/test/gelu @ebavier
 /test/gemm @Aaron-Hutchinson @france5289 @myeh01 @peichialin
+/test/softmax @ebavier
 /test/transpose @Aaron-Hutchinson @Harlen126 @myeh01
 
 /CMakeLists.txt @Aaron-Hutchinson

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,6 +385,8 @@ if (SKL_BUILD_TESTS OR SKL_BUILD_BENCHMARKS)
   skl_add_test(softmax_f16 softmax/softmax_f16.c "-DRUN_ALL;-DBETA=0.5")
   skl_add_test(softmax_bf16 softmax/softmax_bf16.c "-DRUN_ALL;-DBETA=0.5")
   skl_add_test(softmax_f32 softmax/softmax_f32.c "-DRUN_ALL;-DBETA=0.5")
+  skl_add_test(softmax_2d_f32 softmax/softmax_2d_f32.c
+    "-DRUN_ALL;-DM=64;-DN=128;-DBETA=0.5")
   if (RISCV_ZVE32F)
     skl_add_test(skl_depthwise_conv2d_f32_f32_f32_zve32f depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c "")
     skl_add_test(exp_f32 exp/exp_f32.c "-DRUN_ZVE32F;-DRUN_VFEXPA;-DRUN_VFEXP")

--- a/src/softmax/softmax_f32_scalar.c
+++ b/src/softmax/softmax_f32_scalar.c
@@ -23,7 +23,18 @@ SKL_FUNC void skl_softmax_f32_scalar(float *pDst, const float *pSrc, float beta,
   }
 
   float recip_sum = 1.0f / sum;
+#pragma clang loop vectorize(disable)
+#pragma clang loop unroll(disable)
   for (size_t i = 0; i < n; i++) {
     pDst[i] *= recip_sum;
+  }
+}
+
+SKL_FUNC void skl_softmax_2d_f32_scalar(float *s, const size_t rss,
+                                        const float *a, const size_t rsa,
+                                        const float beta, const size_t m,
+                                        const size_t n) {
+  for (size_t i = 0; i < m; ++i) {
+    skl_softmax_f32_scalar(s + i * rss, a + i * rsa, beta, n);
   }
 }

--- a/src/softmax/softmax_f32_scalar.c
+++ b/src/softmax/softmax_f32_scalar.c
@@ -23,8 +23,6 @@ SKL_FUNC void skl_softmax_f32_scalar(float *pDst, const float *pSrc, float beta,
   }
 
   float recip_sum = 1.0f / sum;
-#pragma clang loop vectorize(disable)
-#pragma clang loop unroll(disable)
   for (size_t i = 0; i < n; i++) {
     pDst[i] *= recip_sum;
   }

--- a/src/softmax/softmax_f32_scalar.h
+++ b/src/softmax/softmax_f32_scalar.h
@@ -30,6 +30,28 @@ extern "C" {
 void skl_softmax_f32_scalar(float *pDst, const float *pSrc, float beta,
                             size_t n);
 
+/**
+ * @brief Scalar 2D stable softmax, reducing rows.
+ *
+ * @param s - Pointer to output matrix S.
+ * @param rss - Row stride of S (stride between rows) in elements.
+ * @param a - Pointer to input matrix A.
+ * @param rsa - Row stride of A (stride between rows) in elements.
+ * @param beta - Scaling factor for exponential function arguments.
+ * @param m - Number of rows in S and A.
+ * @param n - Number of columns in S and A.
+ *
+ * Both S and A are unit-stride row-major matrices.
+ *
+ * @note Input A and output S matrices may only overlap if S == A.
+ *
+ * @note
+ * This function is for API documentation purposes only, and should
+ * not be used for performance applications.
+ */
+void skl_softmax_2d_f32_scalar(float *s, size_t rss, const float *a, size_t rsa,
+                               float beta, size_t m, size_t n);
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/src/softmax/softmax_f32_xsfvfexp32e.c
+++ b/src/softmax/softmax_f32_xsfvfexp32e.c
@@ -10,6 +10,26 @@
 #include <sifive_vector.h>
 #include <stddef.h>
 
+/* 1D vector softmax. */
+SKL_FUNC_PRIVATE vfloat32m8_t skl_softmax_vf_f32m8_xsfvfexp32e(
+    vfloat32m8_t x, const float beta, const size_t vl) {
+  vfloat32m1_t vfirst = __riscv_vlmul_trunc_v_f32m8_f32m1(x);
+  vfirst = __riscv_vfredmax_vs_f32m8_f32m1(x, vfirst, vl);
+  float max = __riscv_vfmv_f_s_f32m1_f32(vfirst);
+
+  x = __riscv_vfsub_vf_f32m8(x, max, vl);
+  if (beta != 1.0f)
+    x = __riscv_vfmul_vf_f32m8(x, beta, vl);
+  x = __riscv_sf_vfexp_v_f32m8(x, vl);
+
+  vfloat32m1_t ssum = __riscv_vfmv_s_f_f32m1(0.0f, vl);
+  ssum = __riscv_vfredusum_vs_f32m8_f32m1(x, ssum, vl);
+  float sum = __riscv_vfmv_f_s_f32m1_f32(ssum);
+  float recip_sum = 1.0f / sum;
+
+  return __riscv_vfmul_vf_f32m8(x, recip_sum, vl);
+}
+
 SKL_FUNC void skl_softmax_f32_xsfvfexp32e(float *pDst, const float *pSrc,
                                           const float beta, const size_t n) {
   size_t vl = __riscv_vsetvl_e32m8(n);
@@ -43,5 +63,134 @@ SKL_FUNC void skl_softmax_f32_xsfvfexp32e(float *pDst, const float *pSrc,
     vfloat32m8_t vx = __riscv_vle32_v_f32m8(pDst + i, vl);
     vx = __riscv_vfmul_vf_f32m8(vx, recip_sum, vl);
     __riscv_vse32_v_f32m8(pDst + i, vx, vl);
+  }
+}
+
+SKL_FUNC_PRIVATE void
+skl_softmax_2d_f32m8_xsfvfexp32e(float *s, const size_t rss, const float *a,
+                                 const size_t rsa, const float beta,
+                                 const size_t m, const size_t vl) {
+  /* Rows fit in a single f32m8 register group. */
+  for (size_t i = 0; i < m; ++i) {
+    vfloat32m8_t x = __riscv_vle32_v_f32m8(a + i * rsa, vl);
+    x = skl_softmax_vf_f32m8_xsfvfexp32e(x, beta, vl);
+    __riscv_vse32_v_f32m8(s + i * rss, x, vl);
+  }
+}
+
+SKL_FUNC_PRIVATE void
+skl_softmax_2d_f32m8_x2_xsfvfexp32e(float *s, const size_t rss, const float *a,
+                                    const size_t rsa, const float beta,
+                                    const size_t m, const size_t vl) {
+  /* Rows fit in a single f32m8 register group, processes two rows at
+     a time. */
+  size_t i;
+  for (i = 0; i + 2 <= m; i += 2) {
+    vfloat32m8_t x0 = __riscv_vle32_v_f32m8(a + (i + 0) * rsa, vl);
+    vfloat32m8_t x1 = __riscv_vle32_v_f32m8(a + (i + 1) * rsa, vl);
+
+    vfloat32m1_t f0 = __riscv_vlmul_trunc_v_f32m8_f32m1(x0);
+    vfloat32m1_t f1 = __riscv_vlmul_trunc_v_f32m8_f32m1(x1);
+    f0 = __riscv_vfredmax_vs_f32m8_f32m1(x0, f0, vl);
+    f1 = __riscv_vfredmax_vs_f32m8_f32m1(x1, f1, vl);
+    float max0 = __riscv_vfmv_f_s_f32m1_f32(f0);
+    float max1 = __riscv_vfmv_f_s_f32m1_f32(f1);
+
+    x0 = __riscv_vfsub_vf_f32m8(x0, max0, vl);
+    x1 = __riscv_vfsub_vf_f32m8(x1, max1, vl);
+    if (beta != 1.0f) {
+      x0 = __riscv_vfmul_vf_f32m8(x0, beta, vl);
+      x1 = __riscv_vfmul_vf_f32m8(x1, beta, vl);
+    }
+    x0 = __riscv_sf_vfexp_v_f32m8(x0, vl);
+    x1 = __riscv_sf_vfexp_v_f32m8(x1, vl);
+
+    vfloat32m1_t s0 = __riscv_vfmv_s_f_f32m1(0.0f, vl);
+    vfloat32m1_t s1 = __riscv_vfmv_s_f_f32m1(0.0f, vl);
+    s0 = __riscv_vfredusum_vs_f32m8_f32m1(x0, s0, vl);
+    s1 = __riscv_vfredusum_vs_f32m8_f32m1(x1, s1, vl);
+    float r0 = 1.0f / __riscv_vfmv_f_s_f32m1_f32(s0);
+    float r1 = 1.0f / __riscv_vfmv_f_s_f32m1_f32(s1);
+
+    x0 = __riscv_vfmul_vf_f32m8(x0, r0, vl);
+    x1 = __riscv_vfmul_vf_f32m8(x1, r1, vl);
+    __riscv_vse32_v_f32m8(s + (i + 0) * rss, x0, vl);
+    __riscv_vse32_v_f32m8(s + (i + 1) * rss, x1, vl);
+  }
+  if (i != m) { /* Cleanup */
+    skl_softmax_2d_f32m8_xsfvfexp32e(s + i * rss, rss, a + i * rsa, rsa, beta,
+                                     1, vl);
+  }
+}
+
+SKL_FUNC_PRIVATE void
+skl_softmax_2d_f32m8_x3_xsfvfexp32e(float *s, const size_t rss, const float *a,
+                                    const size_t rsa, const float beta,
+                                    const size_t m, const size_t vl) {
+  /* Rows fit in a single f32m8 register group, processes three rows
+     at a time. */
+  size_t i;
+  for (i = 0; i + 3 <= m; i += 3) {
+    vfloat32m8_t x0 = __riscv_vle32_v_f32m8(a + (i + 0) * rsa, vl);
+    vfloat32m8_t x1 = __riscv_vle32_v_f32m8(a + (i + 1) * rsa, vl);
+    vfloat32m8_t x2 = __riscv_vle32_v_f32m8(a + (i + 2) * rsa, vl);
+
+    vfloat32m1_t f0 = __riscv_vlmul_trunc_v_f32m8_f32m1(x0);
+    vfloat32m1_t f1 = __riscv_vlmul_trunc_v_f32m8_f32m1(x1);
+    vfloat32m1_t f2 = __riscv_vlmul_trunc_v_f32m8_f32m1(x2);
+    f0 = __riscv_vfredmax_vs_f32m8_f32m1(x0, f0, vl);
+    f1 = __riscv_vfredmax_vs_f32m8_f32m1(x1, f1, vl);
+    f2 = __riscv_vfredmax_vs_f32m8_f32m1(x2, f2, vl);
+    float max0 = __riscv_vfmv_f_s_f32m1_f32(f0);
+    float max1 = __riscv_vfmv_f_s_f32m1_f32(f1);
+    float max2 = __riscv_vfmv_f_s_f32m1_f32(f2);
+
+    x0 = __riscv_vfsub_vf_f32m8(x0, max0, vl);
+    x1 = __riscv_vfsub_vf_f32m8(x1, max1, vl);
+    x2 = __riscv_vfsub_vf_f32m8(x2, max2, vl);
+    if (beta != 1.0f) {
+      x0 = __riscv_vfmul_vf_f32m8(x0, beta, vl);
+      x1 = __riscv_vfmul_vf_f32m8(x1, beta, vl);
+      x2 = __riscv_vfmul_vf_f32m8(x2, beta, vl);
+    }
+    x0 = __riscv_sf_vfexp_v_f32m8(x0, vl);
+    x1 = __riscv_sf_vfexp_v_f32m8(x1, vl);
+    x2 = __riscv_sf_vfexp_v_f32m8(x2, vl);
+
+    vfloat32m1_t s0 = __riscv_vfmv_s_f_f32m1(0.0f, vl);
+    vfloat32m1_t s1 = __riscv_vfmv_s_f_f32m1(0.0f, vl);
+    vfloat32m1_t s2 = __riscv_vfmv_s_f_f32m1(0.0f, vl);
+    s0 = __riscv_vfredusum_vs_f32m8_f32m1(x0, s0, vl);
+    s1 = __riscv_vfredusum_vs_f32m8_f32m1(x1, s1, vl);
+    s2 = __riscv_vfredusum_vs_f32m8_f32m1(x2, s2, vl);
+    float r0 = 1.0f / __riscv_vfmv_f_s_f32m1_f32(s0);
+    float r1 = 1.0f / __riscv_vfmv_f_s_f32m1_f32(s1);
+    float r2 = 1.0f / __riscv_vfmv_f_s_f32m1_f32(s2);
+
+    x0 = __riscv_vfmul_vf_f32m8(x0, r0, vl);
+    x1 = __riscv_vfmul_vf_f32m8(x1, r1, vl);
+    x2 = __riscv_vfmul_vf_f32m8(x2, r2, vl);
+    __riscv_vse32_v_f32m8(s + (i + 0) * rss, x0, vl);
+    __riscv_vse32_v_f32m8(s + (i + 1) * rss, x1, vl);
+    __riscv_vse32_v_f32m8(s + (i + 2) * rss, x2, vl);
+  }
+  if (i != m) { /* Cleanup */
+    skl_softmax_2d_f32m8_x2_xsfvfexp32e(s + i * rss, rss, a + i * rsa, rsa,
+                                        beta, m - i, vl);
+  }
+}
+
+/* 2D Softmax vectorizing along rows of S and A. */
+SKL_FUNC void skl_softmax_2d_f32_xsfvfexp32e(float *s, const size_t rss,
+                                             const float *a, const size_t rsa,
+                                             const float beta, const size_t m,
+                                             const size_t n) {
+  size_t vl = __riscv_vsetvl_e32m8(n);
+  if (vl == n) {
+    skl_softmax_2d_f32m8_x3_xsfvfexp32e(s, rss, a, rsa, beta, m, vl);
+  } else {
+    for (size_t i = 0; i < m; ++i) {
+      skl_softmax_f32_xsfvfexp32e(s + i * rss, a + i * rsa, beta, n);
+    }
   }
 }

--- a/src/softmax/softmax_f32_xsfvfexp32e.h
+++ b/src/softmax/softmax_f32_xsfvfexp32e.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Vector FP32 softmax function accelerated with Xsfvfexp32e.
+ * @brief FP32 softmax function accelerated with Xsfvfexp32e.
  *
  * @param pDst - Array of output elements.
  * @param pSrc - Array of input elements.
@@ -29,6 +29,28 @@ extern "C" {
  */
 void skl_softmax_f32_xsfvfexp32e(float *pDst, const float *pSrc,
                                  const float beta, const size_t n);
+
+/**
+ * @brief FP32 2D stable softmax, reducing rows.
+ *
+ * @param s - Pointer to output matrix S.
+ * @param rss - Row stride of S (stride between rows) in elements.
+ * @param a - Pointer to input matrix A.
+ * @param rsa - Row stride of A (stride between rows) in elements.
+ * @param beta - Scaling factor for exponential function arguments.
+ * @param m - Number of rows in S and A.
+ * @param n - Number of columns in S and A.
+ *
+ * Both S and A are unit-stride row-major matrices.
+ *
+ * This function uses SiFive's vector floating-point exponential
+ * function instruction to compute the e^x part of softmax.
+ *
+ * @note Input A and output S matrices may only overlap if S == A.
+ */
+void skl_softmax_2d_f32_xsfvfexp32e(float *s, size_t rss, const float *a,
+                                    size_t rsa, float beta, size_t m, size_t n);
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/src/softmax/softmax_f32_xsfvfexpa.c
+++ b/src/softmax/softmax_f32_xsfvfexpa.c
@@ -66,3 +66,12 @@ SKL_FUNC void skl_softmax_f32_xsfvfexpa(float *pDst, const float *pSrc,
     __riscv_vse32_v_f32m8(pDst + i, vx, vl);
   }
 }
+
+SKL_FUNC void skl_softmax_2d_f32_xsfvfexpa(float *s, const size_t rss,
+                                           const float *a, const size_t rsa,
+                                           const float beta, const size_t m,
+                                           const size_t n) {
+  for (size_t i = 0; i < m; ++i) {
+    skl_softmax_f32_xsfvfexpa(s + i * rss, a + i * rsa, beta, n);
+  }
+}

--- a/src/softmax/softmax_f32_xsfvfexpa.h
+++ b/src/softmax/softmax_f32_xsfvfexpa.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Vector FP32 softmax function accelerated with Xsfvfexpa.
+ * @brief FP32 softmax function accelerated with Xsfvfexpa.
  *
  * @param pDst - Array of output elements.
  * @param pSrc - Array of input elements.
@@ -29,6 +29,33 @@ extern "C" {
  */
 void skl_softmax_f32_xsfvfexpa(float *pDst, const float *pSrc, const float beta,
                                const size_t n);
+
+/**
+ * @brief FP32 2D stable softmax, reducing rows.
+ *
+ * @param s - Pointer to output matrix S.
+ * @param rss - Row stride of S (stride between rows) in elements.
+ * @param a - Pointer to input matrix A.
+ * @param rsa - Row stride of A (stride between rows) in elements.
+ * @param beta - Scaling factor for exponential function arguments.
+ * @param m - Number of rows in S and A.
+ * @param n - Number of columns in S and A.
+ *
+ * Both S and A are unit-stride row-major matrices.
+ *
+ * Computes row-wise softmax equivalent to:
+ * ```
+ * for (i = 0; i < m; i++)
+ *   skl_softmax_f32_scalar(s + i * rss, a + i * rsa, beta, n);
+ * ```
+ *
+ * Exploits the SiFive vector floating-point exponential approximation
+ * instruction to compute the e^x part of softmax.
+ *
+ * @note Input A and output S matrices may only overlap if S == A.
+ */
+void skl_softmax_2d_f32_xsfvfexpa(float *s, size_t rss, const float *a,
+                                  size_t rsa, float beta, size_t m, size_t n);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/src/softmax/softmax_f32_zve32f.c
+++ b/src/softmax/softmax_f32_zve32f.c
@@ -82,3 +82,12 @@ SKL_FUNC void skl_softmax_f32_zve32f(float *pDst, const float *pSrc,
     __riscv_vse32_v_f32m8(pDst + i, vx, vl);
   }
 }
+
+SKL_FUNC void skl_softmax_2d_f32_zve32f(float *s, const size_t rss,
+                                        const float *a, const size_t rsa,
+                                        const float beta, const size_t m,
+                                        const size_t n) {
+  for (size_t i = 0; i < m; ++i) {
+    skl_softmax_f32_zve32f(s + i * rss, a + i * rsa, beta, n);
+  }
+}

--- a/src/softmax/softmax_f32_zve32f.h
+++ b/src/softmax/softmax_f32_zve32f.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Vector FP32 softmax function.
+ * @brief FP32 softmax function.
  *
  * @param pDst - Array of output elements.
  * @param pSrc - Array of input elements.
@@ -26,6 +26,30 @@ extern "C" {
  */
 void skl_softmax_f32_zve32f(float *pDst, const float *pSrc, const float beta,
                             const size_t n);
+
+/**
+ * @brief FP32 2D stable softmax, reducing rows.
+ *
+ * @param s - Pointer to output matrix S.
+ * @param rss - Row stride of S (stride between rows) in elements.
+ * @param a - Pointer to input matrix A.
+ * @param rsa - Row stride of A (stride between rows) in elements.
+ * @param beta - Scaling factor for exponential function arguments.
+ * @param m - Number of rows in S and A.
+ * @param n - Number of columns in S and A.
+ *
+ * Both S and A are unit-stride row-major matrices.
+ *
+ * Computes row-wise softmax equivalent to:
+ * ```
+ * for (i = 0; i < m; i++)
+ *   skl_softmax_f32_scalar(s + i * rss, a + i * rsa, beta, n);
+ * ```
+ *
+ * @note Input A and output S matrices may only overlap if S == A.
+ */
+void skl_softmax_2d_f32_zve32f(float *s, size_t rss, const float *a, size_t rsa,
+                               float beta, size_t m, size_t n);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -274,8 +274,8 @@ static inline float skl_error_ulp_f32(const float *res, const float *ref,
  * @brief Determine maximum error for _Float16 data
  * @details @copydetails skl_check_ulp_f32
  */
-static inline float skl_error_ulp_f16(const _Float16 *res,
-                                      const _Float16 *ref, size_t len) {
+static inline float skl_error_ulp_f16(const _Float16 *res, const _Float16 *ref,
+                                      size_t len) {
   float max = 0;
   for (size_t i = 0; i < len; i++) {
     float err = skl_abs_error_ulp_f16(res[i], ref[i]);

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -235,10 +235,71 @@ static inline float skl_abs_error_ulp_bf16(__bf16 x, __bf16 r) {
   return skl_abs_error_ulp(x, r, FLT_MIN_EXP, 8);
 }
 
+/**
+ * @brief Print a short error message.
+ *
+ * @param name Name of the test
+ * @param err The maximum error measured for this test
+ */
 static inline void skl_print_max_error(const char *name, float err) {
   printf("%15s : maximum error ", name);
   print_float(err);
   printf(" ulp\n");
+}
+
+/**
+ * @brief Determine maximum error for float data
+ *
+ * @param res Array of test result values
+ * @param ref Array of test reference values
+ * @param len Length of result and reference arrays
+ * @returns The maximum error found
+ *
+ * This function calculates and returns the absolute error in ulps
+ * between res[i] and ref[i] for i in [0, len).
+ */
+static inline float skl_error_ulp_f32(const float *res, const float *ref,
+                                      size_t len) {
+  float max = 0;
+  for (size_t i = 0; i < len; i++) {
+    float err = skl_abs_error_ulp_f32(res[i], ref[i]);
+    if (err > max) {
+      max = err;
+    }
+  }
+  return max;
+}
+
+/**
+ * @brief Determine maximum error for _Float16 data
+ * @details @copydetails skl_check_ulp_f32
+ */
+static inline float skl_error_ulp_f16(const _Float16 *res,
+                                      const _Float16 *ref, size_t len) {
+  float max = 0;
+  for (size_t i = 0; i < len; i++) {
+    float err = skl_abs_error_ulp_f16(res[i], ref[i]);
+    if (err > max) {
+      max = err;
+    }
+  }
+  return max;
+}
+
+/**
+ * @brief Determine maximum error for __bf16 data
+ * @details @copydetails skl_check_error_ulp_f32
+ */
+static inline float skl_error_ulp_bf16(const __bf16 *res, const __bf16 *ref,
+                                       size_t len) {
+  float max = 0;
+  for (size_t i = 0; i < len; i++) {
+    float err = skl_abs_error_ulp_bf16(res[i], ref[i]);
+    if (err > max) {
+      max = err;
+    }
+  }
+  return max;
 }
 
 /**
@@ -256,36 +317,25 @@ static inline void skl_print_max_error(const char *name, float err) {
  * then returns 0 if the maximum is less than or equal to the given
  * tolerance or non-zero if greater.
  */
-static inline int skl_check_error_ulp_f32(const char *name, const float *res,
-                                          const float *ref, float tol,
-                                          size_t len) {
-  float max = 0;
-  for (size_t i = 0; i < len; i++) {
-    float err = skl_abs_error_ulp_f32(res[i], ref[i]);
-    if (err > max) {
-      max = err;
-    }
-  }
-  skl_print_max_error(name, max);
-  return max > tol;
+static inline float skl_check_error_ulp_f32(const char *name, const float *res,
+                                            const float *ref, float tol,
+                                            size_t len) {
+  float err = skl_error_ulp_f32(res, ref, len);
+  skl_print_max_error(name, err);
+  return err > tol;
 }
 
 /**
  * @brief Check maximum error for _Float16 data
  * @details @copydetails skl_check_error_ulp_f32
  */
-static inline int skl_check_error_ulp_f16(const char *name, const _Float16 *res,
-                                          const _Float16 *ref, float tol,
-                                          size_t len) {
-  float max = 0;
-  for (size_t i = 0; i < len; i++) {
-    float err = skl_abs_error_ulp_f16(res[i], ref[i]);
-    if (err > max) {
-      max = err;
-    }
-  }
-  skl_print_max_error(name, max);
-  return max > tol;
+static inline float skl_check_error_ulp_f16(const char *name,
+                                            const _Float16 *res,
+                                            const _Float16 *ref, float tol,
+                                            size_t len) {
+  float err = skl_error_ulp_f16(res, ref, len);
+  skl_print_max_error(name, err);
+  return err > tol;
 }
 
 /**
@@ -295,15 +345,9 @@ static inline int skl_check_error_ulp_f16(const char *name, const _Float16 *res,
 static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
                                            const __bf16 *ref, float tol,
                                            size_t len) {
-  float max = 0;
-  for (size_t i = 0; i < len; i++) {
-    float err = skl_abs_error_ulp_bf16(res[i], ref[i]);
-    if (err > max) {
-      max = err;
-    }
-  }
-  skl_print_max_error(name, max);
-  return max > tol;
+  float err = skl_error_ulp_bf16(res, ref, len);
+  skl_print_max_error(name, err);
+  return err > tol;
 }
 
 /**

--- a/test/softmax/softmax_2d_f32.c
+++ b/test/softmax/softmax_2d_f32.c
@@ -1,0 +1,146 @@
+#if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
+#error Must define at least one of ENABLE_TEST and ENABLE_BENCHMARK.
+#endif
+
+#if !defined(M) // Input rows
+#error Must define M
+#endif
+
+#if !defined(N) // Input columns
+#error Must define N
+#endif
+
+#if !defined(BETA)
+#define BETA 1.0 // Exponential scaling factor
+#endif
+
+#include "skl-test.h"
+#include "skl.h"
+#include <inttypes.h>
+#if defined(ENABLE_TEST)
+#include <math.h>
+#include <stdlib.h>
+#endif
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#if defined(RUN_ALL)
+#define RUN_SCALAR 1
+#define RUN_ZVE32F 1
+#define RUN_VFEXPA 1
+#define RUN_VFEXP 1
+#endif
+
+#if !defined(RSA)
+#define RSA N
+#endif
+#if !defined(RSS)
+#define RSS N
+#endif
+
+#if RSA < N || RSS < N
+#error RSA and RSS must be greater than or equal to N
+#endif
+
+enum {
+  ALIGN = 4096,
+  ALEN = M * RSA,
+  SLEN = M * RSS,
+};
+__attribute__((aligned(ALIGN))) float input[ALEN];
+__attribute__((aligned(ALIGN))) float output[SLEN];
+__attribute__((aligned(ALIGN))) float ref_output[SLEN];
+__attribute__((aligned(ALIGN))) double workspace[N];
+
+#if defined(ENABLE_TEST)
+/** Scalar softmax using FP64 intermediates for high accuracy */
+static void reference_softmax_2d_f32(float *S, const size_t rss, const float *A,
+                                     const size_t rsa, const float beta,
+                                     const size_t m, const size_t n,
+                                     double *workspace) {
+  if (m == 0 || n == 1)
+    return;
+
+  for (size_t i = 0; i < m; i++) {
+    float max = A[i * rsa];
+    for (size_t j = 1; j < n; j++) {
+      max = fmaxf(A[i * rsa + j], max);
+    }
+
+    double sum = 0;
+    for (size_t j = 0; j < n; j++) {
+      workspace[j] = exp(beta * ((double)A[i * rsa + j] - max));
+      sum += workspace[j];
+    }
+
+    for (size_t j = 0; j < n; j++) {
+      S[i * rss + j] = (float)(workspace[j] / sum);
+    }
+  }
+}
+#endif // defined(ENABLE_TEST)
+
+int main(void) {
+  int ret = 0; // return value
+  printf("Measuring [%dx%d] softmax:\n\n", M, N);
+  skl_test_init_f32(input, ALEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
+
+#if defined(ENABLE_BENCHMARK)
+  // cycle and instruction counters
+  uint64_t c0, c1, i0, i1; // NOLINT(readability-isolate-declaration)
+#define MEASURE_PERF(FUNCTION, NAME)                                           \
+  /* Measure 2nd run after caches warmed */                                    \
+  riscv_fence();                                                               \
+  c0 = riscv_read_mcycle(), i0 = riscv_read_minstret();                        \
+  FUNCTION(output, RSS, input, RSA, BETA, M, N);                               \
+  riscv_fence();                                                               \
+  c1 = riscv_read_mcycle(), i1 = riscv_read_minstret();                        \
+  report_perf_epc(NAME, c1 - c0, i1 - i0, (size_t)M * N);
+#else
+#define MEASURE_PERF(FUNCTION, NAME)
+#endif
+
+#if defined(ENABLE_TEST)
+  memset(ref_output, 0, SLEN * sizeof(*ref_output));
+  reference_softmax_2d_f32(ref_output, RSS, input, RSA, BETA, M, N, workspace);
+  float max_err;
+#define CHECK_RESULT(FUNCTION, NAME)                                           \
+  max_err = 0.f;                                                               \
+  for (size_t i = 0; i < M; i++) {                                             \
+    max_err = fmaxf(max_err, skl_error_ulp_f32(output + i * RSS,               \
+                                               ref_output + i * RSS, N));      \
+  }                                                                            \
+  skl_print_max_error(NAME, max_err);                                          \
+  ret += (max_err > 64);
+#else
+#define CHECK_RESULT(FUNCTION, NAME)
+#endif
+
+#define RUN(FUNCTION, NAME)                                                    \
+  memset(output, 0, SLEN * sizeof(*output));                                   \
+  FUNCTION(output, RSS, input, RSA, BETA, M, N);                               \
+  MEASURE_PERF(FUNCTION, NAME);                                                \
+  CHECK_RESULT(FUNCTION, NAME);
+
+  // Run subset of functions depending on ISA compatibility
+#if defined(RUN_SCALAR)
+  RUN(skl_softmax_2d_f32_scalar, "scalar");
+#endif
+#if defined(__riscv_zve32f) && defined(RUN_ZVE32F)
+  RUN(skl_softmax_2d_f32_zve32f, "zve32f");
+#endif
+#if defined(__riscv_xsfvfexpa) && defined(RUN_VFEXPA)
+  RUN(skl_softmax_2d_f32_xsfvfexpa, "xsfvfexpa");
+#endif
+#if defined(__riscv_xsfvfexp32e) && defined(RUN_VFEXP)
+  RUN(skl_softmax_2d_f32_xsfvfexp32e, "xsfvfexp32e");
+#endif
+
+#if !(defined(RUN_SCALAR) || defined(RUN_ZVE32F) || defined(RUN_VFEXPA) ||     \
+      defined(RUN_VFEXP))
+#error No tests or benchmarks enabled!
+#endif
+
+  return ret > 0;
+}


### PR DESCRIPTION
This adds an API and kernels for a 2D matrix Softmax where the reduction is along rows of the input.

* src/softmax/softmax_f32_scalar.h (skl_softmax_2d_f32_scalar): Declare new 2d function.
* src/softmax/softmax_f32_xsfvfexp32e.h, src/softmax/softmax_f32_xsfvfexpa.h, src/softmax/softmax_f32_zve32f.h: Similarly.  Remove "Vector" from docs of array functions.
* src/softmax/softmax_f32_scalar.c (skl_softmax_2d_f32_scalar): New function.
(skl_softmax_f32_scalar): Add loop pragmas to prevent autovectorization.
* src/softmax/softmax_f32_xsfvfexpa.c (skl_softmax_2d_f32_xsfvfexpa): New function.
* src/softmax/softmax_f32_zve32f.c (skl_softmax_2d_f32_zve32f): Same.
* src/softmax/softmax_f32_xsfvfexp32e.c (skl_softmax_vf_f32m8_xsfvfexp32e) (skl_softmax_2d_f32m8_xsfvfexp32e, skl_softmax_2d_f32m8_x2_xsfvfexp32e) (skl_softmax_2d_f32m8_x3_xsfvfexp32e): New private functions. (skl_softmax_2d_f32_xsfvfexp32e): New public function.
* test/skl-test.h (skl_error_ulp_f32, skl_error_ulp_f16) (skl_error_ulp_bf16): New functions.
(skl_check_error_ulp_f32, skl_check_error_ulp_f16) (skl_check_error_ulp_bf16): Use them.
* test/softmax/softmax_2d_f32.c: New test.
* CMakeLists.txt (softmax_2d_f32): Add it.
* .github/CODEOWNERS: Claim ownership.