### PR TITLE
[Test] Add SKL_TEST_MAIN to optionally define main() in harnesses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,7 +304,12 @@ function(skl_add_test TEST_NAME TEST_SRC OPTS)
     ${SKL_TEST_COMPILE_OPTIONS}
     ${OPTS}
   )
-  target_compile_definitions(test-${TEST_NAME} PRIVATE SKL_TEST_NAME=${TEST_NAME})
+  target_compile_definitions(
+    test-${TEST_NAME}
+    PRIVATE
+      SKL_TEST_NAME=${TEST_NAME}
+      SKL_TEST_MAIN
+  )
   if (SKL_BUILD_TESTS)
     target_compile_definitions(test-${TEST_NAME} PRIVATE ENABLE_TEST)
   endif()

--- a/test/gemm/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c
+++ b/test/gemm/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c
@@ -134,7 +134,7 @@ int check_error(void) {
 #define TEST_LABEL(S) #S ":\n"
 #define PRINT_TEST_NAME(S) printf(TEST_LABEL(S));
 
-int main(void) {
+int gemm_a1b01_i8_i8pc_i32_xsfvqdotq_main(void) {
   int status = 0;
   SKL_TEST_REQUIRE(status, RSA >= K);
   SKL_TEST_REQUIRE(status, RSB >= N);
@@ -178,3 +178,7 @@ int main(void) {
 
   return res;
 }
+
+#if defined(SKL_TEST_MAIN)
+int main(void) { return gemm_a1b01_i8_i8pc_i32_xsfvqdotq_main(); }
+#endif

--- a/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
+++ b/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
@@ -172,7 +172,7 @@ int check_error(void) {
 }
 #endif // ENABLE_TEST
 
-int main(void) {
+int gemm_bf16rc_bf16rc_f32rc_main(void) {
   int res = EXIT_SUCCESS;
 
   printf("%s:\n", skl_test_name);
@@ -201,3 +201,7 @@ int main(void) {
 
   return res;
 }
+
+#if defined(SKL_TEST_MAIN)
+int main(void) { return gemm_bf16rc_bf16rc_f32rc_main(); }
+#endif

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -237,7 +237,7 @@ int check_error(void) {
 }
 #endif // ENABLE_TEST
 
-int main(void) {
+int gemm_bf16rcprc_bf16rcprc_f32rcprc_main(void) {
   int res = EXIT_SUCCESS;
 
   printf("%s:\n", skl_test_name);
@@ -274,3 +274,7 @@ int main(void) {
 
   return res;
 }
+
+#if defined(SKL_TEST_MAIN)
+int main(void) { return gemm_bf16rcprc_bf16rcprc_f32rcprc_main(); }
+#endif

--- a/test/gemm/gemm_f16rc_f16rc_f16rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f16rc.c
@@ -169,7 +169,7 @@ int check_error(void) {
 }
 #endif // ENABLE_TEST
 
-int main(void) {
+int gemm_f16rc_f16rc_f16rc_main(void) {
   int res = EXIT_SUCCESS;
 
   printf("%s:\n", skl_test_name);
@@ -198,3 +198,7 @@ int main(void) {
 
   return res;
 }
+
+#if defined(SKL_TEST_MAIN)
+int main(void) { return gemm_f16rc_f16rc_f16rc_main(); }
+#endif

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -190,7 +190,7 @@ int check_error(void) {
 }
 #endif // ENABLE_TEST
 
-int main(void) {
+int gemm_f16rc_f16rc_f32rc_main(void) {
   int res = EXIT_SUCCESS;
 
   printf("%s:\n", skl_test_name);
@@ -219,3 +219,7 @@ int main(void) {
 
   return res;
 }
+
+#if defined(SKL_TEST_MAIN)
+int main(void) { return gemm_f16rc_f16rc_f32rc_main(); }
+#endif

--- a/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -237,7 +237,7 @@ int check_error(void) {
 }
 #endif // ENABLE_TEST
 
-int main(void) {
+int gemm_f16rcprc_f16rcprc_f32rcprc_main(void) {
   int res = EXIT_SUCCESS;
 
   printf("%s:\n", skl_test_name);
@@ -274,3 +274,7 @@ int main(void) {
 
   return res;
 }
+
+#if defined(SKL_TEST_MAIN)
+int main(void) { return gemm_f16rcprc_f16rcprc_f32rcprc_main(); }
+#endif

--- a/test/gemm/gemm_f32rc_f32rc_f32rc.c
+++ b/test/gemm/gemm_f32rc_f32rc_f32rc.c
@@ -214,7 +214,7 @@ int check_error(void) {
 }
 #endif // ENABLE_TEST
 
-int main(void) {
+int gemm_f32rc_f32rc_f32rc_main(void) {
   int res = EXIT_SUCCESS;
 
 #if defined(SKL_TEST_MALLOC)
@@ -256,3 +256,7 @@ int main(void) {
 
   return res;
 }
+
+#if defined(SKL_TEST_MAIN)
+int main(void) { return gemm_f32rc_f32rc_f32rc_main(); }
+#endif

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -237,7 +237,7 @@ int check_error(void) {
 }
 #endif // ENABLE_TEST
 
-int main(void) {
+int gemm_f32rcprc_f32rcprc_f32rcprc_main(void) {
   int res = EXIT_SUCCESS;
 
   printf("%s:\n", skl_test_name);
@@ -274,3 +274,7 @@ int main(void) {
 
   return res;
 }
+
+#if defined(SKL_TEST_MAIN)
+int main(void) { return gemm_f32rcprc_f32rcprc_f32rcprc_main(); }
+#endif

--- a/test/gemm/gemm_f64rc_f64rc_f64rc.c
+++ b/test/gemm/gemm_f64rc_f64rc_f64rc.c
@@ -171,7 +171,7 @@ int check_error(void) {
 }
 #endif // ENABLE_TEST
 
-int main(void) {
+int gemm_f64rc_f64rc_f64rc_main(void) {
   int res = EXIT_SUCCESS;
 
   printf("%s:\n", skl_test_name);
@@ -200,3 +200,7 @@ int main(void) {
 
   return res;
 }
+
+#if defined(SKL_TEST_MAIN)
+int main(void) { return gemm_f64rc_f64rc_f64rc_main(); }
+#endif

--- a/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
+++ b/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
@@ -265,7 +265,7 @@ int check_error(void) {
 }
 #endif // ENABLE_TEST
 
-int main(void) {
+int gemm_f8e4m3rc_f8e4m3rc_f32rc_main(void) {
   int res = EXIT_SUCCESS;
 
   printf("%s:\n", skl_test_name);
@@ -294,3 +294,7 @@ int main(void) {
 
   return res;
 }
+
+#if defined(SKL_TEST_MAIN)
+int main(void) { return gemm_f8e4m3rc_f8e4m3rc_f32rc_main(); }
+#endif

--- a/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -315,7 +315,7 @@ int check_error(void) {
 }
 #endif // ENABLE_TEST
 
-int main(void) {
+int gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc_main(void) {
   int res = EXIT_SUCCESS;
 
   printf("%s:\n", skl_test_name);
@@ -352,3 +352,7 @@ int main(void) {
 
   return res;
 }
+
+#if defined(SKL_TEST_MAIN)
+int main(void) { return gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc_main(); }
+#endif

--- a/test/gemm/gemm_i8rc_i8rc_i32rc.c
+++ b/test/gemm/gemm_i8rc_i8rc_i32rc.c
@@ -147,7 +147,7 @@ int check_error(void) {
 }
 #endif // ENABLE_TEST
 
-int main(void) {
+int gemm_i8rc_i8rc_i32rc_main(void) {
   int res = EXIT_SUCCESS;
 
   printf("%s:\n", skl_test_name);
@@ -176,3 +176,7 @@ int main(void) {
 
   return res;
 }
+
+#if defined(SKL_TEST_MAIN)
+int main(void) { return gemm_i8rc_i8rc_i32rc_main(); }
+#endif

--- a/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -228,7 +228,7 @@ int check_error(void) {
 }
 #endif // ENABLE_TEST
 
-int main(void) {
+int gemm_i8rcprc_i8rcprc_i32rcprc_main(void) {
   int res = EXIT_SUCCESS;
 
   printf("%s:\n", skl_test_name);
@@ -267,3 +267,7 @@ int main(void) {
 
   return res;
 }
+
+#if defined(SKL_TEST_MAIN)
+int main(void) { return gemm_i8rcprc_i8rcprc_i32rcprc_main(); }
+#endif

--- a/test/gemm/pack_b_i8_xsfvqdotq.c
+++ b/test/gemm/pack_b_i8_xsfvqdotq.c
@@ -122,7 +122,7 @@ int check_error(void) {
 #define TEST_LABEL(S) #S ":\n"
 #define PRINT_TEST_NAME(S) printf(TEST_LABEL(S));
 
-int main(void) {
+int pack_b_i8_xsfvqdotq_main(void) {
   int status = 0;
   SKL_TEST_REQUIRE(status, RSB >= N);
   SKL_TEST_REQUIRE(status, RSB1 >= 4 * N);
@@ -153,3 +153,7 @@ int main(void) {
 
   return res;
 }
+
+#if defined(SKL_TEST_MAIN)
+int main(void) { return pack_b_i8_xsfvqdotq_main(); }
+#endif


### PR DESCRIPTION
Add a new macro parameter for test/benchmark harnesses, `SKL_TEST_MAIN`, which the latter shall use to decide whether or not `int main() {}` is defined or not.  This allows the harness code to be called by a different C `main()` in client apps that need to do their own initialization, or in binaries that combine multiple SKL test harnesses together and would otherwise have a symbol conflict.

The example usage is shown with the `gemm_f32rc_f32rc_f32rc.c` benchmark, which has been converted to use it.  Once agreed on, all others will be converted over time to follow the same pattern.