### PR TITLE
[Test] [GEMM] Support custom allocators for benchmark buffers

### DIFF
--- a/test/gemm/gemm_f32rc_f32rc_f32rc.c
+++ b/test/gemm/gemm_f32rc_f32rc_f32rc.c
@@ -132,9 +132,17 @@ enum {
   ALEN = ((M - 1) * RSA + (K - 1) * CSA + 1),
   BLEN = ((K - 1) * RSB + (N - 1) * CSB + 1),
 };
+
+#if defined(CUSTOM_ALLOC)
+float *a;
+float *b;
+float *c;
+#else
 _Alignas(ALIGN) float a[ALEN];
 _Alignas(ALIGN) float b[BLEN];
 _Alignas(ALIGN) float c[CLEN];
+#endif
+
 #if defined(ENABLE_TEST)
 double a_wide[ALEN];
 double b_wide[BLEN];
@@ -208,12 +216,19 @@ int check_error(void) {
 int main(void) {
   int res = EXIT_SUCCESS;
 
+#if defined(CUSTOM_ALLOC)
+  a = (float *)CUSTOM_ALLOC(ALIGN, ALEN * sizeof(float));
+  b = (float *)CUSTOM_ALLOC(ALIGN, BLEN * sizeof(float));
+  c = (float *)CUSTOM_ALLOC(ALIGN, CLEN * sizeof(float));
+#endif
+
   PRINT_TEST_NAME(SKL_TEST_NAME);
   printf("M = %u, N = %u, K = %u\n", M, N, K);
   printf("ALPHA = %f, BETA = %f\n", ALPHA, BETA);
   printf("RSA = %u, CSA = %u\n", RSA, CSA);
   printf("RSB = %u, CSB = %u\n", RSB, CSB);
   printf("RSC = %u, CSC = %u\n", RSC, CSC);
+  printf("a = %p, b = %p, c = %p\n", (void *)a, (void *)b, (void *)c);
 
   /* Populate the matrices. */
   skl_test_init_f32(a, ALEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
@@ -248,6 +263,12 @@ int main(void) {
   print_float((float)(M * N * K) / (float)cycles);
   printf("\n");
 #endif // ENABLE_BENCHMARK
+
+#if defined(CUSTOM_ALLOC) && defined(CUSTOM_FREE)
+  CUSTOM_FREE(a);
+  CUSTOM_FREE(b);
+  CUSTOM_FREE(c);
+#endif
 
   return res;
 }

--- a/test/gemm/gemm_f32rc_f32rc_f32rc.c
+++ b/test/gemm/gemm_f32rc_f32rc_f32rc.c
@@ -133,7 +133,7 @@ enum {
   BLEN = ((K - 1) * RSB + (N - 1) * CSB + 1),
 };
 
-#if defined(CUSTOM_ALLOC)
+#if defined(SKL_TEST_MALLOC)
 float *a;
 float *b;
 float *c;
@@ -216,10 +216,10 @@ int check_error(void) {
 int main(void) {
   int res = EXIT_SUCCESS;
 
-#if defined(CUSTOM_ALLOC)
-  a = (float *)CUSTOM_ALLOC(ALIGN, ALEN * sizeof(float));
-  b = (float *)CUSTOM_ALLOC(ALIGN, BLEN * sizeof(float));
-  c = (float *)CUSTOM_ALLOC(ALIGN, CLEN * sizeof(float));
+#if defined(SKL_TEST_MALLOC)
+  a = (float *)SKL_TEST_MALLOC(ALIGN, ALEN * sizeof(float));
+  b = (float *)SKL_TEST_MALLOC(ALIGN, BLEN * sizeof(float));
+  c = (float *)SKL_TEST_MALLOC(ALIGN, CLEN * sizeof(float));
 #endif
 
   PRINT_TEST_NAME(SKL_TEST_NAME);
@@ -264,10 +264,10 @@ int main(void) {
   printf("\n");
 #endif // ENABLE_BENCHMARK
 
-#if defined(CUSTOM_ALLOC) && defined(CUSTOM_FREE)
-  CUSTOM_FREE(a);
-  CUSTOM_FREE(b);
-  CUSTOM_FREE(c);
+#if defined(SKL_TEST_MALLOC) && defined(SKL_TEST_FREE)
+  SKL_TEST_FREE(a);
+  SKL_TEST_FREE(b);
+  SKL_TEST_FREE(c);
 #endif
 
   return res;

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -512,18 +512,33 @@ SKL_TEST_INIT_FUNC(int32_t, i32, INT, unused)
 
 /**
  * @brief Custom memory allocation function
- * @details If defined, this function will be used to allocate memory for
- * buffers in benchmark mode.
+ *
+ * If defined, this function will be used to allocate memory for
+ * buffers in benchmark mode. If not defined, benchmarks should
+ * declare and initialize buffers as static arrays.
  */
 #if defined(CUSTOM_ALLOC)
+/**
+ * @brief Aligned memory allocation function.
+ *
+ * @param alignment Alignment of memory to allocate in bytes
+ * @param size Size of memory to allocate in bytes
+ * @return Pointer to allocated memory
+ */
 void *CUSTOM_ALLOC(size_t alignment, size_t size);
 #endif
 
 /**
  * @brief Custom memory free function
- * @details If defined, this function will be used to free memory allocated
+ *
+ * If defined, this function will be used to free memory allocated
  * by CUSTOM_ALLOC.
  */
 #if defined(CUSTOM_FREE)
+/**
+ * @brief Custom memory free function.
+ *
+ * @param ptr Pointer to memory to free
+ */
 void CUSTOM_FREE(void *ptr);
 #endif

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -516,6 +516,10 @@ SKL_TEST_INIT_FUNC(int32_t, i32, INT, unused)
  * If defined, this function will be used to allocate memory for
  * buffers in benchmark mode. If not defined, benchmarks should
  * declare and initialize buffers as static arrays.
+ *
+ * @note The prototype is declared by this macro so that it is not
+ * it can name an arbitrary symbol in a linked translation unit without
+ * modification to the benchmark source.
  */
 #if defined(CUSTOM_ALLOC)
 /**

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -509,3 +509,21 @@ SKL_TEST_INIT_FUNC(int32_t, i32, INT, unused)
 #undef SKL_TEST_INIT_FUNC
 #undef SKL_TEST_INIT_RANDOM_IMPL_FLOAT
 #undef SKL_TEST_INIT_RANDOM_IMPL_INT
+
+/**
+ * @brief Custom memory allocation function
+ * @details If defined, this function will be used to allocate memory for
+ * buffers in benchmark mode.
+ */
+#if defined(CUSTOM_ALLOC)
+void *CUSTOM_ALLOC(size_t alignment, size_t size);
+#endif
+
+/**
+ * @brief Custom memory free function
+ * @details If defined, this function will be used to free memory allocated
+ * by CUSTOM_ALLOC.
+ */
+#if defined(CUSTOM_FREE)
+void CUSTOM_FREE(void *ptr);
+#endif

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -537,6 +537,10 @@ void *CUSTOM_ALLOC(size_t alignment, size_t size);
  *
  * If defined, this function will be used to free memory allocated
  * by CUSTOM_ALLOC.
+ *
+ * @note The prototype is declared by this macro so that
+ * it can name an arbitrary symbol in a linked translation unit without
+ * modification to the benchmark source.
  */
 #if defined(CUSTOM_FREE) && defined(CUSTOM_ALLOC)
 /**

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -521,7 +521,7 @@ SKL_TEST_INIT_FUNC(int32_t, i32, INT, unused)
  * it can name an arbitrary symbol in a linked translation unit without
  * modification to the benchmark source.
  */
-#if defined(CUSTOM_ALLOC)
+#if defined(SKL_TEST_MALLOC)
 /**
  * @brief Aligned memory allocation function.
  *
@@ -529,24 +529,24 @@ SKL_TEST_INIT_FUNC(int32_t, i32, INT, unused)
  * @param size Size of memory to allocate in bytes
  * @return Pointer to allocated memory
  */
-void *CUSTOM_ALLOC(size_t alignment, size_t size);
+void *SKL_TEST_MALLOC(size_t alignment, size_t size);
 #endif
 
 /**
  * @brief Custom memory free function
  *
  * If defined, this function will be used to free memory allocated
- * by CUSTOM_ALLOC.
+ * by SKL_TEST_MALLOC.
  *
  * @note The prototype is declared by this macro so that
  * it can name an arbitrary symbol in a linked translation unit without
  * modification to the benchmark source.
  */
-#if defined(CUSTOM_FREE) && defined(CUSTOM_ALLOC)
+#if defined(SKL_TEST_FREE) && defined(SKL_TEST_MALLOC)
 /**
  * @brief Custom memory free function.
  *
  * @param ptr Pointer to memory to free
  */
-void CUSTOM_FREE(void *ptr);
+void SKL_TEST_FREE(void *ptr);
 #endif

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -513,9 +513,9 @@ SKL_TEST_INIT_FUNC(int32_t, i32, INT, unused)
 /**
  * @brief Custom memory allocation function
  *
- * If defined, this function will be used to allocate memory for
- * buffers in benchmark mode. If not defined, benchmarks should
- * declare and initialize buffers as static arrays.
+ * If defined, benchmarks should use this function to allocate buffers.
+ * If not defined, benchmarks should declare and initialize buffers as static
+ * arrays.
  *
  * @note The prototype is declared by this macro so that
  * it can name an arbitrary symbol in a linked translation unit without

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -517,7 +517,7 @@ SKL_TEST_INIT_FUNC(int32_t, i32, INT, unused)
  * buffers in benchmark mode. If not defined, benchmarks should
  * declare and initialize buffers as static arrays.
  *
- * @note The prototype is declared by this macro so that it is not
+ * @note The prototype is declared by this macro so that
  * it can name an arbitrary symbol in a linked translation unit without
  * modification to the benchmark source.
  */
@@ -538,7 +538,7 @@ void *CUSTOM_ALLOC(size_t alignment, size_t size);
  * If defined, this function will be used to free memory allocated
  * by CUSTOM_ALLOC.
  */
-#if defined(CUSTOM_FREE)
+#if defined(CUSTOM_FREE) && defined(CUSTOM_ALLOC)
 /**
  * @brief Custom memory free function.
  *


### PR DESCRIPTION
To make the SKL test harness suite more useful for certain benchmarking environments, this PR introduces a new paradigm for primary buffer allocation in kernel benchmarks.  Specifically, the `CUSTOM_ALLOC` and `CUSTOM_FREE` macros allow surrounding environments to control how and, crucially, _where_ benchmark data resides in memory.  For example, some systems may need to place data in fast scratchpad memory, etc.

As an initial demonstration, the new allocation strategy is implemented in the `gemm_f32rc_f32rc_f32rc` benchmark.  After merger, others should be ported to this format in separate PRs.

## Custom Allocator Syntax

If the `CUSTOM_ALLOC` macro is defined, it is expected to name a function of the following signature:
```c
void *CUSTOM_ALLOC(size_t alignment, size_t size);
```
This matches the C11 [aligned_alloc](https://en.cppreference.com/w/c/memory/aligned_alloc) function in argument order and should provide identical semantics.

Client environments that define `CUSTOM_ALLOC` may optionally define `CUSTOM_FREE`, which benchmarks must use during post-execution cleanup.

## Hybrid Static/Dynamic Allocation

Currently, all buffers are defined as static global arrays (`_Alignas(ALIGN) float c[CLEN];`); this PR changes to conditionally declare uninitialized pointers if `CUSTOM_ALLOC` is defined:
```c
#if defined(CUSTOM_ALLOC)
float *a;
float *b;
float *c;
#else
_Alignas(ALIGN) float a[ALEN];
_Alignas(ALIGN) float b[BLEN];
_Alignas(ALIGN) float c[CLEN];
#endif
```

## Rationale

Ideally, this kind of thing could be handled linker scripts and section attributes, but in practice we have found these may not be available in every environment.  At the opposite extreme, if we use `malloc`/`free` or equivalents in the benchmark harnesses, then ideally all allocation could be made dynamic, but unfortunately this too fails on systems without a working `aligned_alloc`.