### PR TITLE
Allow customization of GEMM performance reports

### DIFF
--- a/test/gemm/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c
+++ b/test/gemm/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c
@@ -49,7 +49,10 @@
 #error Must define BETA
 #endif
 
+#ifndef SKL_TEST_PERF_REPORT
 #define SKL_TEST_PERF_REPORT report_perf_mpc
+#endif
+
 #include "skl-test.h"
 #include "skl.h"
 #include <inttypes.h>

--- a/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
+++ b/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
@@ -43,7 +43,10 @@
 #include <math.h>
 #endif
 
+#ifndef SKL_TEST_PERF_REPORT
 #define SKL_TEST_PERF_REPORT report_perf_mpc
+#endif
+
 #include "skl-test.h"
 #include "skl.h"
 #include <inttypes.h>

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -64,7 +64,10 @@
 #include <math.h>
 #endif
 
+#ifndef SKL_TEST_PERF_REPORT
 #define SKL_TEST_PERF_REPORT report_perf_mpc
+#endif
+
 #include "skl-test.h"
 #include "skl.h"
 #include <inttypes.h>

--- a/test/gemm/gemm_f16rc_f16rc_f16rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f16rc.c
@@ -43,7 +43,10 @@
 #include <math.h>
 #endif
 
+#ifndef SKL_TEST_PERF_REPORT
 #define SKL_TEST_PERF_REPORT report_perf_mpc
+#endif
+
 #include "skl-test.h"
 #include "skl.h"
 #include <inttypes.h>

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -43,7 +43,10 @@
 #include <math.h>
 #endif
 
+#ifndef SKL_TEST_PERF_REPORT
 #define SKL_TEST_PERF_REPORT report_perf_mpc
+#endif
+
 #include "skl-test.h"
 #include "skl.h"
 #include <inttypes.h>

--- a/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -64,7 +64,10 @@
 #include <math.h>
 #endif
 
+#ifndef SKL_TEST_PERF_REPORT
 #define SKL_TEST_PERF_REPORT report_perf_mpc
+#endif
+
 #include "skl-test.h"
 #include "skl.h"
 #include <inttypes.h>

--- a/test/gemm/gemm_f32rc_f32rc_f32rc.c
+++ b/test/gemm/gemm_f32rc_f32rc_f32rc.c
@@ -43,7 +43,10 @@
 #include <math.h>
 #endif
 
+#ifndef SKL_TEST_PERF_REPORT
 #define SKL_TEST_PERF_REPORT report_perf_mpc
+#endif
+
 #include "skl-test.h"
 #include "skl.h"
 #include <inttypes.h>

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -64,7 +64,10 @@
 #include <math.h>
 #endif
 
+#ifndef SKL_TEST_PERF_REPORT
 #define SKL_TEST_PERF_REPORT report_perf_mpc
+#endif
+
 #include "skl-test.h"
 #include "skl.h"
 #include <inttypes.h>

--- a/test/gemm/gemm_f64rc_f64rc_f64rc.c
+++ b/test/gemm/gemm_f64rc_f64rc_f64rc.c
@@ -43,7 +43,10 @@
 #include <math.h>
 #endif
 
+#ifndef SKL_TEST_PERF_REPORT
 #define SKL_TEST_PERF_REPORT report_perf_mpc
+#endif
+
 #include "skl-test.h"
 #include "skl.h"
 #include <inttypes.h>

--- a/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
+++ b/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
@@ -55,7 +55,10 @@
 // in int8_t
 #define SKL_TEST_RAND_MAX_I8 126
 
+#ifndef SKL_TEST_PERF_REPORT
 #define SKL_TEST_PERF_REPORT report_perf_mpc
+#endif
+
 #include "skl-test.h"
 #include "skl.h"
 #include <inttypes.h>

--- a/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -76,7 +76,10 @@
 // in int8_t
 #define SKL_TEST_RAND_MAX_I8 126
 
+#ifndef SKL_TEST_PERF_REPORT
 #define SKL_TEST_PERF_REPORT report_perf_mpc
+#endif
+
 #include "skl-test.h"
 #include "skl.h"
 #include <inttypes.h>

--- a/test/gemm/gemm_i8rc_i8rc_i32rc.c
+++ b/test/gemm/gemm_i8rc_i8rc_i32rc.c
@@ -39,7 +39,10 @@
 #error Must define BETA
 #endif
 
+#ifndef SKL_TEST_PERF_REPORT
 #define SKL_TEST_PERF_REPORT report_perf_mpc
+#endif
+
 #include "skl-test.h"
 #include "skl.h"
 #include <inttypes.h>

--- a/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -60,7 +60,10 @@
 #error Must define BETA
 #endif
 
+#ifndef SKL_TEST_PERF_REPORT
 #define SKL_TEST_PERF_REPORT report_perf_mpc
+#endif
+
 #include "skl-test.h"
 #include "skl.h"
 #include <inttypes.h>

--- a/test/gemm/pack_b_i8_xsfvqdotq.c
+++ b/test/gemm/pack_b_i8_xsfvqdotq.c
@@ -31,7 +31,10 @@
 #error Must define N
 #endif
 
+#ifndef SKL_TEST_PERF_REPORT
 #define SKL_TEST_PERF_REPORT report_perf_mpc
+#endif
+
 #include "skl-test.h"
 #include "skl.h" // NOLINT(misc-include-cleaner)
 #include <inttypes.h>


### PR DESCRIPTION
The default performance report for GEMM benchmarks was set to report_perf_mpc in the benchmark source files themselves.  This patch makes this setting conditional on the macro SKL_TEST_PERF_REPORT not already being defined so that a build flow may use another reporting function.