### PR TITLE
[GEMM] Use skl.h in packed gemm test harnesses

### DIFF
--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -61,12 +61,11 @@
 #endif
 
 #if defined(ENABLE_TEST)
-#include "gemm/scalar/gemm_bf16rcprc_bf16rcprc_f32rcprc_scalar.h"
-#include "gemm/scalar/gemm_f64rcprc_f64rcprc_f64rcprc_scalar.h"
 #include <math.h>
 #endif
 
 #include "skl-test.h"
+#include "skl.h"
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -76,8 +75,6 @@
 
 /* Include various BF16 GEMM kernels depending on ISA compatibility. */
 #if defined(__riscv_xsfmm32a16f)
-#include "gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.h"
-
 void skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f_wrapper(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
     float alpha, const __bf16 *a_pack, size_t rsa0,

--- a/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -61,12 +61,11 @@
 #endif
 
 #if defined(ENABLE_TEST)
-#include "gemm/scalar/gemm_f16rcprc_f16rcprc_f32rcprc_scalar.h"
-#include "gemm/scalar/gemm_f64rcprc_f64rcprc_f64rcprc_scalar.h"
 #include <math.h>
 #endif
 
 #include "skl-test.h"
+#include "skl.h"
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -76,8 +75,6 @@
 
 /* Include various FP16 GEMM kernels depending on ISA compatibility. */
 #if defined(__riscv_xsfmm32a16f)
-#include "gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.h"
-
 void skl_gemm_a1b01_f16pc_f16cp_f32rcp_xsfmm32a16f_wrapper(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
     float alpha, const _Float16 *a_pack, size_t rsa0,

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -61,12 +61,11 @@
 #endif
 
 #if defined(ENABLE_TEST)
-#include "gemm/scalar/gemm_f32rcprc_f32rcprc_f32rcprc_scalar.h"
-#include "gemm/scalar/gemm_f64rcprc_f64rcprc_f64rcprc_scalar.h"
 #include <math.h>
 #endif
 
 #include "skl-test.h"
+#include "skl.h"
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -76,8 +75,6 @@
 
 /* Include various FP32 GEMM kernels depending on ISA compatibility. */
 #if defined(__riscv_xsfmm32a32f)
-#include "gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.h"
-
 void skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f_wrapper(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
     float alpha, const float *a_pack, size_t rsa0,

--- a/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -60,11 +60,8 @@
 #error Must define BETA
 #endif
 
-#if defined(ENABLE_TEST)
-#include "gemm/scalar/gemm_i8rcprc_i8rcprc_i32rcprc_scalar.h"
-#endif
-
 #include "skl-test.h"
+#include "skl.h"
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -74,8 +71,6 @@
 
 /* Include various int8 GEMM kernels depending on ISA compatibility. */
 #if defined(__riscv_xsfmm32a8i)
-#include "gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.h"
-
 void skl_gemm_a1b01_i8pc_i8cp_i32rcp_xsfmm32a8i_wrapper(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
     int32_t alpha, const int8_t *a_pack, size_t rsa0,
@@ -107,8 +102,6 @@ void skl_gemm_a1b01_i8pc_i8cp_i32rcp_xsfmm32a8i_wrapper(
 
 /* Include various int8 GEMM kernels depending on ISA compatibility. */
 #if defined(__riscv_xsfvqdotq)
-#include "gemm/xsfvqdotq/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.h"
-
 void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_wrapper(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
     int32_t alpha, const int8_t *a_pack, __attribute__((unused)) size_t rsa0,


### PR DESCRIPTION
This PR uses `skl.h` in the packed GEMM test harnesses to be consistent with other GEMM test harnesses.