### PR TITLE
Fix compiler errors related to #32

### DIFF
--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -724,247 +724,385 @@ skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
                        "v21", "v24", "v25", "v26", "v27", "v28", "v29", "vtype",
                        "vl", "memory");
   } else {
-    __asm__ volatile(
-        "sf.vsettnt x0, %[tn0], e8, w4\n"
-        "sf.vsettm x0, %[tm0]\n"
-        "sf.vsettk x0, %[k]\n"
+    if (tm0 == tn0) {
+      __asm__ volatile(
+          "sf.vsettnt x0, %[tn0], e8, w4\n"
+          "sf.vsettm x0, %[tm0]\n"
+          "sf.vsettk x0, %[k]\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v6, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
 
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
-        "vle8.v v12, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v14, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
 
-        "bltu %[k], %[i8], 2f\n"
-        "beq %[tm0], %[tn0], 1f\n"
+          "bltu %[k], %[i8], 1f\n"
 
-        "0:\n"
-        "addi %[k], %[k], -4\n"
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
-        "vle8.v v20, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v22, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
+          "0:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
 
-        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
 
-        "vle8.v v24, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v26, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
-        "vle8.v v28, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v30, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v24, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v26, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v28, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v30, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
 
-        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
 
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
-        "vle8.v v12, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v14, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
 
-        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v6, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
 
-        "bgeu %[k], %[i8], 0b\n"
-        "j 2f\n"
+          "bgeu %[k], %[i8], 0b\n"
 
-        "1:\n"
-        "addi %[k], %[k], -4\n"
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
-        "vle8.v v20, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v22, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
+          "1:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
 
-        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
 
-        "vle8.v v24, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v26, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
-        "vle8.v v28, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v30, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v24, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v26, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v28, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v30, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
 
-        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
 
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
-        "vle8.v v12, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v14, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
+          "beq %[k], %[i2], 2f\n"
+          "beq %[k], %[i1], 3f\n"
+          "beqz %[k], 4f\n"
 
-        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+          // k % 4 == 3
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "vle8.v v12, (%[b0_0])\n"
 
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v6, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
 
-        "bgeu %[k], %[i8], 1b\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "vle8.v v4, (%[a0_0])\n"
 
-        "2:\n"
-        "addi %[k], %[k], -4\n"
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
-        "vle8.v v20, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v22, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "vle8.v v20, (%[b1_0])\n"
 
-        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
 
-        "vle8.v v24, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v26, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
-        "vle8.v v28, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v30, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v24, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v26, (%[b2_1])\n"
+          "vle8.v v28, (%[b2_0])\n"
 
-        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+          "j 5f\n"
 
-        "beq %[k], %[i2], 3f\n"
-        "beq %[k], %[i1], 4f\n"
-        "beqz %[k], 5f\n"
+          "2:\n" // k % 4 == 2
+          "vle8.v v8, (%[b0_0])\n"
+          "vle8.v v10, (%[b0_1])\n"
 
-        // k % 4 == 3
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "vle8.v v12, (%[b0_0])\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
 
-        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "vle8.v v2, (%[a0_1])\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "vle8.v v18, (%[b1_1])\n"
 
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "vle8.v v20, (%[b1_0])\n"
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
 
-        "sf.vsettk x0, %[k]\n"
-        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+          "vle8.v v24, (%[b2_0])\n"
+          "vle8.v v26, (%[b2_1])\n"
 
-        "vle8.v v24, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v26, (%[b2_1])\n"
-        "vle8.v v28, (%[b2_0])\n"
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+          "j 5f\n"
 
-        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
-        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
-        "j 6f\n"
+          "3:\n" // k % 4 == 1
+          "vle8.v v8, (%[b0_0])\n"
 
-        "3:\n" // k % 4 == 2
-        "vle8.v v8, (%[b0_0])\n"
-        "vle8.v v10, (%[b0_1])\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
 
-        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+          "vle8.v v0, (%[a0_0])\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v16, (%[b1_0])\n"
 
-        "vle8.v v16, (%[b1_0])\n"
-        "vle8.v v18, (%[b1_1])\n"
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
 
-        "sf.vsettk x0, %[k]\n"
-        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+          "vle8.v v24, (%[b2_0])\n"
 
-        "vle8.v v24, (%[b2_0])\n"
-        "vle8.v v26, (%[b2_1])\n"
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+          "j 5f\n"
 
-        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
-        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
-        "j 6f\n"
+          "4:\n" // k % 4 == 0
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
 
-        "4:\n" // k % 4 == 1
-        "vle8.v v8, (%[b0_0])\n"
+          "5:\n"
+          : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
+            [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
+            [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [k] "+&r"(k)
+          : [sa] "r"(2 * rsa * sizeof(uint8_t)),
+            [sb] "r"(2 * rsb0 * sizeof(uint8_t)), [tm0] "r"(tm0),
+            [tn0] "r"(tn0), [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
+          : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+            "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19",
+            "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28",
+            "v29", "v30", "v31", "vtype", "vl", "memory");
+    } else { // tm0 != tn0
+      __asm__ volatile(
+          "sf.vsettnt x0, %[tn0], e8, w4\n"
+          "sf.vsettm x0, %[tm0]\n"
+          "sf.vsettk x0, %[k]\n"
 
-        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "sf.vsettn x0, %[tn0]\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
 
-        "vle8.v v16, (%[b1_0])\n"
+          "bltu %[k], %[i8], 1f\n"
 
-        "sf.vsettk x0, %[k]\n"
-        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+          "0:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
 
-        "vle8.v v24, (%[b2_0])\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
 
-        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
-        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
-        "j 6f\n"
+          "vle8.v v24, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v26, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v28, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v30, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
 
-        "5:\n" // k % 4 == 0
-        "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
 
-        "6:\n"
-        : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
-          [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
-          [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [k] "+&r"(k)
-        : [sa] "r"(2 * rsa * sizeof(uint8_t)),
-          [sb] "r"(2 * rsb0 * sizeof(uint8_t)), [tm0] "r"(tm0), [tn0] "r"(tn0),
-          [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
-        : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
-          "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
-          "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30",
-          "v31", "vtype", "vl", "memory");
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "bgeu %[k], %[i8], 0b\n"
+
+          "1:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+          "vle8.v v24, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v26, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v28, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v30, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+          "beq %[k], %[i2], 2f\n"
+          "beq %[k], %[i1], 3f\n"
+          "beqz %[k], 4f\n"
+
+          // k % 4 == 3
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "vle8.v v12, (%[b0_0])\n"
+
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "vle8.v v20, (%[b1_0])\n"
+
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+          "vle8.v v24, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v26, (%[b2_1])\n"
+          "vle8.v v28, (%[b2_0])\n"
+
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+          "j 5f\n"
+
+          "2:\n" // k % 4 == 2
+          "vle8.v v8, (%[b0_0])\n"
+          "vle8.v v10, (%[b0_1])\n"
+
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "vle8.v v16, (%[b1_0])\n"
+          "vle8.v v18, (%[b1_1])\n"
+
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+          "vle8.v v24, (%[b2_0])\n"
+          "vle8.v v26, (%[b2_1])\n"
+
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+          "j 5f\n"
+
+          "3:\n" // k % 4 == 1
+          "vle8.v v8, (%[b0_0])\n"
+
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "vle8.v v16, (%[b1_0])\n"
+
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+          "vle8.v v24, (%[b2_0])\n"
+
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+          "j 5f\n"
+
+          "4:\n" // k % 4 == 0
+          "sf.mm.e4m3.e4m3 mt8, v0, v24\n"
+
+          "5:\n"
+          : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
+            [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
+            [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [k] "+&r"(k)
+          : [sa] "r"(2 * rsa * sizeof(uint8_t)),
+            [sb] "r"(2 * rsb0 * sizeof(uint8_t)), [tm0] "r"(tm0),
+            [tn0] "r"(tn0), [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
+          : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+            "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19",
+            "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28",
+            "v29", "v30", "v31", "vtype", "vl", "memory");
+    }
   }
 
   /* Store tiles to memory. */
@@ -1198,296 +1336,461 @@ skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
           "v13", "v16", "v17", "v18", "v19", "v20", "v21", "vtype", "vl",
           "memory");
   } else {
-    __asm__ volatile(
-        "sf.vsettnt x0, %[tn0], e8, w4\n"
-        "sf.vsettm x0, %[tm0]\n"
-        "sf.vsettk x0, %[k]\n"
+    if (tm0 == tn0) {
+      __asm__ volatile(
+          "sf.vsettnt x0, %[tn0], e8, w4\n"
+          "sf.vsettm x0, %[tm0]\n"
+          "sf.vsettk x0, %[k]\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v6, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
 
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
-        "vle8.v v12, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v14, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
 
-        "bltu %[k], %[i8], 2f\n"
-        "beq %[tm0], %[tn0], 1f\n"
+          "bltu %[k], %[i8], 1f\n"
 
-        "0:\n"
-        "addi %[k], %[k], -4\n"
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
-        "vle8.v v20, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v22, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
+          "0:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
 
-        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
 
-        "vle8.v v8, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v10, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
-        "vle8.v v12, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v14, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v8, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v10, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v12, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v14, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
 
-        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
 
-        "vle8.v v16, (%[b3_0])\n"
-        "add %[b3_0], %[b3_0], %[sb]\n"
-        "vle8.v v18, (%[b3_1])\n"
-        "add %[b3_1], %[b3_1], %[sb]\n"
-        "vle8.v v20, (%[b3_0])\n"
-        "add %[b3_0], %[b3_0], %[sb]\n"
-        "vle8.v v22, (%[b3_1])\n"
-        "add %[b3_1], %[b3_1], %[sb]\n"
+          "vle8.v v16, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v18, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
+          "vle8.v v20, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v22, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
 
-        "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
 
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
-        "vle8.v v12, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v14, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
 
-        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v6, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
 
-        "bgeu %[k], %[i8], 0b\n"
-        "j 2f\n"
+          "bgeu %[k], %[i8], 0b\n"
 
-        "1:\n"
-        "addi %[k], %[k], -4\n"
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
-        "vle8.v v20, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v22, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
+          "1:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
 
-        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
 
-        "vle8.v v8, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v10, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
-        "vle8.v v12, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v14, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v8, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v10, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v12, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v14, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
 
-        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
 
-        "vle8.v v16, (%[b3_0])\n"
-        "add %[b3_0], %[b3_0], %[sb]\n"
-        "vle8.v v18, (%[b3_1])\n"
-        "add %[b3_1], %[b3_1], %[sb]\n"
-        "vle8.v v20, (%[b3_0])\n"
-        "add %[b3_0], %[b3_0], %[sb]\n"
-        "vle8.v v22, (%[b3_1])\n"
-        "add %[b3_1], %[b3_1], %[sb]\n"
+          "vle8.v v16, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v18, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
+          "vle8.v v20, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v22, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
 
-        "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
 
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
-        "vle8.v v12, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v14, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
+          "beq %[k], %[i2], 2f\n"
+          "beq %[k], %[i1], 3f\n"
+          "beqz %[k], 4f\n"
 
-        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+          // k % 4 == 3
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "vle8.v v12, (%[b0_0])\n"
 
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v6, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
 
-        "bgeu %[k], %[i8], 1b\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "vle8.v v4, (%[a0_0])\n"
 
-        "2:\n"
-        "addi %[k], %[k], -4\n"
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
-        "vle8.v v20, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v22, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "vle8.v v20, (%[b1_0])\n"
 
-        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
 
-        "vle8.v v8, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v10, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
-        "vle8.v v12, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v14, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v8, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v10, (%[b2_1])\n"
+          "vle8.v v12, (%[b2_0])\n"
 
-        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
 
-        "vle8.v v16, (%[b3_0])\n"
-        "add %[b3_0], %[b3_0], %[sb]\n"
-        "vle8.v v18, (%[b3_1])\n"
-        "add %[b3_1], %[b3_1], %[sb]\n"
-        "vle8.v v20, (%[b3_0])\n"
-        "add %[b3_0], %[b3_0], %[sb]\n"
-        "vle8.v v22, (%[b3_1])\n"
-        "add %[b3_1], %[b3_1], %[sb]\n"
+          "vle8.v v16, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v18, (%[b3_1])\n"
+          "vle8.v v20, (%[b3_0])\n"
 
-        "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+          "j 5f\n"
 
-        "beq %[k], %[i2], 3f\n"
-        "beq %[k], %[i1], 4f\n"
-        "beqz %[k], 5f\n"
+          "2:\n" // k % 4 == 2
+          "vle8.v v8, (%[b0_0])\n"
+          "vle8.v v10, (%[b0_1])\n"
 
-        // k % 4 == 3
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "vle8.v v12, (%[b0_0])\n"
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
 
-        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "vle8.v v2, (%[a0_1])\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "vle8.v v18, (%[b1_1])\n"
 
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "vle8.v v20, (%[b1_0])\n"
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
 
-        "sf.vsettk x0, %[k]\n"
-        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+          "vle8.v v8, (%[b2_0])\n"
+          "vle8.v v10, (%[b2_1])\n"
 
-        "vle8.v v8, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v10, (%[b2_1])\n"
-        "vle8.v v12, (%[b2_0])\n"
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
 
-        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "vle8.v v16, (%[b3_0])\n"
+          "vle8.v v18, (%[b3_1])\n"
 
-        "vle8.v v16, (%[b3_0])\n"
-        "add %[b3_0], %[b3_0], %[sb]\n"
-        "vle8.v v18, (%[b3_1])\n"
-        "vle8.v v20, (%[b3_0])\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+          "j 5f\n"
 
-        "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
-        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
-        "j 6f\n"
+          "3:\n" // k % 4 == 1
+          "vle8.v v8, (%[b0_0])\n"
 
-        "3:\n" // k % 4 == 2
-        "vle8.v v8, (%[b0_0])\n"
-        "vle8.v v10, (%[b0_1])\n"
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
 
-        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+          "vle8.v v0, (%[a0_0])\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v16, (%[b1_0])\n"
 
-        "vle8.v v16, (%[b1_0])\n"
-        "vle8.v v18, (%[b1_1])\n"
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
 
-        "sf.vsettk x0, %[k]\n"
-        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+          "vle8.v v8, (%[b2_0])\n"
 
-        "vle8.v v8, (%[b2_0])\n"
-        "vle8.v v10, (%[b2_1])\n"
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
 
-        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "vle8.v v16, (%[b3_0])\n"
 
-        "vle8.v v16, (%[b3_0])\n"
-        "vle8.v v18, (%[b3_1])\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+          "j 5f\n"
 
-        "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
-        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
-        "j 6f\n"
+          "4:\n" // k % 4 == 0
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
 
-        "4:\n" // k % 4 == 1
-        "vle8.v v8, (%[b0_0])\n"
+          "5:\n"
+          : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
+            [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
+            [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [b3_0] "+&r"(b3_0),
+            [b3_1] "+&r"(b3_1), [k] "+&r"(k)
+          : [sa] "r"(2 * rsa * sizeof(uint8_t)),
+            [sb] "r"(2 * rsb0 * sizeof(uint8_t)), [tm0] "r"(tm0),
+            [tn0] "r"(tn0), [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
+          : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+            "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19",
+            "v20", "v21", "v22", "v23", "vtype", "vl", "memory");
+    } else { // tm0 != tn0
+      __asm__ volatile(
+          "sf.vsettnt x0, %[tn0], e8, w4\n"
+          "sf.vsettm x0, %[tm0]\n"
+          "sf.vsettk x0, %[k]\n"
 
-        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "sf.vsettn x0, %[tn0]\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
 
-        "vle8.v v16, (%[b1_0])\n"
+          "bltu %[k], %[i8], 1f\n"
 
-        "sf.vsettk x0, %[k]\n"
-        "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+          "0:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
 
-        "vle8.v v8, (%[b2_0])\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
 
-        "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+          "vle8.v v8, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v10, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v12, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v14, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
 
-        "vle8.v v16, (%[b3_0])\n"
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
 
-        "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
-        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
-        "j 6f\n"
+          "vle8.v v16, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v18, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
+          "vle8.v v20, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v22, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
 
-        "5:\n" // k % 4 == 0
-        "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+          "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
 
-        "6:\n"
-        : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
-          [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
-          [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [b3_0] "+&r"(b3_0),
-          [b3_1] "+&r"(b3_1), [k] "+&r"(k)
-        : [sa] "r"(2 * rsa * sizeof(uint8_t)),
-          [sb] "r"(2 * rsb0 * sizeof(uint8_t)), [tm0] "r"(tm0), [tn0] "r"(tn0),
-          [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
-        : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
-          "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
-          "v21", "v22", "v23", "vtype", "vl", "memory");
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "bgeu %[k], %[i8], 0b\n"
+
+          "1:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+          "vle8.v v8, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v10, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v12, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v14, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+          "vle8.v v16, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v18, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
+          "vle8.v v20, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v22, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
+
+          "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+
+          "beq %[k], %[i2], 2f\n"
+          "beq %[k], %[i1], 3f\n"
+          "beqz %[k], 4f\n"
+
+          // k % 4 == 3
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "vle8.v v12, (%[b0_0])\n"
+
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "vle8.v v20, (%[b1_0])\n"
+
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+          "vle8.v v8, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v10, (%[b2_1])\n"
+          "vle8.v v12, (%[b2_0])\n"
+
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+          "vle8.v v16, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v18, (%[b3_1])\n"
+          "vle8.v v20, (%[b3_0])\n"
+
+          "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+          "j 5f\n"
+
+          "2:\n" // k % 4 == 2
+          "vle8.v v8, (%[b0_0])\n"
+          "vle8.v v10, (%[b0_1])\n"
+
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "vle8.v v16, (%[b1_0])\n"
+          "vle8.v v18, (%[b1_1])\n"
+
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+          "vle8.v v8, (%[b2_0])\n"
+          "vle8.v v10, (%[b2_1])\n"
+
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+          "vle8.v v16, (%[b3_0])\n"
+          "vle8.v v18, (%[b3_1])\n"
+
+          "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+          "j 5f\n"
+
+          "3:\n" // k % 4 == 1
+          "vle8.v v8, (%[b0_0])\n"
+
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "vle8.v v16, (%[b1_0])\n"
+
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.e4m3.e4m3 mt0, v0, v8\n"
+
+          "vle8.v v8, (%[b2_0])\n"
+
+          "sf.mm.e4m3.e4m3 mt4, v0, v16\n"
+
+          "vle8.v v16, (%[b3_0])\n"
+
+          "sf.mm.e4m3.e4m3 mt8, v0, v8\n"
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+          "j 5f\n"
+
+          "4:\n" // k % 4 == 0
+          "sf.mm.e4m3.e4m3 mt12, v0, v16\n"
+
+          "5:\n"
+          : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
+            [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
+            [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [b3_0] "+&r"(b3_0),
+            [b3_1] "+&r"(b3_1), [k] "+&r"(k)
+          : [sa] "r"(2 * rsa * sizeof(uint8_t)),
+            [sb] "r"(2 * rsb0 * sizeof(uint8_t)), [tm0] "r"(tm0),
+            [tn0] "r"(tn0), [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
+          : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+            "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19",
+            "v20", "v21", "v22", "v23", "vtype", "vl", "memory");
+    }
   }
 
   /* Store tiles to memory. */

--- a/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
+++ b/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
@@ -721,247 +721,385 @@ SKL_FUNC_PRIVATE void skl_gemm_1tm3tn_3tm1tn_a1b01_i8c_i8_i32_xsfmm32a8i(
                        "v21", "v24", "v25", "v26", "v27", "v28", "v29", "vtype",
                        "vl", "memory");
   } else {
-    __asm__ volatile(
-        "sf.vsettnt x0, %[tn0], e8, w4\n"
-        "sf.vsettm x0, %[tm0]\n"
-        "sf.vsettk x0, %[k]\n"
+    if (tm0 == tn0) {
+      __asm__ volatile(
+          "sf.vsettnt x0, %[tn0], e8, w4\n"
+          "sf.vsettm x0, %[tm0]\n"
+          "sf.vsettk x0, %[k]\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v6, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
 
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
-        "vle8.v v12, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v14, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
 
-        "bltu %[k], %[i8], 2f\n"
-        "beq %[tm0], %[tn0], 1f\n"
+          "bltu %[k], %[i8], 1f\n"
 
-        "0:\n"
-        "addi %[k], %[k], -4\n"
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
-        "vle8.v v20, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v22, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
+          "0:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
 
-        "sf.mm.s.s mt0, v0, v8\n"
+          "sf.mm.s.s mt0, v0, v8\n"
 
-        "vle8.v v24, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v26, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
-        "vle8.v v28, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v30, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v24, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v26, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v28, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v30, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
 
-        "sf.mm.s.s mt4, v0, v16\n"
+          "sf.mm.s.s mt4, v0, v16\n"
 
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
-        "vle8.v v12, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v14, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
 
-        "sf.mm.s.s mt8, v0, v24\n"
+          "sf.mm.s.s mt8, v0, v24\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v6, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
 
-        "bgeu %[k], %[i8], 0b\n"
-        "j 2f\n"
+          "bgeu %[k], %[i8], 0b\n"
 
-        "1:\n"
-        "addi %[k], %[k], -4\n"
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
-        "vle8.v v20, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v22, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
+          "1:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
 
-        "sf.mm.s.s mt0, v0, v8\n"
+          "sf.mm.s.s mt0, v0, v8\n"
 
-        "vle8.v v24, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v26, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
-        "vle8.v v28, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v30, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v24, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v26, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v28, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v30, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
 
-        "sf.mm.s.s mt4, v0, v16\n"
+          "sf.mm.s.s mt4, v0, v16\n"
 
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
-        "vle8.v v12, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v14, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
+          "beq %[k], %[i2], 2f\n"
+          "beq %[k], %[i1], 3f\n"
+          "beqz %[k], 4f\n"
 
-        "sf.mm.s.s mt8, v0, v24\n"
+          // k % 4 == 3
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "vle8.v v12, (%[b0_0])\n"
 
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v6, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
+          "sf.mm.s.s mt8, v0, v24\n"
 
-        "bgeu %[k], %[i8], 1b\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "vle8.v v4, (%[a0_0])\n"
 
-        "2:\n"
-        "addi %[k], %[k], -4\n"
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
-        "vle8.v v20, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v22, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "vle8.v v20, (%[b1_0])\n"
 
-        "sf.mm.s.s mt0, v0, v8\n"
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.s.s mt0, v0, v8\n"
 
-        "vle8.v v24, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v26, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
-        "vle8.v v28, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v30, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v24, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v26, (%[b2_1])\n"
+          "vle8.v v28, (%[b2_0])\n"
 
-        "sf.mm.s.s mt4, v0, v16\n"
+          "sf.mm.s.s mt4, v0, v16\n"
+          "sf.mm.s.s mt8, v0, v24\n"
+          "j 5f\n"
 
-        "beq %[k], %[i2], 3f\n"
-        "beq %[k], %[i1], 4f\n"
-        "beqz %[k], 5f\n"
+          "2:\n" // k % 4 == 2
+          "vle8.v v8, (%[b0_0])\n"
+          "vle8.v v10, (%[b0_1])\n"
 
-        // k % 4 == 3
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "vle8.v v12, (%[b0_0])\n"
+          "sf.mm.s.s mt8, v0, v24\n"
 
-        "sf.mm.s.s mt8, v0, v24\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "vle8.v v2, (%[a0_1])\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "vle8.v v18, (%[b1_1])\n"
 
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "vle8.v v20, (%[b1_0])\n"
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.s.s mt0, v0, v8\n"
 
-        "sf.vsettk x0, %[k]\n"
-        "sf.mm.s.s mt0, v0, v8\n"
+          "vle8.v v24, (%[b2_0])\n"
+          "vle8.v v26, (%[b2_1])\n"
 
-        "vle8.v v24, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v26, (%[b2_1])\n"
-        "vle8.v v28, (%[b2_0])\n"
+          "sf.mm.s.s mt4, v0, v16\n"
+          "sf.mm.s.s mt8, v0, v24\n"
+          "j 5f\n"
 
-        "sf.mm.s.s mt4, v0, v16\n"
-        "sf.mm.s.s mt8, v0, v24\n"
-        "j 6f\n"
+          "3:\n" // k % 4 == 1
+          "vle8.v v8, (%[b0_0])\n"
 
-        "3:\n" // k % 4 == 2
-        "vle8.v v8, (%[b0_0])\n"
-        "vle8.v v10, (%[b0_1])\n"
+          "sf.mm.s.s mt8, v0, v24\n"
 
-        "sf.mm.s.s mt8, v0, v24\n"
+          "vle8.v v0, (%[a0_0])\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v16, (%[b1_0])\n"
 
-        "vle8.v v16, (%[b1_0])\n"
-        "vle8.v v18, (%[b1_1])\n"
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.s.s mt0, v0, v8\n"
 
-        "sf.vsettk x0, %[k]\n"
-        "sf.mm.s.s mt0, v0, v8\n"
+          "vle8.v v24, (%[b2_0])\n"
 
-        "vle8.v v24, (%[b2_0])\n"
-        "vle8.v v26, (%[b2_1])\n"
+          "sf.mm.s.s mt4, v0, v16\n"
+          "sf.mm.s.s mt8, v0, v24\n"
+          "j 5f\n"
 
-        "sf.mm.s.s mt4, v0, v16\n"
-        "sf.mm.s.s mt8, v0, v24\n"
-        "j 6f\n"
+          "4:\n" // k % 4 == 0
+          "sf.mm.s.s mt8, v0, v24\n"
 
-        "4:\n" // k % 4 == 1
-        "vle8.v v8, (%[b0_0])\n"
+          "5:\n"
+          : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
+            [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
+            [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [k] "+&r"(k)
+          : [sa] "r"(2 * rsa * sizeof(int8_t)),
+            [sb] "r"(2 * rsb0 * sizeof(int8_t)), [tm0] "r"(tm0), [tn0] "r"(tn0),
+            [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
+          : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+            "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19",
+            "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28",
+            "v29", "v30", "v31", "vtype", "vl", "memory");
+    } else { // tm0 != tn0
+      __asm__ volatile(
+          "sf.vsettnt x0, %[tn0], e8, w4\n"
+          "sf.vsettm x0, %[tm0]\n"
+          "sf.vsettk x0, %[k]\n"
 
-        "sf.mm.s.s mt8, v0, v24\n"
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "sf.vsettn x0, %[tn0]\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
 
-        "vle8.v v16, (%[b1_0])\n"
+          "bltu %[k], %[i8], 1f\n"
 
-        "sf.vsettk x0, %[k]\n"
-        "sf.mm.s.s mt0, v0, v8\n"
+          "0:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
 
-        "vle8.v v24, (%[b2_0])\n"
+          "sf.mm.s.s mt0, v0, v8\n"
 
-        "sf.mm.s.s mt4, v0, v16\n"
-        "sf.mm.s.s mt8, v0, v24\n"
-        "j 6f\n"
+          "vle8.v v24, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v26, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v28, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v30, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
 
-        "5:\n" // k % 4 == 0
-        "sf.mm.s.s mt8, v0, v24\n"
+          "sf.mm.s.s mt4, v0, v16\n"
 
-        "6:\n"
-        : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
-          [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
-          [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [k] "+&r"(k)
-        : [sa] "r"(2 * rsa * sizeof(int8_t)),
-          [sb] "r"(2 * rsb0 * sizeof(int8_t)), [tm0] "r"(tm0), [tn0] "r"(tn0),
-          [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
-        : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
-          "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
-          "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30",
-          "v31", "vtype", "vl", "memory");
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+
+          "sf.mm.s.s mt8, v0, v24\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "bgeu %[k], %[i8], 0b\n"
+
+          "1:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+
+          "sf.mm.s.s mt0, v0, v8\n"
+
+          "vle8.v v24, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v26, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v28, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v30, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+
+          "sf.mm.s.s mt4, v0, v16\n"
+
+          "beq %[k], %[i2], 2f\n"
+          "beq %[k], %[i1], 3f\n"
+          "beqz %[k], 4f\n"
+
+          // k % 4 == 3
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "vle8.v v12, (%[b0_0])\n"
+
+          "sf.mm.s.s mt8, v0, v24\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "vle8.v v20, (%[b1_0])\n"
+
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.s.s mt0, v0, v8\n"
+
+          "vle8.v v24, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v26, (%[b2_1])\n"
+          "vle8.v v28, (%[b2_0])\n"
+
+          "sf.mm.s.s mt4, v0, v16\n"
+          "sf.mm.s.s mt8, v0, v24\n"
+          "j 5f\n"
+
+          "2:\n" // k % 4 == 2
+          "vle8.v v8, (%[b0_0])\n"
+          "vle8.v v10, (%[b0_1])\n"
+
+          "sf.mm.s.s mt8, v0, v24\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "vle8.v v16, (%[b1_0])\n"
+          "vle8.v v18, (%[b1_1])\n"
+
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.s.s mt0, v0, v8\n"
+
+          "vle8.v v24, (%[b2_0])\n"
+          "vle8.v v26, (%[b2_1])\n"
+
+          "sf.mm.s.s mt4, v0, v16\n"
+          "sf.mm.s.s mt8, v0, v24\n"
+          "j 5f\n"
+
+          "3:\n" // k % 4 == 1
+          "vle8.v v8, (%[b0_0])\n"
+
+          "sf.mm.s.s mt8, v0, v24\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "vle8.v v16, (%[b1_0])\n"
+
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.s.s mt0, v0, v8\n"
+
+          "vle8.v v24, (%[b2_0])\n"
+
+          "sf.mm.s.s mt4, v0, v16\n"
+          "sf.mm.s.s mt8, v0, v24\n"
+          "j 5f\n"
+
+          "4:\n" // k % 4 == 0
+          "sf.mm.s.s mt8, v0, v24\n"
+
+          "5:\n"
+          : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
+            [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
+            [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [k] "+&r"(k)
+          : [sa] "r"(2 * rsa * sizeof(int8_t)),
+            [sb] "r"(2 * rsb0 * sizeof(int8_t)), [tm0] "r"(tm0), [tn0] "r"(tn0),
+            [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
+          : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+            "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19",
+            "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28",
+            "v29", "v30", "v31", "vtype", "vl", "memory");
+    }
   }
 
   /* Store tiles to memory. */
@@ -1194,296 +1332,461 @@ SKL_FUNC_PRIVATE void skl_gemm_1tm4tn_4tm1tn_a1b01_i8c_i8_i32_xsfmm32a8i(
           "v13", "v16", "v17", "v18", "v19", "v20", "v21", "vtype", "vl",
           "memory");
   } else {
-    __asm__ volatile(
-        "sf.vsettnt x0, %[tn0], e8, w4\n"
-        "sf.vsettm x0, %[tm0]\n"
-        "sf.vsettk x0, %[k]\n"
+    if (tm0 == tn0) {
+      __asm__ volatile(
+          "sf.vsettnt x0, %[tn0], e8, w4\n"
+          "sf.vsettm x0, %[tm0]\n"
+          "sf.vsettk x0, %[k]\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v6, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
 
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
-        "vle8.v v12, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v14, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
 
-        "bltu %[k], %[i8], 2f\n"
-        "beq %[tm0], %[tn0], 1f\n"
+          "bltu %[k], %[i8], 1f\n"
 
-        "0:\n"
-        "addi %[k], %[k], -4\n"
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
-        "vle8.v v20, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v22, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
+          "0:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
 
-        "sf.mm.s.s mt0, v0, v8\n"
+          "sf.mm.s.s mt0, v0, v8\n"
 
-        "vle8.v v8, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v10, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
-        "vle8.v v12, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v14, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v8, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v10, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v12, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v14, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
 
-        "sf.mm.s.s mt4, v0, v16\n"
+          "sf.mm.s.s mt4, v0, v16\n"
 
-        "vle8.v v16, (%[b3_0])\n"
-        "add %[b3_0], %[b3_0], %[sb]\n"
-        "vle8.v v18, (%[b3_1])\n"
-        "add %[b3_1], %[b3_1], %[sb]\n"
-        "vle8.v v20, (%[b3_0])\n"
-        "add %[b3_0], %[b3_0], %[sb]\n"
-        "vle8.v v22, (%[b3_1])\n"
-        "add %[b3_1], %[b3_1], %[sb]\n"
+          "vle8.v v16, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v18, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
+          "vle8.v v20, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v22, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
 
-        "sf.mm.s.s mt8, v0, v8\n"
+          "sf.mm.s.s mt8, v0, v8\n"
 
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
-        "vle8.v v12, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v14, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
 
-        "sf.mm.s.s mt12, v0, v16\n"
+          "sf.mm.s.s mt12, v0, v16\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v6, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
 
-        "bgeu %[k], %[i8], 0b\n"
-        "j 2f\n"
+          "bgeu %[k], %[i8], 0b\n"
 
-        "1:\n"
-        "addi %[k], %[k], -4\n"
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
-        "vle8.v v20, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v22, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
+          "1:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
 
-        "sf.mm.s.s mt0, v0, v8\n"
+          "sf.mm.s.s mt0, v0, v8\n"
 
-        "vle8.v v8, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v10, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
-        "vle8.v v12, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v14, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v8, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v10, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v12, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v14, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
 
-        "sf.mm.s.s mt4, v0, v16\n"
+          "sf.mm.s.s mt4, v0, v16\n"
 
-        "vle8.v v16, (%[b3_0])\n"
-        "add %[b3_0], %[b3_0], %[sb]\n"
-        "vle8.v v18, (%[b3_1])\n"
-        "add %[b3_1], %[b3_1], %[sb]\n"
-        "vle8.v v20, (%[b3_0])\n"
-        "add %[b3_0], %[b3_0], %[sb]\n"
-        "vle8.v v22, (%[b3_1])\n"
-        "add %[b3_1], %[b3_1], %[sb]\n"
+          "vle8.v v16, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v18, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
+          "vle8.v v20, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v22, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
 
-        "sf.mm.s.s mt8, v0, v8\n"
+          "sf.mm.s.s mt8, v0, v8\n"
 
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
-        "vle8.v v12, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v14, (%[b0_1])\n"
-        "add %[b0_1], %[b0_1], %[sb]\n"
+          "beq %[k], %[i2], 2f\n"
+          "beq %[k], %[i1], 3f\n"
+          "beqz %[k], 4f\n"
 
-        "sf.mm.s.s mt12, v0, v16\n"
+          // k % 4 == 3
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "vle8.v v12, (%[b0_0])\n"
 
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v6, (%[a0_1])\n"
-        "add %[a0_1], %[a0_1], %[sa]\n"
+          "sf.mm.s.s mt12, v0, v16\n"
 
-        "bgeu %[k], %[i8], 1b\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "vle8.v v4, (%[a0_0])\n"
 
-        "2:\n"
-        "addi %[k], %[k], -4\n"
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
-        "vle8.v v20, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v22, (%[b1_1])\n"
-        "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "vle8.v v20, (%[b1_0])\n"
 
-        "sf.mm.s.s mt0, v0, v8\n"
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.s.s mt0, v0, v8\n"
 
-        "vle8.v v8, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v10, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
-        "vle8.v v12, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v14, (%[b2_1])\n"
-        "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v8, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v10, (%[b2_1])\n"
+          "vle8.v v12, (%[b2_0])\n"
 
-        "sf.mm.s.s mt4, v0, v16\n"
+          "sf.mm.s.s mt4, v0, v16\n"
 
-        "vle8.v v16, (%[b3_0])\n"
-        "add %[b3_0], %[b3_0], %[sb]\n"
-        "vle8.v v18, (%[b3_1])\n"
-        "add %[b3_1], %[b3_1], %[sb]\n"
-        "vle8.v v20, (%[b3_0])\n"
-        "add %[b3_0], %[b3_0], %[sb]\n"
-        "vle8.v v22, (%[b3_1])\n"
-        "add %[b3_1], %[b3_1], %[sb]\n"
+          "vle8.v v16, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v18, (%[b3_1])\n"
+          "vle8.v v20, (%[b3_0])\n"
 
-        "sf.mm.s.s mt8, v0, v8\n"
+          "sf.mm.s.s mt8, v0, v8\n"
+          "sf.mm.s.s mt12, v0, v16\n"
+          "j 5f\n"
 
-        "beq %[k], %[i2], 3f\n"
-        "beq %[k], %[i1], 4f\n"
-        "beqz %[k], 5f\n"
+          "2:\n" // k % 4 == 2
+          "vle8.v v8, (%[b0_0])\n"
+          "vle8.v v10, (%[b0_1])\n"
 
-        // k % 4 == 3
-        "vle8.v v8, (%[b0_0])\n"
-        "add %[b0_0], %[b0_0], %[sb]\n"
-        "vle8.v v10, (%[b0_1])\n"
-        "vle8.v v12, (%[b0_0])\n"
+          "sf.mm.s.s mt12, v0, v16\n"
 
-        "sf.mm.s.s mt12, v0, v16\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "vle8.v v2, (%[a0_1])\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "add %[a0_0], %[a0_0], %[sa]\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "vle8.v v4, (%[a0_0])\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "vle8.v v18, (%[b1_1])\n"
 
-        "vle8.v v16, (%[b1_0])\n"
-        "add %[b1_0], %[b1_0], %[sb]\n"
-        "vle8.v v18, (%[b1_1])\n"
-        "vle8.v v20, (%[b1_0])\n"
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.s.s mt0, v0, v8\n"
 
-        "sf.vsettk x0, %[k]\n"
-        "sf.mm.s.s mt0, v0, v8\n"
+          "vle8.v v8, (%[b2_0])\n"
+          "vle8.v v10, (%[b2_1])\n"
 
-        "vle8.v v8, (%[b2_0])\n"
-        "add %[b2_0], %[b2_0], %[sb]\n"
-        "vle8.v v10, (%[b2_1])\n"
-        "vle8.v v12, (%[b2_0])\n"
+          "sf.mm.s.s mt4, v0, v16\n"
 
-        "sf.mm.s.s mt4, v0, v16\n"
+          "vle8.v v16, (%[b3_0])\n"
+          "vle8.v v18, (%[b3_1])\n"
 
-        "vle8.v v16, (%[b3_0])\n"
-        "add %[b3_0], %[b3_0], %[sb]\n"
-        "vle8.v v18, (%[b3_1])\n"
-        "vle8.v v20, (%[b3_0])\n"
+          "sf.mm.s.s mt8, v0, v8\n"
+          "sf.mm.s.s mt12, v0, v16\n"
+          "j 5f\n"
 
-        "sf.mm.s.s mt8, v0, v8\n"
-        "sf.mm.s.s mt12, v0, v16\n"
-        "j 6f\n"
+          "3:\n" // k % 4 == 1
+          "vle8.v v8, (%[b0_0])\n"
 
-        "3:\n" // k % 4 == 2
-        "vle8.v v8, (%[b0_0])\n"
-        "vle8.v v10, (%[b0_1])\n"
+          "sf.mm.s.s mt12, v0, v16\n"
 
-        "sf.mm.s.s mt12, v0, v16\n"
+          "vle8.v v0, (%[a0_0])\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "vle8.v v2, (%[a0_1])\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v16, (%[b1_0])\n"
 
-        "vle8.v v16, (%[b1_0])\n"
-        "vle8.v v18, (%[b1_1])\n"
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.s.s mt0, v0, v8\n"
 
-        "sf.vsettk x0, %[k]\n"
-        "sf.mm.s.s mt0, v0, v8\n"
+          "vle8.v v8, (%[b2_0])\n"
 
-        "vle8.v v8, (%[b2_0])\n"
-        "vle8.v v10, (%[b2_1])\n"
+          "sf.mm.s.s mt4, v0, v16\n"
 
-        "sf.mm.s.s mt4, v0, v16\n"
+          "vle8.v v16, (%[b3_0])\n"
 
-        "vle8.v v16, (%[b3_0])\n"
-        "vle8.v v18, (%[b3_1])\n"
+          "sf.mm.s.s mt8, v0, v8\n"
+          "sf.mm.s.s mt12, v0, v16\n"
+          "j 5f\n"
 
-        "sf.mm.s.s mt8, v0, v8\n"
-        "sf.mm.s.s mt12, v0, v16\n"
-        "j 6f\n"
+          "4:\n" // k % 4 == 0
+          "sf.mm.s.s mt12, v0, v16\n"
 
-        "4:\n" // k % 4 == 1
-        "vle8.v v8, (%[b0_0])\n"
+          "5:\n"
+          : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
+            [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
+            [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [b3_0] "+&r"(b3_0),
+            [b3_1] "+&r"(b3_1), [k] "+&r"(k)
+          : [sa] "r"(2 * rsa * sizeof(int8_t)),
+            [sb] "r"(2 * rsb0 * sizeof(int8_t)), [tm0] "r"(tm0), [tn0] "r"(tn0),
+            [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
+          : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+            "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19",
+            "v20", "v21", "v22", "v23", "vtype", "vl", "memory");
+    } else { // tm0 != tn0
+      __asm__ volatile(
+          "sf.vsettnt x0, %[tn0], e8, w4\n"
+          "sf.vsettm x0, %[tm0]\n"
+          "sf.vsettk x0, %[k]\n"
 
-        "sf.mm.s.s mt12, v0, v16\n"
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "sf.vsettn x0, %[tn0]\n"
 
-        "sf.vsettn x0, %[tm0]\n"
-        "vle8.v v0, (%[a0_0])\n"
-        "sf.vsettn x0, %[tn0]\n"
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
 
-        "vle8.v v16, (%[b1_0])\n"
+          "bltu %[k], %[i8], 1f\n"
 
-        "sf.vsettk x0, %[k]\n"
-        "sf.mm.s.s mt0, v0, v8\n"
+          "0:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
 
-        "vle8.v v8, (%[b2_0])\n"
+          "sf.mm.s.s mt0, v0, v8\n"
 
-        "sf.mm.s.s mt4, v0, v16\n"
+          "vle8.v v8, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v10, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v12, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v14, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
 
-        "vle8.v v16, (%[b3_0])\n"
+          "sf.mm.s.s mt4, v0, v16\n"
 
-        "sf.mm.s.s mt8, v0, v8\n"
-        "sf.mm.s.s mt12, v0, v16\n"
-        "j 6f\n"
+          "vle8.v v16, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v18, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
+          "vle8.v v20, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v22, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
 
-        "5:\n" // k % 4 == 0
-        "sf.mm.s.s mt12, v0, v16\n"
+          "sf.mm.s.s mt8, v0, v8\n"
 
-        "6:\n"
-        : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
-          [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
-          [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [b3_0] "+&r"(b3_0),
-          [b3_1] "+&r"(b3_1), [k] "+&r"(k)
-        : [sa] "r"(2 * rsa * sizeof(int8_t)),
-          [sb] "r"(2 * rsb0 * sizeof(int8_t)), [tm0] "r"(tm0), [tn0] "r"(tn0),
-          [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
-        : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
-          "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
-          "v21", "v22", "v23", "vtype", "vl", "memory");
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+          "vle8.v v12, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v14, (%[b0_1])\n"
+          "add %[b0_1], %[b0_1], %[sb]\n"
+
+          "sf.mm.s.s mt12, v0, v16\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v6, (%[a0_1])\n"
+          "add %[a0_1], %[a0_1], %[sa]\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "bgeu %[k], %[i8], 0b\n"
+
+          "1:\n"
+          "addi %[k], %[k], -4\n"
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+          "vle8.v v20, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v22, (%[b1_1])\n"
+          "add %[b1_1], %[b1_1], %[sb]\n"
+
+          "sf.mm.s.s mt0, v0, v8\n"
+
+          "vle8.v v8, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v10, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+          "vle8.v v12, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v14, (%[b2_1])\n"
+          "add %[b2_1], %[b2_1], %[sb]\n"
+
+          "sf.mm.s.s mt4, v0, v16\n"
+
+          "vle8.v v16, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v18, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
+          "vle8.v v20, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v22, (%[b3_1])\n"
+          "add %[b3_1], %[b3_1], %[sb]\n"
+
+          "sf.mm.s.s mt8, v0, v8\n"
+
+          "beq %[k], %[i2], 2f\n"
+          "beq %[k], %[i1], 3f\n"
+          "beqz %[k], 4f\n"
+
+          // k % 4 == 3
+          "vle8.v v8, (%[b0_0])\n"
+          "add %[b0_0], %[b0_0], %[sb]\n"
+          "vle8.v v10, (%[b0_1])\n"
+          "vle8.v v12, (%[b0_0])\n"
+
+          "sf.mm.s.s mt12, v0, v16\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "add %[a0_0], %[a0_0], %[sa]\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "vle8.v v4, (%[a0_0])\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "vle8.v v16, (%[b1_0])\n"
+          "add %[b1_0], %[b1_0], %[sb]\n"
+          "vle8.v v18, (%[b1_1])\n"
+          "vle8.v v20, (%[b1_0])\n"
+
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.s.s mt0, v0, v8\n"
+
+          "vle8.v v8, (%[b2_0])\n"
+          "add %[b2_0], %[b2_0], %[sb]\n"
+          "vle8.v v10, (%[b2_1])\n"
+          "vle8.v v12, (%[b2_0])\n"
+
+          "sf.mm.s.s mt4, v0, v16\n"
+
+          "vle8.v v16, (%[b3_0])\n"
+          "add %[b3_0], %[b3_0], %[sb]\n"
+          "vle8.v v18, (%[b3_1])\n"
+          "vle8.v v20, (%[b3_0])\n"
+
+          "sf.mm.s.s mt8, v0, v8\n"
+          "sf.mm.s.s mt12, v0, v16\n"
+          "j 5f\n"
+
+          "2:\n" // k % 4 == 2
+          "vle8.v v8, (%[b0_0])\n"
+          "vle8.v v10, (%[b0_1])\n"
+
+          "sf.mm.s.s mt12, v0, v16\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "vle8.v v2, (%[a0_1])\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "vle8.v v16, (%[b1_0])\n"
+          "vle8.v v18, (%[b1_1])\n"
+
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.s.s mt0, v0, v8\n"
+
+          "vle8.v v8, (%[b2_0])\n"
+          "vle8.v v10, (%[b2_1])\n"
+
+          "sf.mm.s.s mt4, v0, v16\n"
+
+          "vle8.v v16, (%[b3_0])\n"
+          "vle8.v v18, (%[b3_1])\n"
+
+          "sf.mm.s.s mt8, v0, v8\n"
+          "sf.mm.s.s mt12, v0, v16\n"
+          "j 5f\n"
+
+          "3:\n" // k % 4 == 1
+          "vle8.v v8, (%[b0_0])\n"
+
+          "sf.mm.s.s mt12, v0, v16\n"
+
+          "sf.vsettn x0, %[tm0]\n"
+          "vle8.v v0, (%[a0_0])\n"
+          "sf.vsettn x0, %[tn0]\n"
+
+          "vle8.v v16, (%[b1_0])\n"
+
+          "sf.vsettk x0, %[k]\n"
+          "sf.mm.s.s mt0, v0, v8\n"
+
+          "vle8.v v8, (%[b2_0])\n"
+
+          "sf.mm.s.s mt4, v0, v16\n"
+
+          "vle8.v v16, (%[b3_0])\n"
+
+          "sf.mm.s.s mt8, v0, v8\n"
+          "sf.mm.s.s mt12, v0, v16\n"
+          "j 5f\n"
+
+          "4:\n" // k % 4 == 0
+          "sf.mm.s.s mt12, v0, v16\n"
+
+          "5:\n"
+          : [a0_0] "+&r"(a0_0), [a0_1] "+&r"(a0_1), [b0_0] "+&r"(b0_0),
+            [b0_1] "+&r"(b0_1), [b1_0] "+&r"(b1_0), [b1_1] "+&r"(b1_1),
+            [b2_0] "+&r"(b2_0), [b2_1] "+&r"(b2_1), [b3_0] "+&r"(b3_0),
+            [b3_1] "+&r"(b3_1), [k] "+&r"(k)
+          : [sa] "r"(2 * rsa * sizeof(int8_t)),
+            [sb] "r"(2 * rsb0 * sizeof(int8_t)), [tm0] "r"(tm0), [tn0] "r"(tn0),
+            [i1] "r"(1), [i2] "r"(2), [i8] "r"(8)
+          : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+            "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19",
+            "v20", "v21", "v22", "v23", "vtype", "vl", "memory");
+    }
   }
 
   /* Store tiles to memory. */


### PR DESCRIPTION
This PR fixes overlength string errors introduced by #32. #32 attempted to specialize the inner loops of the f8 and i8 Xsfmm GEMM kernels for the `tm0 == tn0` case by inserting the specialization directly into the inline assembly block, dispatching between the general and specialized versions using branch instructions. But, for the 1x3 and 1x4 kernels, this caused the inline assembly string to be too long. This PR addresses the issue by using a C `if` statement to dispatch between two versions of the inner loop inline asm block for the 1x3 and 1x4 kernels at the cost of increased code size.