### PR TITLE
Use shared benchmark macro in softmax harnesses

### DIFF
--- a/test/softmax/softmax_2d_f32.c
+++ b/test/softmax/softmax_2d_f32.c
@@ -104,8 +104,8 @@ int main(void) {
 
 #define RUN(FUNCTION, NAME)                                                    \
   memset(output, 0, SLEN * sizeof(*output));                                   \
-  SKL_BENCHMARK_RUN(NAME, M *N, SKL_TEST_WARMUP, FUNCTION, output, RSS, input, \
-                    RSA, BETA, M, N);                                          \
+  SKL_BENCHMARK_RUN(NAME, (M * N), SKL_TEST_WARMUP, FUNCTION, output, RSS,     \
+                    input, RSA, BETA, M, N);                                   \
   CHECK_RESULT(FUNCTION, NAME);
 
   // Run subset of functions depending on ISA compatibility

--- a/test/softmax/softmax_2d_f32.c
+++ b/test/softmax/softmax_2d_f32.c
@@ -86,21 +86,6 @@ int main(void) {
   printf("Measuring [%dx%d] softmax:\n\n", M, N);
   skl_test_init_f32(input, ALEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
 
-#if defined(ENABLE_BENCHMARK)
-  // cycle and instruction counters
-  uint64_t c0, c1, i0, i1; // NOLINT(readability-isolate-declaration)
-#define MEASURE_PERF(FUNCTION, NAME)                                           \
-  /* Measure 2nd run after caches warmed */                                    \
-  riscv_fence();                                                               \
-  c0 = riscv_read_mcycle(), i0 = riscv_read_minstret();                        \
-  FUNCTION(output, RSS, input, RSA, BETA, M, N);                               \
-  riscv_fence();                                                               \
-  c1 = riscv_read_mcycle(), i1 = riscv_read_minstret();                        \
-  report_perf_epc(NAME, c1 - c0, i1 - i0, (size_t)M * N);
-#else
-#define MEASURE_PERF(FUNCTION, NAME)
-#endif
-
 #if defined(ENABLE_TEST)
   memset(ref_output, 0, SLEN * sizeof(*ref_output));
   reference_softmax_2d_f32(ref_output, RSS, input, RSA, BETA, M, N, workspace);
@@ -119,8 +104,8 @@ int main(void) {
 
 #define RUN(FUNCTION, NAME)                                                    \
   memset(output, 0, SLEN * sizeof(*output));                                   \
-  FUNCTION(output, RSS, input, RSA, BETA, M, N);                               \
-  MEASURE_PERF(FUNCTION, NAME);                                                \
+  SKL_BENCHMARK_RUN(NAME, M *N, SKL_TEST_WARMUP, FUNCTION, output, RSS, input, \
+                    RSA, BETA, M, N);                                          \
   CHECK_RESULT(FUNCTION, NAME);
 
   // Run subset of functions depending on ISA compatibility

--- a/test/softmax/softmax_bf16.c
+++ b/test/softmax/softmax_bf16.c
@@ -67,19 +67,6 @@ int main(void) {
   printf("Measuring %d-element softmax:\n\n", NUM_ELEMS);
   skl_test_init_bf16(input, NUM_ELEMS, SKL_TEST_MIN_BF16, SKL_TEST_MAX_BF16);
 
-#if defined(ENABLE_BENCHMARK)
-  // cycle and instruction counters
-  uint64_t c0, c1, i0, i1; // NOLINT(readability-isolate-declaration)
-#define MEASURE_PERF(FUNCTION, NAME)                                           \
-  /* Measure 2nd run after caches warmed */                                    \
-  c0 = riscv_read_mcycle(), i0 = riscv_read_minstret();                        \
-  FUNCTION(output, input, BETA, NUM_ELEMS);                                    \
-  c1 = riscv_read_mcycle(), i1 = riscv_read_minstret();                        \
-  report_perf_epc(NAME, c1 - c0, i1 - i0, NUM_ELEMS);
-#else
-#define MEASURE_PERF(FUNCTION, NAME)
-#endif
-
 #if defined(ENABLE_TEST)
   memset(ref_output, 0, NUM_ELEMS * sizeof(*ref_output));
   reference_softmax_bf16(ref_output, input, BETA, workspace, NUM_ELEMS);
@@ -91,8 +78,8 @@ int main(void) {
 
 #define RUN(FUNCTION, NAME, TOL)                                               \
   memset(output, 0, NUM_ELEMS * sizeof(*output));                              \
-  FUNCTION(output, input, BETA, NUM_ELEMS);                                    \
-  MEASURE_PERF(FUNCTION, NAME);                                                \
+  SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, SKL_TEST_WARMUP, FUNCTION, output, input, \
+                    BETA, NUM_ELEMS);                                          \
   CHECK_RESULT(FUNCTION, NAME, TOL);
 
   // Run subset of functions depending on ISA compatibility

--- a/test/softmax/softmax_f16.c
+++ b/test/softmax/softmax_f16.c
@@ -67,19 +67,6 @@ int main(void) {
   printf("Measuring %d-element softmax:\n\n", NUM_ELEMS);
   skl_test_init_f16(input, NUM_ELEMS, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
 
-#if defined(ENABLE_BENCHMARK)
-  // cycle and instruction counters
-  uint64_t c0, c1, i0, i1; // NOLINT(readability-isolate-declaration)
-#define MEASURE_PERF(FUNCTION, NAME)                                           \
-  /* Measure 2nd run after caches warmed */                                    \
-  c0 = riscv_read_mcycle(), i0 = riscv_read_minstret();                        \
-  FUNCTION(output, input, BETA, NUM_ELEMS);                                    \
-  c1 = riscv_read_mcycle(), i1 = riscv_read_minstret();                        \
-  report_perf_epc(NAME, c1 - c0, i1 - i0, NUM_ELEMS);
-#else
-#define MEASURE_PERF(FUNCTION, NAME)
-#endif
-
 #if defined(ENABLE_TEST)
   memset(ref_output, 0, NUM_ELEMS * sizeof(*ref_output));
   reference_softmax_f16(ref_output, input, BETA, workspace, NUM_ELEMS);
@@ -91,8 +78,8 @@ int main(void) {
 
 #define RUN(FUNCTION, NAME)                                                    \
   memset(output, 0, NUM_ELEMS * sizeof(*output));                              \
-  FUNCTION(output, input, BETA, NUM_ELEMS);                                    \
-  MEASURE_PERF(FUNCTION, NAME);                                                \
+  SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, SKL_TEST_WARMUP, FUNCTION, output, input, \
+                    BETA, NUM_ELEMS);                                          \
   CHECK_RESULT(FUNCTION, NAME);
 
   // Run subset of functions depending on ISA compatibility

--- a/test/softmax/softmax_f32.c
+++ b/test/softmax/softmax_f32.c
@@ -63,20 +63,6 @@ int main(void) {
   printf("Measuring %d-element softmax:\n\n", NUM_ELEMS);
   skl_test_init_f32(input, NUM_ELEMS, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
 
-#if defined(ENABLE_BENCHMARK)
-  // cycle and instruction counters
-  uint64_t c0, c1, i0, i1; // NOLINT(readability-isolate-declaration)
-#define MEASURE_PERF(FUNCTION, NAME)                                           \
-  /* Measure 2nd run after caches warmed */                                    \
-  c0 = riscv_read_mcycle(), i0 = riscv_read_minstret();                        \
-  FUNCTION(output, input, BETA, NUM_ELEMS);                                    \
-  riscv_fence();                                                               \
-  c1 = riscv_read_mcycle(), i1 = riscv_read_minstret();                        \
-  report_perf_epc(NAME, c1 - c0, i1 - i0, NUM_ELEMS);
-#else
-#define MEASURE_PERF(FUNCTION, NAME)
-#endif
-
 #if defined(ENABLE_TEST)
   memset(ref_output, 0, NUM_ELEMS * sizeof(*ref_output));
   reference_softmax_f32(ref_output, input, BETA, workspace, NUM_ELEMS);
@@ -88,8 +74,8 @@ int main(void) {
 
 #define RUN(FUNCTION, NAME)                                                    \
   memset(output, 0, NUM_ELEMS * sizeof(*output));                              \
-  FUNCTION(output, input, BETA, NUM_ELEMS);                                    \
-  MEASURE_PERF(FUNCTION, NAME);                                                \
+  SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, SKL_TEST_WARMUP, FUNCTION, output, input, \
+                    BETA, NUM_ELEMS);                                          \
   CHECK_RESULT(FUNCTION, NAME);
 
   // Run subset of functions depending on ISA compatibility


### PR DESCRIPTION
Standardize softmax benchmarks by using the SKL_BENCHMARK_RUN macro.