### PR TITLE
[Test] Static buffer init mode & new SKL_TEST_INIT_{*} macros (FP only)

### DIFF
--- a/test/gemm/gemm_f32rc_f32rc_f32rc.c
+++ b/test/gemm/gemm_f32rc_f32rc_f32rc.c
@@ -232,9 +232,9 @@ int main(void) {
   printf("a = %p, b = %p, c = %p\n", (void *)a, (void *)b, (void *)c);
 
   /* Populate the matrices. */
-  skl_test_init_f32(a, ALEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
-  skl_test_init_f32(b, BLEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
-  skl_test_init_f32(c, CLEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
+  SKL_TEST_INIT_F32(a, ALEN);
+  SKL_TEST_INIT_F32(b, BLEN);
+  SKL_TEST_INIT_F32(c, CLEN);
 
 #if defined(ENABLE_TEST)
   /* Make copies of C to write the reference and test outputs to. */

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -767,10 +767,10 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
  *
  * Behavior is determined by TEST_INIT_MODE macro:
  * - RANDOM: Initialize with random values between min and max
- * - STATIC: Copy values from existing array NAME_data to buf
+ * - STATIC: Copy values from existing array BUF_data to buf
  * - SEQ: Initialize with equally-spaced values from min to max
  *
- * @note For STATIC mode, the array NAME_data must be defined in the header file
+ * @note For STATIC mode, the array BUF_data must be defined in the header file
  * specified by SKL_TEST_DATA_HEADER, but need not have the same length as the
  * buffer being initialized. The data will be repeated as necessary to fill the
  * buffer.

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -615,12 +615,12 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
  * to test specific ranges of interest. More modes may be added in the future.
  *
  * In STATIC mode, the input data is initialized with static values from
- * pre-defined arrays in data.h. Each
+ * pre-defined arrays in SKL_TEST_DATA_HEADER.
  */
 enum {
   SEQ,    ///< Initialize with equally-spaced values from min to max
   RANDOM, ///< Initialize with random values
-  STATIC  ///< Initialize with static values from arrays in data.h
+  STATIC  ///< Initialize with static values from SKL_TEST_DATA_HEADER
 };
 
 /**

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -752,32 +752,37 @@ enum {
 #define SKL_TEST_STATIC_DATA_LEN(NAME) 0
 #endif
 
+#if defined(TEST_INIT_MODE) && TEST_INIT_MODE == STATIC
 #define SKL_TEST_INIT(BUF, LEN, TYPE, MIN, MAX, IMPL_TYPE, FRAC_TYPE)          \
   {                                                                            \
     TYPE *buf = (BUF);                                                         \
     const size_t len = (LEN);                                                  \
-    if (TEST_INIT_MODE == STATIC) {                                            \
-      size_t avl = len;                                                        \
-      const size_t buf_len = SKL_TEST_STATIC_DATA_LEN(BUF);                    \
-      while (avl > 0) {                                                        \
-        size_t vl = avl > buf_len ? buf_len : avl;                             \
-        memcpy(buf, SKL_TEST_STATIC_DATA(BUF), vl * sizeof(TYPE));             \
-        avl -= vl;                                                             \
-        buf += vl;                                                             \
-      }                                                                        \
-    } else {                                                                   \
-      const TYPE min = (MIN);                                                  \
-      const TYPE max = (MAX);                                                  \
-      const TYPE step = (max - min) / len;                                     \
-      for (size_t i = 0; i < len; i++) {                                       \
-        if (TEST_INIT_MODE == RANDOM) {                                        \
-          SKL_TEST_INIT_RANDOM_IMPL_##IMPL_TYPE(TYPE, FRAC_TYPE);              \
-        } else {                                                               \
-          buf[i] = (TYPE)(min + step * i);                                     \
-        }                                                                      \
+    size_t avl = len;                                                          \
+    const size_t buf_len = SKL_TEST_STATIC_DATA_LEN(BUF);                      \
+    while (avl > 0) {                                                          \
+      size_t vl = avl > buf_len ? buf_len : avl;                               \
+      memcpy(buf, SKL_TEST_STATIC_DATA(BUF), vl * sizeof(TYPE));               \
+      avl -= vl;                                                               \
+      buf += vl;                                                               \
+    }                                                                          \
+  }
+#else
+#define SKL_TEST_INIT(BUF, LEN, TYPE, MIN, MAX, IMPL_TYPE, FRAC_TYPE)          \
+  {                                                                            \
+    TYPE *buf = (BUF);                                                         \
+    const size_t len = (LEN);                                                  \
+    const TYPE min = (MIN);                                                    \
+    const TYPE max = (MAX);                                                    \
+    const TYPE step = (max - min) / len;                                       \
+    for (size_t i = 0; i < len; i++) {                                         \
+      if (TEST_INIT_MODE == RANDOM) {                                          \
+        SKL_TEST_INIT_RANDOM_IMPL_##IMPL_TYPE(TYPE, FRAC_TYPE);                \
+      } else {                                                                 \
+        buf[i] = (TYPE)(min + step * i);                                       \
       }                                                                        \
     }                                                                          \
   }
+#endif
 
 #define SKL_TEST_INIT_RANDOM_IMPL_FLOAT(TYPE, FRAC_TYPE)                       \
   FRAC_TYPE frac = (FRAC_TYPE)rand() / (FRAC_TYPE)RAND_MAX;                    \

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -612,10 +612,14 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
  * Benchmarks will typically use SEQ to reduce overhead from random number
  * generation. Tests will typically use RANDOM though some will likely use SEQ
  * to test specific ranges of interest. More modes may be added in the future.
+ *
+ * In STATIC mode, the input data is initialized with static values from
+ * pre-defined arrays in data.h. Each
  */
 enum {
-  SEQ,   ///< Initialize with equally-spaced values from min to max
-  RANDOM ///< Initialize with random values
+  SEQ,    ///< Initialize with equally-spaced values from min to max
+  RANDOM, ///< Initialize with random values
+  STATIC  ///< Initialize with static values from arrays in data.h
 };
 
 /**
@@ -740,12 +744,50 @@ enum {
     }                                                                          \
   }
 
+#if defined(TEST_INIT_MODE) && TEST_INIT_MODE == STATIC
+#define SKL_TEST_STATIC_DATA(NAME) NAME##_data
+#else
+#define SKL_TEST_STATIC_DATA(NAME) NULL
+#endif
+
+#define SKL_TEST_INIT(BUF, LEN, TYPE, MIN, MAX, IMPL_TYPE, FRAC_TYPE)          \
+  {                                                                            \
+    const size_t len = (LEN);                                                  \
+    if (TEST_INIT_MODE == STATIC) {                                            \
+      memcpy(BUF, SKL_TEST_STATIC_DATA(BUF), len * sizeof(TYPE));              \
+    } else {                                                                   \
+      const TYPE min = (MIN);                                                  \
+      const TYPE max = (MAX);                                                  \
+      const TYPE step = (max - min) / len;                                     \
+      TYPE *buf = (BUF);                                                       \
+      for (size_t i = 0; i < len; i++) {                                       \
+        if (TEST_INIT_MODE == RANDOM) {                                        \
+          SKL_TEST_INIT_RANDOM_IMPL_##IMPL_TYPE(TYPE, FRAC_TYPE);              \
+        } else {                                                               \
+          buf[i] = (TYPE)(min + step * i);                                     \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
+  }
+
 #define SKL_TEST_INIT_RANDOM_IMPL_FLOAT(TYPE, FRAC_TYPE)                       \
   FRAC_TYPE frac = (FRAC_TYPE)rand() / (FRAC_TYPE)RAND_MAX;                    \
   buf[i] = (TYPE)(frac * (max - min) + min);
 
 #define SKL_TEST_INIT_RANDOM_IMPL_INT(TYPE, UNUSED)                            \
   buf[i] = (TYPE)rand() % (max - min + 1) + min;
+
+#define SKL_TEST_INIT_F16(BUF, LEN)                                            \
+  SKL_TEST_INIT(BUF, LEN, _Float16, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16, FLOAT, \
+                float)
+
+#define SKL_TEST_INIT_F32(BUF, LEN)                                            \
+  SKL_TEST_INIT(BUF, LEN, float, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32, FLOAT,    \
+                float)
+
+#define SKL_TEST_INIT_F64(BUF, LEN)                                            \
+  SKL_TEST_INIT(BUF, LEN, double, SKL_TEST_MIN_F64, SKL_TEST_MAX_F64, FLOAT,   \
+                double)
 
 /**
  * @brief Buffer initialization modes
@@ -802,10 +844,6 @@ SKL_TEST_INIT_FUNC(int8_t, i8, INT, unused)
 SKL_TEST_INIT_FUNC(int32_t, i32, INT, unused)
 
 /** @} */ // end of test_init group
-
-#undef SKL_TEST_INIT_FUNC
-#undef SKL_TEST_INIT_RANDOM_IMPL_FLOAT
-#undef SKL_TEST_INIT_RANDOM_IMPL_INT
 
 /**
  * @brief Custom memory allocation function

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -900,7 +900,6 @@ SKL_TEST_INIT_FUNC(int32_t, i32, INT, unused)
 
 /** @} */ // end of test_init group
 
-
 /**
  * @brief Custom memory allocation function
  *

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -746,20 +746,29 @@ enum {
 
 #if defined(TEST_INIT_MODE) && TEST_INIT_MODE == STATIC
 #define SKL_TEST_STATIC_DATA(NAME) NAME##_data
+#define SKL_STATIC_TEST_DATA_LEN(NAME) sizeof(NAME##_data)
 #else
 #define SKL_TEST_STATIC_DATA(NAME) NULL
+#define SKL_STATIC_TEST_DATA_LEN(NAME) 0
 #endif
 
 #define SKL_TEST_INIT(BUF, LEN, TYPE, MIN, MAX, IMPL_TYPE, FRAC_TYPE)          \
   {                                                                            \
+    TYPE *buf = (BUF);                                                         \
     const size_t len = (LEN);                                                  \
     if (TEST_INIT_MODE == STATIC) {                                            \
-      memcpy(BUF, SKL_TEST_STATIC_DATA(BUF), len * sizeof(TYPE));              \
+      size_t avl = len;                                                        \
+      const size_t buf_len = SKL_STATIC_TEST_DATA_LEN(BUF);                    \
+      while (avl > 0) {                                                        \
+        size_t vl = avl > buf_len ? buf_len : avl;                             \
+        memcpy(buf, SKL_TEST_STATIC_DATA(BUF), vl * sizeof(TYPE));             \
+        avl -= vl;                                                             \
+        buf += vl;                                                             \
+      }                                                                        \
     } else {                                                                   \
       const TYPE min = (MIN);                                                  \
       const TYPE max = (MAX);                                                  \
       const TYPE step = (max - min) / len;                                     \
-      TYPE *buf = (BUF);                                                       \
       for (size_t i = 0; i < len; i++) {                                       \
         if (TEST_INIT_MODE == RANDOM) {                                        \
           SKL_TEST_INIT_RANDOM_IMPL_##IMPL_TYPE(TYPE, FRAC_TYPE);              \

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -840,6 +840,8 @@ enum {
   SKL_TEST_INIT(BUF, LEN, double, SKL_TEST_MIN_F64, SKL_TEST_MAX_F64, FLOAT,   \
                 double)
 
+/** @} */ // end of test_init group
+
 /**
  * @brief Buffer initialization modes
  * @details Determines the behavior of skl_test_init functions when not in

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <assert.h>
 #include <float.h>
 #include <inttypes.h>
 #include <math.h>
@@ -734,6 +735,7 @@ enum {
 #define SKL_TEST_INIT_FUNC(TYPE, SUFFIX, IMPL_TYPE, FRAC_TYPE)                 \
   static inline void skl_test_init_##SUFFIX(TYPE *buf, size_t len, TYPE min,   \
                                             TYPE max) {                        \
+    assert(TEST_INIT_MODE == RANDOM || TEST_INIT_MODE == SEQ);                 \
     const TYPE step = (max - min) / len;                                       \
     for (size_t i = 0; i < len; i++) {                                         \
       if (TEST_INIT_MODE == RANDOM) {                                          \

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -778,8 +778,8 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
  * @param BUF - The buffer to initialize
  * @param LEN - The length of the buffer
  * @param TYPE - The data type of the buffer
- * @param MIN - The minimum value to use for initialization
- * @param MAX - The maximum value to use for initialization
+ * @param MIN - The minimum value to use for initialization (ignored in STATIC)
+ * @param MAX - The maximum value to use for initialization (ignored in STATIC)
  * @param IMPL_TYPE - Either FLOAT or INT to select implementation
  * @param FRAC_TYPE - Fractional type for floating point intermediates(float or
  * double)
@@ -899,6 +899,7 @@ SKL_TEST_INIT_FUNC(int8_t, i8, INT, unused)
 SKL_TEST_INIT_FUNC(int32_t, i32, INT, unused)
 
 /** @} */ // end of test_init group
+
 
 /**
  * @brief Custom memory allocation function

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -747,13 +747,8 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
     }                                                                          \
   }
 
-#if defined(TEST_INIT_MODE) && TEST_INIT_MODE == STATIC
 #define SKL_TEST_STATIC_DATA(NAME) NAME##_data
 #define SKL_TEST_STATIC_DATA_LEN(NAME) NAME##_len
-#else
-#define SKL_TEST_STATIC_DATA(NAME) NULL
-#define SKL_TEST_STATIC_DATA_LEN(NAME) 0
-#endif
 
 #define SKL_TEST_INIT_RANDOM_IMPL_FLOAT(TYPE, FRAC_TYPE)                       \
   FRAC_TYPE frac = (FRAC_TYPE)rand() / (FRAC_TYPE)RAND_MAX;                    \

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -773,14 +773,13 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
  * @param BUF - The buffer to initialize
  * @param LEN - The length of the buffer
  * @param TYPE - The data type of the buffer
- * @param MIN - The minimum value to use for initialization (ignored in STATIC)
- * @param MAX - The maximum value to use for initialization (ignored in STATIC)
+ * @param MSUFFIX - The macro suffix for the data type (e.g., F16, F32, I8)
  * @param IMPL_TYPE - Either FLOAT or INT to select implementation
  * @param FRAC_TYPE - Fractional type for floating point intermediates (float or
  * double)
  */
 #if defined(TEST_INIT_MODE) && TEST_INIT_MODE == STATIC
-#define SKL_TEST_INIT(BUF, LEN, TYPE, MIN, MAX, IMPL_TYPE, FRAC_TYPE)          \
+#define SKL_TEST_INIT(BUF, LEN, TYPE, MSUFFIX, IMPL_TYPE, FRAC_TYPE)           \
   {                                                                            \
     TYPE *buf = (BUF);                                                         \
     const size_t len = (LEN);                                                  \
@@ -794,12 +793,12 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
     }                                                                          \
   }
 #else
-#define SKL_TEST_INIT(BUF, LEN, TYPE, MIN, MAX, IMPL_TYPE, FRAC_TYPE)          \
+#define SKL_TEST_INIT(BUF, LEN, TYPE, MSUFFIX, IMPL_TYPE, FRAC_TYPE)           \
   {                                                                            \
     TYPE *buf = (BUF);                                                         \
     const size_t len = (LEN);                                                  \
-    const TYPE min = (MIN);                                                    \
-    const TYPE max = (MAX);                                                    \
+    const TYPE min = (SKL_TEST_MIN_##MSUFFIX);                                 \
+    const TYPE max = (SKL_TEST_MAX_##MSUFFIX);                                 \
     const TYPE step = (max - min) / len;                                       \
     for (size_t i = 0; i < len; i++) {                                         \
       if (TEST_INIT_MODE == RANDOM) {                                          \
@@ -826,16 +825,13 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
  * @{
  */
 #define SKL_TEST_INIT_F16(BUF, LEN)                                            \
-  SKL_TEST_INIT(BUF, LEN, _Float16, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16, FLOAT, \
-                float)
+  SKL_TEST_INIT(BUF, LEN, _Float16, F16, FLOAT, float)
 
 #define SKL_TEST_INIT_F32(BUF, LEN)                                            \
-  SKL_TEST_INIT(BUF, LEN, float, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32, FLOAT,    \
-                float)
+  SKL_TEST_INIT(BUF, LEN, float, F32, FLOAT, float)
 
 #define SKL_TEST_INIT_F64(BUF, LEN)                                            \
-  SKL_TEST_INIT(BUF, LEN, double, SKL_TEST_MIN_F64, SKL_TEST_MAX_F64, FLOAT,   \
-                double)
+  SKL_TEST_INIT(BUF, LEN, double, F64, FLOAT, double)
 
 /** @} */ // end of test_init_macros group
 

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -781,7 +781,7 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
  * @param MIN - The minimum value to use for initialization (ignored in STATIC)
  * @param MAX - The maximum value to use for initialization (ignored in STATIC)
  * @param IMPL_TYPE - Either FLOAT or INT to select implementation
- * @param FRAC_TYPE - Fractional type for floating point intermediates(float or
+ * @param FRAC_TYPE - Fractional type for floating point intermediates (float or
  * double)
  */
 #if defined(TEST_INIT_MODE) && TEST_INIT_MODE == STATIC

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -616,12 +616,13 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
  *
  * In STATIC mode, the input data is initialized with static values from
  * pre-defined arrays in SKL_TEST_DATA_HEADER.
+ *
+ * @note These are defined as preprocessor macros (not just enum constants)
+ * to allow their use in preprocessor conditionals.
  */
-enum {
-  SEQ,    ///< Initialize with equally-spaced values from min to max
-  RANDOM, ///< Initialize with random values
-  STATIC  ///< Initialize with static values from SKL_TEST_DATA_HEADER
-};
+#define SEQ 0    ///< Initialize with equally-spaced values from min to max
+#define RANDOM 1 ///< Initialize with random values
+#define STATIC 2 ///< Initialize with static values from SKL_TEST_DATA_HEADER
 
 /**
  * @defgroup test_ranges Test/Benchmark Value Range Configuration

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -752,6 +752,34 @@ enum {
 #define SKL_TEST_STATIC_DATA_LEN(NAME) 0
 #endif
 
+#define SKL_TEST_INIT_RANDOM_IMPL_FLOAT(TYPE, FRAC_TYPE)                       \
+  FRAC_TYPE frac = (FRAC_TYPE)rand() / (FRAC_TYPE)RAND_MAX;                    \
+  buf[i] = (TYPE)(frac * (max - min) + min);
+
+#define SKL_TEST_INIT_RANDOM_IMPL_INT(TYPE, UNUSED)                            \
+  buf[i] = (TYPE)rand() % (max - min + 1) + min;
+
+/**
+ * @brief Macro to initialize a buffer in a SKL test/benchmark.
+ *
+ * Bevehior is determined by TEST_INIT_MODE macro:
+ * - RANDOM: Initialize with random values between min and max
+ * - STATIC: Copy values from existing array NAME_data to buf
+ * - SEQ: Initialize with equally-spaced values from min to max
+ *
+ * @note For STATIC mode, the array NAME_data must be defined elsewhere, but
+ * need not have the same length as the buffer being initialized. The data will
+ * be repeated as necessary to fill the buffer.
+ *
+ * @param BUF - The buffer to initialize
+ * @param LEN - The length of the buffer
+ * @param TYPE - The data type of the buffer
+ * @param MIN - The minimum value to use for initialization
+ * @param MAX - The maximum value to use for initialization
+ * @param IMPL_TYPE - Either FLOAT or INT to select implementation
+ * @param FRAC_TYPE - Fractional type for floating point intermediates(float or
+ * double)
+ */
 #if defined(TEST_INIT_MODE) && TEST_INIT_MODE == STATIC
 #define SKL_TEST_INIT(BUF, LEN, TYPE, MIN, MAX, IMPL_TYPE, FRAC_TYPE)          \
   {                                                                            \
@@ -784,13 +812,20 @@ enum {
   }
 #endif
 
-#define SKL_TEST_INIT_RANDOM_IMPL_FLOAT(TYPE, FRAC_TYPE)                       \
-  FRAC_TYPE frac = (FRAC_TYPE)rand() / (FRAC_TYPE)RAND_MAX;                    \
-  buf[i] = (TYPE)(frac * (max - min) + min);
-
-#define SKL_TEST_INIT_RANDOM_IMPL_INT(TYPE, UNUSED)                            \
-  buf[i] = (TYPE)rand() % (max - min + 1) + min;
-
+/**
+ * @defgroup test_init Test/Benchmark Data Initialization Macros
+ *
+ * These macros are intended to be the standard way to initialize data buffers
+ * in SKL tests and benchmarks. They will displace the direct use of
+ * skl_test_init functions (deprecated).
+ *
+ * All macros in this group share a common interface and behavior:
+ * - @param BUF Output buffer to fill with values
+ * - @param LEN Number of elements to generate
+ * All macros are wrappers around SKL_TEST_INIT, which has more detailed
+ * documentation.
+ * @{
+ */
 #define SKL_TEST_INIT_F16(BUF, LEN)                                            \
   SKL_TEST_INIT(BUF, LEN, _Float16, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16, FLOAT, \
                 float)

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -746,10 +746,10 @@ enum {
 
 #if defined(TEST_INIT_MODE) && TEST_INIT_MODE == STATIC
 #define SKL_TEST_STATIC_DATA(NAME) NAME##_data
-#define SKL_STATIC_TEST_DATA_LEN(NAME) sizeof(NAME##_data)
+#define SKL_TEST_STATIC_DATA_LEN(NAME) sizeof(NAME##_data)
 #else
 #define SKL_TEST_STATIC_DATA(NAME) NULL
-#define SKL_STATIC_TEST_DATA_LEN(NAME) 0
+#define SKL_TEST_STATIC_DATA_LEN(NAME) 0
 #endif
 
 #define SKL_TEST_INIT(BUF, LEN, TYPE, MIN, MAX, IMPL_TYPE, FRAC_TYPE)          \
@@ -758,7 +758,7 @@ enum {
     const size_t len = (LEN);                                                  \
     if (TEST_INIT_MODE == STATIC) {                                            \
       size_t avl = len;                                                        \
-      const size_t buf_len = SKL_STATIC_TEST_DATA_LEN(BUF);                    \
+      const size_t buf_len = SKL_TEST_STATIC_DATA_LEN(BUF);                    \
       while (avl > 0) {                                                        \
         size_t vl = avl > buf_len ? buf_len : avl;                             \
         memcpy(buf, SKL_TEST_STATIC_DATA(BUF), vl * sizeof(TYPE));             \

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -748,7 +748,7 @@ enum {
 
 #if defined(TEST_INIT_MODE) && TEST_INIT_MODE == STATIC
 #define SKL_TEST_STATIC_DATA(NAME) NAME##_data
-#define SKL_TEST_STATIC_DATA_LEN(NAME) sizeof(NAME##_data)
+#define SKL_TEST_STATIC_DATA_LEN(NAME) NAME##_len
 #else
 #define SKL_TEST_STATIC_DATA(NAME) NULL
 #define SKL_TEST_STATIC_DATA_LEN(NAME) 0
@@ -935,4 +935,12 @@ void *SKL_TEST_MALLOC(size_t alignment, size_t size);
  * @param ptr Pointer to memory to free
  */
 void SKL_TEST_FREE(void *ptr);
+#endif
+
+#if TEST_INIT_MODE == STATIC
+#if !defined(SKL_TEST_DATA_HEADER)
+#error "SKL_TEST_DATA_HEADER must be defined when TEST_INIT_MODE == STATIC"
+#else
+#include SKL_TEST_DATA_HEADER
+#endif
 #endif

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -940,7 +940,7 @@ void *SKL_TEST_MALLOC(size_t alignment, size_t size);
 void SKL_TEST_FREE(void *ptr);
 #endif
 
-#if TEST_INIT_MODE == STATIC
+#if defined(TEST_INIT_MODE) && TEST_INIT_MODE == STATIC
 #if !defined(SKL_TEST_DATA_HEADER)
 #error "SKL_TEST_DATA_HEADER must be defined when TEST_INIT_MODE == STATIC"
 #else

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -764,14 +764,15 @@ enum {
 /**
  * @brief Macro to initialize a buffer in a SKL test/benchmark.
  *
- * Bevehior is determined by TEST_INIT_MODE macro:
+ * Behavior is determined by TEST_INIT_MODE macro:
  * - RANDOM: Initialize with random values between min and max
  * - STATIC: Copy values from existing array NAME_data to buf
  * - SEQ: Initialize with equally-spaced values from min to max
  *
- * @note For STATIC mode, the array NAME_data must be defined elsewhere, but
- * need not have the same length as the buffer being initialized. The data will
- * be repeated as necessary to fill the buffer.
+ * @note For STATIC mode, the array NAME_data must be defined in the header file
+ * specified by SKL_TEST_DATA_HEADER, but need not have the same length as the
+ * buffer being initialized. The data will be repeated as necessary to fill the
+ * buffer.
  *
  * @param BUF - The buffer to initialize
  * @param LEN - The length of the buffer
@@ -815,7 +816,7 @@ enum {
 #endif
 
 /**
- * @defgroup test_init Test/Benchmark Data Initialization Macros
+ * @defgroup test_init_macros Test/Benchmark Data Initialization Macros
  *
  * These macros are intended to be the standard way to initialize data buffers
  * in SKL tests and benchmarks. They will displace the direct use of
@@ -840,7 +841,7 @@ enum {
   SKL_TEST_INIT(BUF, LEN, double, SKL_TEST_MIN_F64, SKL_TEST_MAX_F64, FLOAT,   \
                 double)
 
-/** @} */ // end of test_init group
+/** @} */ // end of test_init_macros group
 
 /**
  * @brief Buffer initialization modes


### PR DESCRIPTION
This PR adds a new `TEST_INIT_MODE` -- `STATIC` -- to the buffer init code that copies data from a pre-defined array `BUF##_data` for `BUF`.  This is sometimes needed support execution environments such as RTL simulation where the cost of random initialization during runtime would be too high.

However, since the existing initialization functions cannot access the name of the buffer parameter to associate with a corresponding data array, I have introduced a new initialization paradigm that uses macros instead of functions:

```c
#define SKL_TEST_INIT(BUF, LEN, TYPE, MIN, MAX, IMPL_TYPE, FRAC_TYPE)          \
  {                                                                            \
    TYPE *buf = (BUF);                                                         \
    const size_t len = (LEN);                                                  \
    size_t avl = len;                                                          \
    const size_t buf_len = SKL_TEST_STATIC_DATA_LEN(BUF);                      \
    while (avl > 0) {                                                          \
      size_t vl = avl > buf_len ? buf_len : avl;                               \
      memcpy(buf, SKL_TEST_STATIC_DATA(BUF), vl * sizeof(TYPE));               \
      avl -= vl;                                                               \
      buf += vl;                                                               \
    }                                                                          \
  }
```

This somewhat unwieldy definition is complemented by simpler wrappers:
```c
#define SKL_TEST_INIT_F16(BUF, LEN)  [...]
#define SKL_TEST_INIT_F32(BUF, LEN)  [...]
#define SKL_TEST_INIT_F64(BUF, LEN)  [...]
```

This PR only adds these macros for the F{16,32,64} types, and makes use only of the F32 version in the single benchmark of `gemm_f32rc_f32rc_f32rc.c`.  Subsequent PRs will add the remaining types and test conversions. **Ultimately, the goal is to deprecate and remove the old `skl_test_init_{*}` functions**.
