### PR TITLE
[GEMM] Add CLP-tuned version of Xsfvqdotq GEMM kernel

### DIFF
--- a/src/gemm/xsfvqdotq/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c
+++ b/src/gemm/xsfvqdotq/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c
@@ -18,12 +18,11 @@
 
 #include "skl-common.h"
 
-SKL_FUNC_PRIVATE void skl_mm_6xe32m4_i8i32_vqdotvx(size_t n, size_t k,
-                                                   const int8_t *a, size_t rsa1,
-                                                   size_t csa1, const int8_t *b,
-                                                   size_t rsb1, int32_t *c,
-                                                   size_t rsc, bool accum,
-                                                   bool x390_clp) {
+SKL_FUNC_PRIVATE void
+skl_mm_6xe32m4_i8i32_vqdotvx(size_t n, size_t k, const int8_t *a, size_t rsa1,
+                             size_t csa1, const int8_t *b, size_t rsb1,
+                             int32_t *c, size_t rsc, bool accum,
+                             __attribute__((unused)) bool x390_clp) {
   // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
   vint32m4_t cvec0 = __riscv_vundefined_i32m4();
   vint32m4_t cvec1 = __riscv_vundefined_i32m4();

--- a/src/gemm/xsfvqdotq/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c
+++ b/src/gemm/xsfvqdotq/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c
@@ -22,7 +22,8 @@ SKL_FUNC_PRIVATE void skl_mm_6xe32m4_i8i32_vqdotvx(size_t n, size_t k,
                                                    const int8_t *a, size_t rsa1,
                                                    size_t csa1, const int8_t *b,
                                                    size_t rsb1, int32_t *c,
-                                                   size_t rsc, bool accum) {
+                                                   size_t rsc, bool accum,
+                                                   bool x390_clp) {
   // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
   vint32m4_t cvec0 = __riscv_vundefined_i32m4();
   vint32m4_t cvec1 = __riscv_vundefined_i32m4();
@@ -253,9 +254,12 @@ SKL_FUNC_PRIVATE void skl_mm_6xe32m4_i8i32_vqdotvx(size_t n, size_t k,
 }
 
 // a is 4-byte aligned and rsa1 is a multiple of 4
-SKL_FUNC_PRIVATE void skl_mm_6xe32m4_aligned_i8i32_vqdotvx(
-    size_t n, size_t k, const int8_t *a, size_t rsa1, size_t csa1,
-    const int8_t *b, size_t rsb1, int32_t *c, size_t rsc, bool accum) {
+// If x390_clp == true, uses an inner loop tuned for the CLP on x390.
+SKL_FUNC_PRIVATE void
+skl_mm_6xe32m4_aligned_i8i32_vqdotvx(size_t n, size_t k, const int8_t *a,
+                                     size_t rsa1, size_t csa1, const int8_t *b,
+                                     size_t rsb1, int32_t *c, size_t rsc,
+                                     bool accum, bool x390_clp) {
   // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
   vint32m4_t cvec0 = __riscv_vundefined_i32m4();
   vint32m4_t cvec1 = __riscv_vundefined_i32m4();
@@ -327,73 +331,144 @@ SKL_FUNC_PRIVATE void skl_mm_6xe32m4_aligned_i8i32_vqdotvx(
 
     while (k >= 12) {
       vint8m4_t bvec1;
-      __asm__ volatile(
-          // compute first tile
-          "vsetvli x0, %[n], e32, m4, ta, ma\n"
-          "sf.vqdot.vx %[cvec0], %[bvec0], %[a0_0]\n"
-          "sf.vqdot.vx %[cvec1], %[bvec0], %[a0_1]\n"
-          "sf.vqdot.vx %[cvec2], %[bvec0], %[a0_2]\n"
-          "sf.vqdot.vx %[cvec3], %[bvec0], %[a0_3]\n"
+      if (x390_clp) {
+        __asm__ volatile(
+            "lw %[a1_0], 0(%[a0])\n"
+            "lw %[a1_1], 0(%[a1])\n"
+            "lw %[a1_2], 0(%[a2])\n"
+            "lw %[a1_3], 0(%[a3])\n"
+            "lw %[a1_4], 0(%[a4])\n"
+            "lw %[a1_5], 0(%[a5])\n"
+            "add %[a0], %[a0], %[csa1]\n"
+            "add %[a1], %[a1], %[csa1]\n"
+            "add %[a2], %[a2], %[csa1]\n"
+            "add %[a3], %[a3], %[csa1]\n"
+            "add %[a4], %[a4], %[csa1]\n"
+            "add %[a5], %[a5], %[csa1]\n"
 
-          // load second B tile (4xn)
-          "vsetvli x0, %[n4], e8, m4, ta, ma\n"
-          "vle8.v %[bvec1], (%[b])\n"
-          "add %[b], %[b], %[rsb1]\n"
+            // load second B tile (4xn)
+            "vsetvli x0, %[n4], e8, m4, ta, ma\n"
+            "vle8.v %[bvec1], (%[b])\n"
+            "add %[b], %[b], %[rsb1]\n"
 
-          "lw %[a1_0], 0(%[a0])\n"
-          "add %[a0], %[a0], %[csa1]\n"
-          "lw %[a1_1], 0(%[a1])\n"
-          "add %[a1], %[a1], %[csa1]\n"
-          "lw %[a1_2], 0(%[a2])\n"
-          "add %[a2], %[a2], %[csa1]\n"
-          "lw %[a1_3], 0(%[a3])\n"
-          "add %[a3], %[a3], %[csa1]\n"
-          "lw %[a1_4], 0(%[a4])\n"
-          "add %[a4], %[a4], %[csa1]\n"
-          "lw %[a1_5], 0(%[a5])\n"
-          "add %[a5], %[a5], %[csa1]\n"
+            // compute first tile
+            "vsetvli x0, %[n], e32, m4, ta, ma\n"
+            "sf.vqdot.vx %[cvec0], %[bvec0], %[a0_0]\n"
+            "sf.vqdot.vx %[cvec1], %[bvec0], %[a0_1]\n"
+            "sf.vqdot.vx %[cvec2], %[bvec0], %[a0_2]\n"
+            "sf.vqdot.vx %[cvec3], %[bvec0], %[a0_3]\n"
+            "sf.vqdot.vx %[cvec4], %[bvec0], %[a0_4]\n"
+            "sf.vqdot.vx %[cvec5], %[bvec0], %[a0_5]\n"
 
-          "vsetvli x0, %[n], e32, m4, ta, ma\n"
-          "sf.vqdot.vx %[cvec4], %[bvec0], %[a0_4]\n"
-          "sf.vqdot.vx %[cvec5], %[bvec0], %[a0_5]\n"
+            "lw %[a0_0], 0(%[a0])\n"
+            "lw %[a0_1], 0(%[a1])\n"
+            "lw %[a0_2], 0(%[a2])\n"
+            "lw %[a0_3], 0(%[a3])\n"
+            "lw %[a0_4], 0(%[a4])\n"
+            "lw %[a0_5], 0(%[a5])\n"
+            "add %[a0], %[a0], %[csa1]\n"
+            "add %[a1], %[a1], %[csa1]\n"
+            "add %[a2], %[a2], %[csa1]\n"
+            "add %[a3], %[a3], %[csa1]\n"
+            "add %[a4], %[a4], %[csa1]\n"
+            "add %[a5], %[a5], %[csa1]\n"
 
-          // compute second tile
-          "sf.vqdot.vx %[cvec0], %[bvec1], %[a1_0]\n"
-          "sf.vqdot.vx %[cvec1], %[bvec1], %[a1_1]\n"
-          "sf.vqdot.vx %[cvec2], %[bvec1], %[a1_2]\n"
-          "sf.vqdot.vx %[cvec3], %[bvec1], %[a1_3]\n"
-          "sf.vqdot.vx %[cvec4], %[bvec1], %[a1_4]\n"
-          "sf.vqdot.vx %[cvec5], %[bvec1], %[a1_5]\n"
+            // pre-load first B tile (4xn) of next iteration
+            "vsetvli x0, %[n4], e8, m4, ta, ma\n"
+            "vle8.v %[bvec0], (%[b])\n"
+            "add %[b], %[b], %[rsb1]\n"
 
-          // pre-load first B tile (4xn) of next iteration
-          "vsetvli x0, %[n4], e8, m4, ta, ma\n"
-          "vle8.v %[bvec0], (%[b])\n"
-          "add %[b], %[b], %[rsb1]\n"
+            // compute second tile
+            "vsetvli x0, %[n], e32, m4, ta, ma\n"
+            "sf.vqdot.vx %[cvec0], %[bvec1], %[a1_0]\n"
+            "sf.vqdot.vx %[cvec1], %[bvec1], %[a1_1]\n"
+            "sf.vqdot.vx %[cvec2], %[bvec1], %[a1_2]\n"
+            "sf.vqdot.vx %[cvec3], %[bvec1], %[a1_3]\n"
+            "sf.vqdot.vx %[cvec4], %[bvec1], %[a1_4]\n"
+            "sf.vqdot.vx %[cvec5], %[bvec1], %[a1_5]\n"
+            : [cvec0] "+&vr"(cvec0), [cvec1] "+&vr"(cvec1),
+              [cvec2] "+&vr"(cvec2), [cvec3] "+&vr"(cvec3),
+              [cvec4] "+&vr"(cvec4), [cvec5] "+&vr"(cvec5),
+              [bvec0] "+&vr"(bvec0), [bvec1] "=&vr"(bvec1), [a0_0] "+&r"(a0_0),
+              [a0_1] "+&r"(a0_1), [a0_2] "+&r"(a0_2), [a0_3] "+&r"(a0_3),
+              [a0_4] "+&r"(a0_4), [a0_5] "+&r"(a0_5), [a1_0] "=&r"(a1_0),
+              [a1_1] "=&r"(a1_1), [a1_2] "=&r"(a1_2), [a1_3] "=&r"(a1_3),
+              [a1_4] "=&r"(a1_4), [a1_5] "=&r"(a1_5), [a0] "+&r"(a0),
+              [a1] "+&r"(a1), [a2] "+&r"(a2), [a3] "+&r"(a3), [a4] "+&r"(a4),
+              [a5] "+&r"(a5), [b] "+&r"(b)
+            : [csa1] "rI"(csa1 * sizeof(int8_t)),
+              [rsb1] "rI"(rsb1 * sizeof(int8_t)), [n] "r"(n), [n4] "r"(4 * n)
+            : "vl", "vtype", "memory");
+      } else {
+        __asm__ volatile(
+            // compute first tile
+            "vsetvli x0, %[n], e32, m4, ta, ma\n"
+            "sf.vqdot.vx %[cvec0], %[bvec0], %[a0_0]\n"
+            "sf.vqdot.vx %[cvec1], %[bvec0], %[a0_1]\n"
+            "sf.vqdot.vx %[cvec2], %[bvec0], %[a0_2]\n"
+            "sf.vqdot.vx %[cvec3], %[bvec0], %[a0_3]\n"
 
-          "lw %[a0_0], 0(%[a0])\n"
-          "add %[a0], %[a0], %[csa1]\n"
-          "lw %[a0_1], 0(%[a1])\n"
-          "add %[a1], %[a1], %[csa1]\n"
-          "lw %[a0_2], 0(%[a2])\n"
-          "add %[a2], %[a2], %[csa1]\n"
-          "lw %[a0_3], 0(%[a3])\n"
-          "add %[a3], %[a3], %[csa1]\n"
-          "lw %[a0_4], 0(%[a4])\n"
-          "add %[a4], %[a4], %[csa1]\n"
-          "lw %[a0_5], 0(%[a5])\n"
-          "add %[a5], %[a5], %[csa1]\n"
-          : [cvec0] "+&vr"(cvec0), [cvec1] "+&vr"(cvec1), [cvec2] "+&vr"(cvec2),
-            [cvec3] "+&vr"(cvec3), [cvec4] "+&vr"(cvec4), [cvec5] "+&vr"(cvec5),
-            [bvec0] "+&vr"(bvec0), [bvec1] "=&vr"(bvec1), [a0_0] "+&r"(a0_0),
-            [a0_1] "+&r"(a0_1), [a0_2] "+&r"(a0_2), [a0_3] "+&r"(a0_3),
-            [a0_4] "+&r"(a0_4), [a0_5] "+&r"(a0_5), [a1_0] "=&r"(a1_0),
-            [a1_1] "=&r"(a1_1), [a1_2] "=&r"(a1_2), [a1_3] "=&r"(a1_3),
-            [a1_4] "=&r"(a1_4), [a1_5] "=&r"(a1_5), [a0] "+&r"(a0),
-            [a1] "+&r"(a1), [a2] "+&r"(a2), [a3] "+&r"(a3), [a4] "+&r"(a4),
-            [a5] "+&r"(a5), [b] "+&r"(b)
-          : [csa1] "rI"(csa1 * sizeof(int8_t)),
-            [rsb1] "rI"(rsb1 * sizeof(int8_t)), [n] "r"(n), [n4] "r"(4 * n)
-          : "vl", "vtype", "memory");
+            // load second B tile (4xn)
+            "vsetvli x0, %[n4], e8, m4, ta, ma\n"
+            "vle8.v %[bvec1], (%[b])\n"
+            "add %[b], %[b], %[rsb1]\n"
+
+            "lw %[a1_0], 0(%[a0])\n"
+            "add %[a0], %[a0], %[csa1]\n"
+            "lw %[a1_1], 0(%[a1])\n"
+            "add %[a1], %[a1], %[csa1]\n"
+            "lw %[a1_2], 0(%[a2])\n"
+            "add %[a2], %[a2], %[csa1]\n"
+            "lw %[a1_3], 0(%[a3])\n"
+            "add %[a3], %[a3], %[csa1]\n"
+            "lw %[a1_4], 0(%[a4])\n"
+            "add %[a4], %[a4], %[csa1]\n"
+            "lw %[a1_5], 0(%[a5])\n"
+            "add %[a5], %[a5], %[csa1]\n"
+
+            "vsetvli x0, %[n], e32, m4, ta, ma\n"
+            "sf.vqdot.vx %[cvec4], %[bvec0], %[a0_4]\n"
+            "sf.vqdot.vx %[cvec5], %[bvec0], %[a0_5]\n"
+
+            // compute second tile
+            "sf.vqdot.vx %[cvec0], %[bvec1], %[a1_0]\n"
+            "sf.vqdot.vx %[cvec1], %[bvec1], %[a1_1]\n"
+            "sf.vqdot.vx %[cvec2], %[bvec1], %[a1_2]\n"
+            "sf.vqdot.vx %[cvec3], %[bvec1], %[a1_3]\n"
+            "sf.vqdot.vx %[cvec4], %[bvec1], %[a1_4]\n"
+            "sf.vqdot.vx %[cvec5], %[bvec1], %[a1_5]\n"
+
+            // pre-load first B tile (4xn) of next iteration
+            "vsetvli x0, %[n4], e8, m4, ta, ma\n"
+            "vle8.v %[bvec0], (%[b])\n"
+            "add %[b], %[b], %[rsb1]\n"
+
+            "lw %[a0_0], 0(%[a0])\n"
+            "add %[a0], %[a0], %[csa1]\n"
+            "lw %[a0_1], 0(%[a1])\n"
+            "add %[a1], %[a1], %[csa1]\n"
+            "lw %[a0_2], 0(%[a2])\n"
+            "add %[a2], %[a2], %[csa1]\n"
+            "lw %[a0_3], 0(%[a3])\n"
+            "add %[a3], %[a3], %[csa1]\n"
+            "lw %[a0_4], 0(%[a4])\n"
+            "add %[a4], %[a4], %[csa1]\n"
+            "lw %[a0_5], 0(%[a5])\n"
+            "add %[a5], %[a5], %[csa1]\n"
+            : [cvec0] "+&vr"(cvec0), [cvec1] "+&vr"(cvec1),
+              [cvec2] "+&vr"(cvec2), [cvec3] "+&vr"(cvec3),
+              [cvec4] "+&vr"(cvec4), [cvec5] "+&vr"(cvec5),
+              [bvec0] "+&vr"(bvec0), [bvec1] "=&vr"(bvec1), [a0_0] "+&r"(a0_0),
+              [a0_1] "+&r"(a0_1), [a0_2] "+&r"(a0_2), [a0_3] "+&r"(a0_3),
+              [a0_4] "+&r"(a0_4), [a0_5] "+&r"(a0_5), [a1_0] "=&r"(a1_0),
+              [a1_1] "=&r"(a1_1), [a1_2] "=&r"(a1_2), [a1_3] "=&r"(a1_3),
+              [a1_4] "=&r"(a1_4), [a1_5] "=&r"(a1_5), [a0] "+&r"(a0),
+              [a1] "+&r"(a1), [a2] "+&r"(a2), [a3] "+&r"(a3), [a4] "+&r"(a4),
+              [a5] "+&r"(a5), [b] "+&r"(b)
+            : [csa1] "rI"(csa1 * sizeof(int8_t)),
+              [rsb1] "rI"(rsb1 * sizeof(int8_t)), [n] "r"(n), [n4] "r"(4 * n)
+            : "vl", "vtype", "memory");
+      }
 
       k -= 8;
     }
@@ -982,18 +1057,18 @@ skl_vm_1xe32m4_aligned_i8i32_vqdotvx(size_t n, size_t k, const int8_t *a,
   __riscv_vse32_v_i32m4(c, cvec, n);
 }
 
-SKL_FUNC void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(size_t m, size_t n, size_t k,
-                                                   const int8_t *a, size_t rsa,
-                                                   const int8_t *b_pack,
-                                                   size_t rsb1, int32_t *c,
-                                                   size_t rsc, bool accum) {
+SKL_FUNC_PRIVATE void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_dispatch(
+    size_t m, size_t n, size_t k, const int8_t *a, size_t rsa,
+    const int8_t *b_pack, size_t rsb1, int32_t *c, size_t rsc, bool accum,
+    bool x390_clp) {
   const size_t m0 = 6;
   const size_t n0 = __riscv_vsetvlmax_e32m4();
   const size_t k0 = 4;
 
   void (*skl_mm_6xe32m4_i8i32_vqdotvx_kernel)(
       size_t n, size_t k, const int8_t *a, size_t rsa1, size_t csa1,
-      const int8_t *b, size_t rsb1, int32_t *c, size_t rsc, bool accum);
+      const int8_t *b, size_t rsb1, int32_t *c, size_t rsc, bool accum,
+      bool x390_clp);
   void (*skl_mm_lt6xe32m4_i8i32_vqdotvx_kernel)(
       size_t m, size_t n, size_t k, const int8_t *a, size_t rsa1, size_t csa1,
       const int8_t *b, size_t rsb1, int32_t *c, size_t rsc, bool accum);
@@ -1031,7 +1106,7 @@ SKL_FUNC void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(size_t m, size_t n, size_t k,
         const size_t n_tile = n0 <= n - n_idx ? n0 : n - n_idx;
         (*skl_mm_6xe32m4_i8i32_vqdotvx_kernel)(n_tile, k, a_tile_ptr, rsa, k0,
                                                b_tile_ptr, rsb1, c_write, rsc,
-                                               accum);
+                                               accum, x390_clp);
         c_write += n_tile;
       }
     }
@@ -1050,4 +1125,20 @@ SKL_FUNC void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(size_t m, size_t n, size_t k,
       }
     }
   }
+}
+
+SKL_FUNC void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(size_t m, size_t n, size_t k,
+                                                   const int8_t *a, size_t rsa,
+                                                   const int8_t *b_pack,
+                                                   size_t rsb1, int32_t *c,
+                                                   size_t rsc, bool accum) {
+  skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_dispatch(m, n, k, a, rsa, b_pack, rsb1,
+                                                c, rsc, accum, false);
+}
+
+SKL_FUNC void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_x390_clp(
+    size_t m, size_t n, size_t k, const int8_t *a, size_t rsa,
+    const int8_t *b_pack, size_t rsb1, int32_t *c, size_t rsc, bool accum) {
+  skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_dispatch(m, n, k, a, rsa, b_pack, rsb1,
+                                                c, rsc, accum, true);
 }

--- a/src/gemm/xsfvqdotq/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.h
@@ -79,8 +79,8 @@ void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(size_t m, size_t n, size_t k,
                                           int32_t *c, size_t rsc, bool accum);
 
 /**
- * @brief Xsfvqdotq int8 A * B_pack matrix-matrix multiplication with row-major
- * A, packed B_pack, and row-major int32 output, tuned for the CLP on x390.
+ * @brief Int8 GEMM tuned for Core Local Port memory on SiFive's X390
+ * 
  *
  * @param m - Number of rows in matrix A and matrix C.
  * @param n - Number of columns in matrix B and matrix C.
@@ -113,7 +113,7 @@ void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(size_t m, size_t n, size_t k,
  * pre-allocated with size ((k + 3) / 4) * rsb1 bytes, then
  * ```
  * skl_pack_b_i8_xsfvqdotq(k, n, b, rsb, b_pack, rsb1);
- * skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(m, n, k, a, rsa, b_pack, rsb1, c, rsc,
+ * skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_x390_clp(m, n, k, a, rsa, b_pack, rsb1, c, rsc,
  *                                      accum);
  * ```
  * is equivalent to scalar call:
@@ -129,10 +129,11 @@ void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(size_t m, size_t n, size_t k,
  *
  * This version of skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq has been tuned for
  * improved performance on x390 when all of the following conditions are met:
- * 1) the matrices are allocated in the CLP,
+ * 1) the matrices are allocated in CLP memory,
  * 2) m >= 6, and
  * 3) A is 4-byte-aligned and rsa is a multiple 4.
- *
+ * If matrices are not allocated in the CLP address space, please use
+ * skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq instead.
  * @note
  * Matrix B_pack must be pre-packed using skl_pack_b_i8_xsfvqdotq(). Matrix A is
  * used directly in row-major format without requiring pre-packing. Performance

--- a/src/gemm/xsfvqdotq/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.h
@@ -79,8 +79,7 @@ void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(size_t m, size_t n, size_t k,
                                           int32_t *c, size_t rsc, bool accum);
 
 /**
- * @brief Int8 GEMM tuned for Core Local Port memory on SiFive's X390
- * 
+ * @brief Int8 GEMM tuned for Core Local Port memory on SiFive's X390.
  *
  * @param m - Number of rows in matrix A and matrix C.
  * @param n - Number of columns in matrix B and matrix C.
@@ -113,8 +112,8 @@ void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(size_t m, size_t n, size_t k,
  * pre-allocated with size ((k + 3) / 4) * rsb1 bytes, then
  * ```
  * skl_pack_b_i8_xsfvqdotq(k, n, b, rsb, b_pack, rsb1);
- * skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_x390_clp(m, n, k, a, rsa, b_pack, rsb1, c, rsc,
- *                                      accum);
+ * skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_x390_clp(m, n, k, a, rsa, b_pack, rsb1,
+ *                                               c, rsc, accum);
  * ```
  * is equivalent to scalar call:
  * ```
@@ -128,7 +127,7 @@ void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(size_t m, size_t n, size_t k,
  * - For m>1: uses tiled GEMM kernels
  *
  * This version of skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq has been tuned for
- * improved performance on x390 when all of the following conditions are met:
+ * improved performance on X390 when all of the following conditions are met:
  * 1) the matrices are allocated in CLP memory,
  * 2) m >= 6, and
  * 3) A is 4-byte-aligned and rsa is a multiple 4.
@@ -145,6 +144,7 @@ void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_x390_clp(size_t m, size_t n, size_t k,
                                                    const int8_t *b_pack,
                                                    size_t rsb1, int32_t *c,
                                                    size_t rsc, bool accum);
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/src/gemm/xsfvqdotq/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.h
@@ -20,28 +20,23 @@ extern "C" {
 #endif
 
 /**
- * @brief Int8 GEMM kernel using RISC-V xsfvqdotq extension with packed matrix
- * B.
+ * @brief Xsfvqdotq int8 A * B_pack matrix-matrix multiplication with row-major
+ * A, packed B_pack, and row-major int32 output.
  *
  * @param m - Number of rows in matrix A and matrix C.
  * @param n - Number of columns in matrix B and matrix C.
  * @param k - Number of columns in matrix A and rows in matrix B.
  * @param a - Pointer to matrix A in row-major format.
  * @param rsa - Stride between rows of matrix A in elements.
- * @param b_pack - Pointer to packed matrix B.
- * @param rsb1 - Row stride between blocks of packed matrix B in elements.
+ * @param b_pack - Pointer to packed matrix B_pack.
+ * @param rsb1 - Row stride between blocks of packed matrix B_pack in elements.
  * @param c - Pointer to matrix C in row-major format.
  * @param rsc - Stride between rows of matrix C in elements.
  * @param accum - Determines if output matrix is accumulated or overwritten.
  *
  * Computes `C = A * B_pack + C` (if `accum == true`) or `C = A * B_pack` (if
- * `accum == false`) for int8 matrices A and packed B with int32 output matrix
- * C. This kernel uses the SiFive xsfvqdotq extension for vector quad widening
- * 4D dot product operations to achieve high performance on 8-bit integer data.
- *
- * The kernel automatically dispatches to optimized internal implementations:
- * - For m=1: uses an internal GEMV kernel
- * - For m>1: uses tiled GEMM kernels
+ * `accum == false`) for int8 matrix A, packed int8 matrix B_pack, and int32
+ * output matrix C.
  *
  * When k % 4 == 0, equivalent to scalar call:
  * ```
@@ -55,7 +50,8 @@ extern "C" {
  * );
  * ```
  *
- * Assuming b_pack is pre-allocated and has size ((k + 3) / 4) * rsb1 bytes,
+ * If B is a k x n int8 row-major matrix with row stride rsb and b_pack is
+ * pre-allocated with size ((k + 3) / 4) * rsb1 bytes, then
  * ```
  * skl_pack_b_i8_xsfvqdotq(k, n, b, rsb, b_pack, rsb1);
  * skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(m, n, k, a, rsa, b_pack, rsb1, c, rsc,
@@ -66,15 +62,87 @@ extern "C" {
  * skl_gemm_i8_i32_scalar(m, n, k, 1, a, rsa, b, rsb, accum ? 1 : 0, c, rsc);
  * ```
  *
+ * This kernel uses the SiFive Xsfvqdotq extension for vector quad widening 4D
+ * dot product operations to achieve high performance on 8-bit integer data. The
+ * kernel automatically dispatches to optimized internal implementations:
+ * - For m=1: uses an internal GEMV kernel
+ * - For m>1: uses tiled GEMM kernels
+ *
  * @note
- * Matrix B must be pre-packed using skl_pack_b_i8_xsfvqdotq(). Matrix A is used
- * directly in row-major format without requiring pre-packing. Performance will
- * be best when A is 4-byte-aligned and rsa is a multiple of 4.
+ * Matrix B_pack must be pre-packed using skl_pack_b_i8_xsfvqdotq(). Matrix A is
+ * used directly in row-major format without requiring pre-packing. Performance
+ * will be best when A is 4-byte-aligned and rsa is a multiple of 4.
  */
 void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(size_t m, size_t n, size_t k,
                                           const int8_t *a, size_t rsa,
                                           const int8_t *b_pack, size_t rsb1,
                                           int32_t *c, size_t rsc, bool accum);
+
+/**
+ * @brief Xsfvqdotq int8 A * B_pack matrix-matrix multiplication with row-major
+ * A, packed B_pack, and row-major int32 output, tuned for the CLP on x390.
+ *
+ * @param m - Number of rows in matrix A and matrix C.
+ * @param n - Number of columns in matrix B and matrix C.
+ * @param k - Number of columns in matrix A and rows in matrix B.
+ * @param a - Pointer to matrix A in row-major format.
+ * @param rsa - Stride between rows of matrix A in elements.
+ * @param b_pack - Pointer to packed matrix B_pack.
+ * @param rsb1 - Row stride between blocks of packed matrix B_pack in elements.
+ * @param c - Pointer to matrix C in row-major format.
+ * @param rsc - Stride between rows of matrix C in elements.
+ * @param accum - Determines if output matrix is accumulated or overwritten.
+ *
+ * Computes `C = A * B_pack + C` (if `accum == true`) or `C = A * B_pack` (if
+ * `accum == false`) for int8 matrix A, packed int8 matrix B_pack, and int32
+ * output matrix C.
+ *
+ * When k % 4 == 0, equivalent to scalar call:
+ * ```
+ * skl_gemm_i8rcprc_i8rcprc_i32rcprc_scalar(
+ *     1, 1, 4, m, n, k / 4,   // m0, n0, k0, m1, n1, k1
+ *     1,                      // alpha
+ *     a, 0, 1, rsa, 4,        // a_pack, rsa0, csa0, rsa1, csa1
+ *     b_pack, 1, 0, rsb1, 4,  // b_pack, rsb0, csb0, rsb1, csb1
+ *     accum ? 1 : 0,          // beta
+ *     c, 0, 0, rsc, 1         // c_pack, rsc0, csc0, rsc1, csc1
+ * );
+ * ```
+ *
+ * If B is a k x n int8 row-major matrix with row stride rsb and b_pack is
+ * pre-allocated with size ((k + 3) / 4) * rsb1 bytes, then
+ * ```
+ * skl_pack_b_i8_xsfvqdotq(k, n, b, rsb, b_pack, rsb1);
+ * skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(m, n, k, a, rsa, b_pack, rsb1, c, rsc,
+ *                                      accum);
+ * ```
+ * is equivalent to scalar call:
+ * ```
+ * skl_gemm_i8_i32_scalar(m, n, k, 1, a, rsa, b, rsb, accum ? 1 : 0, c, rsc);
+ * ```
+ *
+ * This kernel uses the SiFive Xsfvqdotq extension for vector quad widening 4D
+ * dot product operations to achieve high performance on 8-bit integer data. The
+ * kernel automatically dispatches to optimized internal implementations:
+ * - For m=1: uses an internal GEMV kernel
+ * - For m>1: uses tiled GEMM kernels
+ *
+ * This version of skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq has been tuned for
+ * improved performance on x390 when all of the following conditions are met:
+ * 1) the matrices are allocated in the CLP,
+ * 2) m >= 6, and
+ * 3) A is 4-byte-aligned and rsa is a multiple 4.
+ *
+ * @note
+ * Matrix B_pack must be pre-packed using skl_pack_b_i8_xsfvqdotq(). Matrix A is
+ * used directly in row-major format without requiring pre-packing. Performance
+ * will be best when A is 4-byte-aligned and rsa is a multiple of 4.
+ */
+void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_x390_clp(size_t m, size_t n, size_t k,
+                                                   const int8_t *a, size_t rsa,
+                                                   const int8_t *b_pack,
+                                                   size_t rsb1, int32_t *c,
+                                                   size_t rsc, bool accum);
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/src/gemm/xsfvqdotq/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.h
@@ -134,6 +134,7 @@ void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(size_t m, size_t n, size_t k,
  * 3) A is 4-byte-aligned and rsa is a multiple 4.
  * If matrices are not allocated in the CLP address space, please use
  * skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq instead.
+ *
  * @note
  * Matrix B_pack must be pre-packed using skl_pack_b_i8_xsfvqdotq(). Matrix A is
  * used directly in row-major format without requiring pre-packing. Performance


### PR DESCRIPTION
This PR adds a version of the Xsfvqdotq GEMM kernel tuned for the CLP on x390 when `m >= 6` and `A` is suitably aligned (4-byte-aligned, `rsa` a multiple of 4). In the general and aligned 6xm4 kernels, an additional boolean parameter `x390_clp` is added. It is unused in the general 6xm4 kernel, i.e. the general 6xm4 kernel has no CLP-tuned version, while in the aligned 6xm4 kernel, `x390_clp` selects between two inner loop schedules. The original kernel `skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq` is preserved. The new kernel `skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_x390_clp` uses the CLP-tuned 6xm4 kernel when `A` is suitably aligned, otherwise it is identical to `skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq` .