### PR TITLE
[Test] SKL_TEST_LOG() and use in SKL_TEST_INIT

### DIFF
--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -14,7 +14,11 @@
 #include <string.h>
 
 #if defined(SKL_TEST_LOG_LEVEL) && SKL_TEST_LOG_LEVEL >= 1
-#define SKL_TEST_LOG(...) printf(__VA_ARGS__)
+#define SKL_TEST_LOG(...)                                                      \
+  {                                                                            \
+    printf("SKL TEST: ");                                                      \
+    printf(__VA_ARGS__);                                                       \
+  }
 #else
 #define SKL_TEST_LOG(...) ((void)0)
 #endif
@@ -791,9 +795,8 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
     const size_t len = (LEN);                                                  \
     size_t avl = len;                                                          \
     const size_t buf_len = SKL_TEST_STATIC_DATA_LEN(BUF);                      \
-    SKL_TEST_LOG("Initializing buffer %s (%p - len %zu) with static data (%p " \
-                 "- len %zu)\n",                                               \
-                 #BUF, (void *)buf, len, (void *)SKL_TEST_STATIC_DATA(BUF),    \
+    SKL_TEST_LOG("Init %s (%p +%zu): static data (%p + %zu)\n", #BUF,          \
+                 (void *)buf, len, (void *)SKL_TEST_STATIC_DATA(BUF),          \
                  buf_len);                                                     \
     while (avl > 0) {                                                          \
       size_t vl = avl > buf_len ? buf_len : avl;                               \
@@ -810,10 +813,8 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
     const TYPE min = (SKL_TEST_MIN_##MSUFFIX);                                 \
     const TYPE max = (SKL_TEST_MAX_##MSUFFIX);                                 \
     const TYPE step = (max - min) / len;                                       \
-    SKL_TEST_LOG("Initializing buffer %s (%p - len %zu) with min %f, max %f "  \
-                 "(mode %d)\n",                                                \
-                 #BUF, (void *)buf, len, (double)min, (double)max,             \
-                 TEST_INIT_MODE);                                              \
+    SKL_TEST_LOG("Init %s (%p +%zu): range %f - %f (mode %d)\n", #BUF,         \
+                 (void *)buf, len, (double)min, (double)max, TEST_INIT_MODE);  \
     for (size_t i = 0; i < len; i++) {                                         \
       if (TEST_INIT_MODE == RANDOM) {                                          \
         SKL_TEST_INIT_RANDOM_IMPL_##IMPL_TYPE(TYPE, FRAC_TYPE);                \

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -13,6 +13,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(SKL_TEST_LOG_LEVEL) && SKL_TEST_LOG_LEVEL >= 1
+#define SKL_TEST_LOG(...) printf(__VA_ARGS__)
+#else
+#define SKL_TEST_LOG(...) ((void)0)
+#endif
+
 /* Extract the test name from SKL_TEST_NAME as a string. */
 #define SKL_TEST_NAME_STR(NAME) #NAME
 #define DECL_SKL_TEST_NAME(NAME)                                               \
@@ -785,6 +791,10 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
     const size_t len = (LEN);                                                  \
     size_t avl = len;                                                          \
     const size_t buf_len = SKL_TEST_STATIC_DATA_LEN(BUF);                      \
+    SKL_TEST_LOG("Initializing buffer %s (%p - len %zu) with static data (%p " \
+                 "- len %zu)\n",                                               \
+                 #BUF, (void *)buf, len, (void *)SKL_TEST_STATIC_DATA(BUF),    \
+                 buf_len);                                                     \
     while (avl > 0) {                                                          \
       size_t vl = avl > buf_len ? buf_len : avl;                               \
       memcpy(buf, SKL_TEST_STATIC_DATA(BUF), vl * sizeof(TYPE));               \
@@ -800,6 +810,10 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
     const TYPE min = (SKL_TEST_MIN_##MSUFFIX);                                 \
     const TYPE max = (SKL_TEST_MAX_##MSUFFIX);                                 \
     const TYPE step = (max - min) / len;                                       \
+    SKL_TEST_LOG("Initializing buffer %s (%p - len %zu) with min %f, max %f "  \
+                 "(mode %d)\n",                                                \
+                 #BUF, (void *)buf, len, (double)min, (double)max,             \
+                 TEST_INIT_MODE);                                              \
     for (size_t i = 0; i < len; i++) {                                         \
       if (TEST_INIT_MODE == RANDOM) {                                          \
         SKL_TEST_INIT_RANDOM_IMPL_##IMPL_TYPE(TYPE, FRAC_TYPE);                \


### PR DESCRIPTION
For debugging purposes it is often useful to have some logging output from the test harnesses. This adds `SKL_TEST_LOG`, which is a wrapper around `printf` that can be enabled or disabled depending on whether `SKL_TEST_LOG_LEVEL` is defined (and > 0).

As an initial use case, it is added to the two `SKL_TEST_INIT` macro definitions to indicate which initialization mode and other parameters were configured.  For example, in a GEMM benchmark:
```
SKL TEST: Init a (0x0000000040000000 +256): range 0.000000 - 1.000000 (mode 1)
SKL TEST: Init b (0x0000000040001000 +256): range 0.000000 - 1.000000 (mode 1)
SKL TEST: Init c (0x0000000040002000 +256): range 0.000000 - 1.000000 (mode 1)
```