### PR TITLE
Use shared benchmark macro in exp harnesses

### DIFF
--- a/test/exp/exp_bf16.c
+++ b/test/exp/exp_bf16.c
@@ -28,10 +28,6 @@ __attribute__((aligned(ALIGN))) __bf16 ref_output[NUM_ELEMS];
 
 int main(void) {
   int ret = 0; // return value
-#if defined(ENABLE_BENCHMARK)
-  // Cycle and instruction counts
-  uint64_t c0, c1, i0, i1; // NOLINT(readability-isolate-declaration)
-#endif
   printf("Measuring %d-element exponential:\n", NUM_ELEMS);
   skl_test_init_bf16(input, NUM_ELEMS, SKL_TEST_MIN_BF16, SKL_TEST_MAX_BF16);
 
@@ -39,17 +35,6 @@ int main(void) {
   memset(ref_output, 0, NUM_ELEMS * sizeof(*ref_output));
   scalar_exp_bf16(ref_output, input,
                   NUM_ELEMS); // Use scalar output as reference
-#endif
-
-#if defined(ENABLE_BENCHMARK)
-#define MEASURE_PERF(FUNCTION, NAME)                                           \
-  /* Measure 2nd run after caches warmed */                                    \
-  c0 = riscv_read_mcycle(), i0 = riscv_read_minstret();                        \
-  FUNCTION(output, input, NUM_ELEMS);                                          \
-  c1 = riscv_read_mcycle(), i1 = riscv_read_minstret();                        \
-  report_perf_epc(NAME, c1 - c0, i1 - i0, NUM_ELEMS);
-#else
-#define MEASURE_PERF(FUNCTION, NAME)
 #endif
 
 #if defined(ENABLE_TEST)
@@ -61,8 +46,8 @@ int main(void) {
 
 #define RUN(FUNCTION, NAME, TOL)                                               \
   memset(output, 0, NUM_ELEMS * sizeof(*output));                              \
-  FUNCTION(output, input, NUM_ELEMS);                                          \
-  MEASURE_PERF(FUNCTION, NAME);                                                \
+  SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, SKL_TEST_WARMUP, FUNCTION, output, input, \
+                    NUM_ELEMS);                                                \
   CHECK_RESULT(FUNCTION, NAME, TOL);
 
 #if defined(__riscv_zve32f) && defined(RUN_ZVE32F)

--- a/test/exp/exp_f16.c
+++ b/test/exp/exp_f16.c
@@ -28,10 +28,6 @@ __attribute__((aligned(ALIGN))) _Float16 ref_output[NUM_ELEMS];
 
 int main(void) {
   int ret = 0; // return value
-#if defined(ENABLE_BENCHMARK)
-  // Cycle and instruction counts
-  uint64_t c0, c1, i0, i1; // NOLINT(readability-isolate-declaration)
-#endif
   printf("Measuring %d-element exponential:\n", NUM_ELEMS);
   skl_test_init_f16(input, NUM_ELEMS, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
 
@@ -39,17 +35,6 @@ int main(void) {
   memset(ref_output, 0, NUM_ELEMS * sizeof(*ref_output));
   scalar_exp_f16(ref_output, input,
                  NUM_ELEMS); // Use scalar output as reference
-#endif
-
-#if defined(ENABLE_BENCHMARK)
-#define MEASURE_PERF(FUNCTION, NAME)                                           \
-  /* Measure 2nd run after caches warmed */                                    \
-  c0 = riscv_read_mcycle(), i0 = riscv_read_minstret();                        \
-  FUNCTION(output, input, NUM_ELEMS);                                          \
-  c1 = riscv_read_mcycle(), i1 = riscv_read_minstret();                        \
-  report_perf_epc(NAME, c1 - c0, i1 - i0, NUM_ELEMS);
-#else
-#define MEASURE_PERF(FUNCTION, NAME)
 #endif
 
 #if defined(ENABLE_TEST)
@@ -61,8 +46,8 @@ int main(void) {
 
 #define RUN(FUNCTION, NAME, TOL)                                               \
   memset(output, 0, NUM_ELEMS * sizeof(*output));                              \
-  FUNCTION(output, input, NUM_ELEMS);                                          \
-  MEASURE_PERF(FUNCTION, NAME);                                                \
+  SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, SKL_TEST_WARMUP, FUNCTION, output, input, \
+                    NUM_ELEMS);                                                \
   CHECK_RESULT(FUNCTION, NAME, TOL);
 
 #if defined(__riscv_zvfh) && defined(RUN_ZVFH)

--- a/test/exp/exp_f32.c
+++ b/test/exp/exp_f32.c
@@ -28,27 +28,12 @@ __attribute__((aligned(ALIGN))) float ref_output[NUM_ELEMS];
 
 int main(void) {
   int ret = 0; // return value
-#if defined(ENABLE_BENCHMARK)
-  // Cycle and instruction counts
-  uint64_t c0, c1, i0, i1; // NOLINT(readability-isolate-declaration)
-#endif
   printf("Measuring %d-element exponential:\n", NUM_ELEMS);
   skl_test_init_f32(input, NUM_ELEMS, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
 #if defined(ENABLE_TEST)
   memset(ref_output, 0, NUM_ELEMS * sizeof(*ref_output));
   scalar_exp_f32(ref_output, input,
                  NUM_ELEMS); // Use scalar output as reference
-#endif
-
-#if defined(ENABLE_BENCHMARK)
-#define MEASURE_PERF(FUNCTION, NAME)                                           \
-  /* Measure 2nd run after caches warmed */                                    \
-  c0 = riscv_read_mcycle(), i0 = riscv_read_minstret();                        \
-  FUNCTION(output, input, NUM_ELEMS);                                          \
-  c1 = riscv_read_mcycle(), i1 = riscv_read_minstret();                        \
-  report_perf_epc(NAME, c1 - c0, i1 - i0, NUM_ELEMS);
-#else
-#define MEASURE_PERF(FUNCTION, NAME)
 #endif
 
 #if defined(ENABLE_TEST)
@@ -60,8 +45,8 @@ int main(void) {
 
 #define RUN(FUNCTION, NAME, TOL)                                               \
   memset(output, 0, NUM_ELEMS * sizeof(*output));                              \
-  FUNCTION(output, input, NUM_ELEMS);                                          \
-  MEASURE_PERF(FUNCTION, NAME);                                                \
+  SKL_BENCHMARK_RUN(NAME, NUM_ELEMS, SKL_TEST_WARMUP, FUNCTION, output, input, \
+                    NUM_ELEMS);                                                \
   CHECK_RESULT(FUNCTION, NAME, TOL);
 
 #if defined(__riscv_zve32f) && defined(RUN_ZVE32F)


### PR DESCRIPTION
Standardize exp benchmarks by using the SKL_BENCHMARK_RUN macro.