### PR TITLE
[Test] SKL_TEST_INIT_I{8,32} and use in GEMM tests

### DIFF
--- a/test/gemm/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c
+++ b/test/gemm/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c
@@ -154,10 +154,10 @@ int main(void) {
   printf("RSB1 = %u\n", RSB1);
 
   /* Populate the matrices. */
-  skl_test_init_i8(a, ALEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
-  skl_test_init_i8(b, BLEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
-  skl_test_init_i8(b_pack, BLEN_PACKED, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
-  skl_test_init_i32(c, CLEN, SKL_TEST_MIN_I32, SKL_TEST_MAX_I32);
+  SKL_TEST_INIT_I8(a, ALEN);
+  SKL_TEST_INIT_I8(b, BLEN);
+  SKL_TEST_INIT_I8(b_pack, BLEN_PACKED);
+  SKL_TEST_INIT_I32(c, CLEN);
 
   skl_pack_b_i8_xsfvqdotq(K, N, b, (size_t)RSB, b_pack, (size_t)RSB1);
 

--- a/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
+++ b/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
@@ -276,9 +276,9 @@ int main(void) {
   printf("RSC = %u, CSC = %u\n", RSC, CSC);
 
   /* Populate the matrices. */
-  skl_test_init_i8((int8_t *)a, ALEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
-  skl_test_init_i8((int8_t *)b, BLEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
-  skl_test_init_f32(c, CLEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
+  SKL_TEST_INIT_I8((int8_t *)a, ALEN);
+  SKL_TEST_INIT_I8((int8_t *)b, BLEN);
+  SKL_TEST_INIT_F32(c, CLEN);
 
 #if defined(ENABLE_TEST)
   /* Make copies of C to write the reference and test outputs to. */

--- a/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -330,9 +330,9 @@ int main(void) {
          CSC1);
 
   /* Populate the matrices. */
-  skl_test_init_i8((int8_t *)a, ALEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
-  skl_test_init_i8((int8_t *)b, BLEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
-  skl_test_init_f32(c, CLEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
+  SKL_TEST_INIT_I8((int8_t *)a, ALEN);
+  SKL_TEST_INIT_I8((int8_t *)b, BLEN);
+  SKL_TEST_INIT_F32(c, CLEN);
 
 #if defined(ENABLE_TEST)
   /* Make copies of C to write the reference and test outputs to. */

--- a/test/gemm/gemm_i8rc_i8rc_i32rc.c
+++ b/test/gemm/gemm_i8rc_i8rc_i32rc.c
@@ -158,9 +158,9 @@ int main(void) {
   printf("RSC = %u, CSC = %u\n", RSC, CSC);
 
   /* Populate the matrices. */
-  skl_test_init_i8(a, ALEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
-  skl_test_init_i8(b, BLEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
-  skl_test_init_i32(c, CLEN, SKL_TEST_MIN_I32, SKL_TEST_MAX_I32);
+  SKL_TEST_INIT_I8(a, ALEN);
+  SKL_TEST_INIT_I8(b, BLEN);
+  SKL_TEST_INIT_I32(c, CLEN);
 
 #if defined(ENABLE_TEST)
   /* Make copies of C to write the reference and test outputs to. */

--- a/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -243,9 +243,9 @@ int main(void) {
          CSC1);
 
   /* Populate the matrices. */
-  skl_test_init_i8(a, ALEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
-  skl_test_init_i8(b, BLEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
-  skl_test_init_i32(c, CLEN, SKL_TEST_MIN_I32, SKL_TEST_MAX_I32);
+  SKL_TEST_INIT_I8(a, ALEN);
+  SKL_TEST_INIT_I8(b, BLEN);
+  SKL_TEST_INIT_I32(c, CLEN);
 
 #if defined(ENABLE_TEST)
   /* Make copies of C to write the reference and test outputs to. */

--- a/test/gemm/pack_b_i8_xsfvqdotq.c
+++ b/test/gemm/pack_b_i8_xsfvqdotq.c
@@ -137,8 +137,8 @@ int main(void) {
   printf("RSB = %u, RSB1 = %u\n", RSB, RSB1);
 
   /* Populate the matrices. */
-  skl_test_init_i8(b, BLEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
-  skl_test_init_i8(b_pack, BLEN_PACKED, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
+  SKL_TEST_INIT_I8(b, BLEN);
+  SKL_TEST_INIT_I8(b_pack, BLEN_PACKED);
 
 #if defined(ENABLE_TEST)
   memcpy(ref_b_pack, b_pack, BLEN_PACKED * sizeof(int8_t));

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -833,6 +833,12 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
 #define SKL_TEST_INIT_F64(BUF, LEN)                                            \
   SKL_TEST_INIT(BUF, LEN, double, F64, FLOAT, double)
 
+#define SKL_TEST_INIT_I8(BUF, LEN)                                             \
+  SKL_TEST_INIT(BUF, LEN, int8_t, I8, INT, unused)
+
+#define SKL_TEST_INIT_I32(BUF, LEN)                                            \
+  SKL_TEST_INIT(BUF, LEN, int32_t, I32, INT, unused)
+
 /** @} */ // end of test_init_macros group
 
 /**


### PR DESCRIPTION
In furtherance of the work begun in https://github.com/sifive/skl/pull/34, this PR adds the signed-integer `SKL_TEST_INIT_I8` and `SKL_TEST_INIT_I32` macros to `test/skl-test.h`, and converts all int-typed GEMM kernel test harnesses to use them.