### PR TITLE
[Test] Rename to SKL_TEST_MEMALIGN

### DIFF
--- a/test/gemm/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c
+++ b/test/gemm/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c
@@ -95,10 +95,18 @@ enum {
   BLEN_PACKED = K1 * RSB1,
 };
 
+#if defined(SKL_TEST_MEMALIGN)
+int8_t *a;
+int8_t *b;
+int8_t *b_pack;
+int32_t *c;
+#else
 _Alignas(ALIGN) int8_t a[ALEN];
 _Alignas(ALIGN) int8_t b[BLEN];
 _Alignas(ALIGN) int8_t b_pack[BLEN_PACKED];
 _Alignas(ALIGN) int32_t c[CLEN];
+#endif
+
 #if defined(ENABLE_TEST)
 _Alignas(ALIGN) int32_t ref_c[CLEN];
 _Alignas(ALIGN) int32_t test_c[CLEN];
@@ -153,6 +161,13 @@ int main(void) {
   printf("RSA = %u, RSB = %u, RSC = %u\n", RSA, RSB, RSC);
   printf("RSB1 = %u\n", RSB1);
 
+#if defined(SKL_TEST_MEMALIGN)
+  a = (int8_t *)SKL_TEST_MEMALIGN(ALIGN, ALEN * sizeof(int8_t));
+  b = (int8_t *)SKL_TEST_MEMALIGN(ALIGN, BLEN * sizeof(int8_t));
+  b_pack = (int8_t *)SKL_TEST_MEMALIGN(ALIGN, BLEN_PACKED * sizeof(int8_t));
+  c = (int32_t *)SKL_TEST_MEMALIGN(ALIGN, CLEN * sizeof(int32_t));
+#endif
+
   /* Populate the matrices. */
   skl_test_init_i8(a, ALEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
   skl_test_init_i8(b, BLEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
@@ -175,6 +190,13 @@ int main(void) {
                     SKL_TEST_WARMUP, skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq, M, N,
                     K, a, (size_t)RSA, b_pack, (size_t)RSB1, c, (size_t)RSC,
                     ACCUM);
+
+#if defined(SKL_TEST_MEMALIGN) && defined(SKL_TEST_FREE)
+  SKL_TEST_FREE(a);
+  SKL_TEST_FREE(b);
+  SKL_TEST_FREE(b_pack);
+  SKL_TEST_FREE(c);
+#endif
 
   return res;
 }

--- a/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
+++ b/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
@@ -102,9 +102,17 @@ enum {
   ALEN = ((M - 1) * RSA + (K - 1) * CSA + 1),
   BLEN = ((K - 1) * RSB + (N - 1) * CSB + 1),
 };
+
+#if defined(SKL_TEST_MEMALIGN)
+__bf16 *a;
+__bf16 *b;
+float *c;
+#else
 _Alignas(ALIGN) __bf16 a[ALEN];
 _Alignas(ALIGN) __bf16 b[BLEN];
 _Alignas(ALIGN) float c[CLEN];
+#endif
+
 #if defined(ENABLE_TEST)
 double a_wide[ALEN];
 double b_wide[BLEN];
@@ -182,6 +190,12 @@ int main(void) {
   printf("RSB = %u, CSB = %u\n", RSB, CSB);
   printf("RSC = %u, CSC = %u\n", RSC, CSC);
 
+#if defined(SKL_TEST_MEMALIGN)
+  a = (__bf16 *)SKL_TEST_MEMALIGN(ALIGN, ALEN * sizeof(__bf16));
+  b = (__bf16 *)SKL_TEST_MEMALIGN(ALIGN, BLEN * sizeof(__bf16));
+  c = (float *)SKL_TEST_MEMALIGN(ALIGN, CLEN * sizeof(float));
+#endif
+
   /* Populate the matrices. */
   skl_test_init_bf16(a, ALEN, SKL_TEST_MIN_BF16, SKL_TEST_MAX_BF16);
   skl_test_init_bf16(b, BLEN, SKL_TEST_MIN_BF16, SKL_TEST_MAX_BF16);
@@ -198,6 +212,12 @@ int main(void) {
 
   SKL_BENCHMARK_RUN(skl_test_name, M * N * K, SKL_TEST_WARMUP, SKL_TEST_NAME, M,
                     N, K, ALPHA, a, RSA, CSA, b, RSB, CSB, BETA, c, RSC, CSC);
+
+#if defined(SKL_TEST_MEMALIGN) && defined(SKL_TEST_FREE)
+  SKL_TEST_FREE(a);
+  SKL_TEST_FREE(b);
+  SKL_TEST_FREE(c);
+#endif
 
   return res;
 }

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -158,9 +158,17 @@ enum {
           (N0 - 1) * CSB0 + 1),
   // NOLINTEND(misc-redundant-expression)
 };
+
+#if defined(SKL_TEST_MEMALIGN)
+__bf16 *a;
+__bf16 *b;
+float *c;
+#else
 _Alignas(ALIGN) __bf16 a[ALEN];
 _Alignas(ALIGN) __bf16 b[BLEN];
 _Alignas(ALIGN) float c[CLEN];
+#endif
+
 #if defined(ENABLE_TEST)
 double a_wide[ALEN];
 double b_wide[BLEN];
@@ -251,6 +259,12 @@ int main(void) {
   printf("RSC0 = %u, CSC0 = %u, RSC1 = %u, CSC1 = %u\n", RSC0, CSC0, RSC1,
          CSC1);
 
+#if defined(SKL_TEST_MEMALIGN)
+  a = (__bf16 *)SKL_TEST_MEMALIGN(ALIGN, ALEN * sizeof(__bf16));
+  b = (__bf16 *)SKL_TEST_MEMALIGN(ALIGN, BLEN * sizeof(__bf16));
+  c = (float *)SKL_TEST_MEMALIGN(ALIGN, CLEN * sizeof(float));
+#endif
+
   /* Populate the matrices. */
   skl_test_init_bf16(a, ALEN, SKL_TEST_MIN_BF16, SKL_TEST_MAX_BF16);
   skl_test_init_bf16(b, BLEN, SKL_TEST_MIN_BF16, SKL_TEST_MAX_BF16);
@@ -271,6 +285,12 @@ int main(void) {
                     (size_t)RSA1, (size_t)CSA1, b, RSB0, CSB0, (size_t)RSB1,
                     (size_t)CSB1, BETA, c, RSC0, CSC0, (size_t)RSC1,
                     (size_t)CSC1);
+
+#if defined(SKL_TEST_MEMALIGN) && defined(SKL_TEST_FREE)
+  SKL_TEST_FREE(a);
+  SKL_TEST_FREE(b);
+  SKL_TEST_FREE(c);
+#endif
 
   return res;
 }

--- a/test/gemm/gemm_f16rc_f16rc_f16rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f16rc.c
@@ -99,9 +99,17 @@ enum {
   ALEN = ((M - 1) * RSA + (K - 1) * CSA + 1),
   BLEN = ((K - 1) * RSB + (N - 1) * CSB + 1),
 };
+
+#if defined(SKL_TEST_MEMALIGN)
+_Float16 *a;
+_Float16 *b;
+_Float16 *c;
+#else
 _Alignas(ALIGN) _Float16 a[ALEN];
 _Alignas(ALIGN) _Float16 b[BLEN];
 _Alignas(ALIGN) _Float16 c[CLEN];
+#endif
+
 #if defined(ENABLE_TEST)
 float a_wide[ALEN];
 float b_wide[BLEN];
@@ -179,6 +187,12 @@ int main(void) {
   printf("RSB = %u, CSB = %u\n", RSB, CSB);
   printf("RSC = %u, CSC = %u\n", RSC, CSC);
 
+#if defined(SKL_TEST_MEMALIGN)
+  a = (_Float16 *)SKL_TEST_MEMALIGN(ALIGN, ALEN * sizeof(_Float16));
+  b = (_Float16 *)SKL_TEST_MEMALIGN(ALIGN, BLEN * sizeof(_Float16));
+  c = (_Float16 *)SKL_TEST_MEMALIGN(ALIGN, CLEN * sizeof(_Float16));
+#endif
+
   /* Populate the matrices. */
   skl_test_init_f16(a, ALEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
   skl_test_init_f16(b, BLEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
@@ -195,6 +209,12 @@ int main(void) {
 
   SKL_BENCHMARK_RUN(skl_test_name, M * N * K, SKL_TEST_WARMUP, SKL_TEST_NAME, M,
                     N, K, ALPHA, a, RSA, CSA, b, RSB, CSB, BETA, c, RSC, CSC);
+
+#if defined(SKL_TEST_MEMALIGN) && defined(SKL_TEST_FREE)
+  SKL_TEST_FREE(a);
+  SKL_TEST_FREE(b);
+  SKL_TEST_FREE(c);
+#endif
 
   return res;
 }

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -120,9 +120,17 @@ enum {
   ALEN = ((M - 1) * RSA + (K - 1) * CSA + 1),
   BLEN = ((K - 1) * RSB + (N - 1) * CSB + 1),
 };
+
+#if defined(SKL_TEST_MEMALIGN)
+_Float16 *a;
+_Float16 *b;
+float *c;
+#else
 _Alignas(ALIGN) _Float16 a[ALEN];
 _Alignas(ALIGN) _Float16 b[BLEN];
 _Alignas(ALIGN) float c[CLEN];
+#endif
+
 #if defined(ENABLE_TEST)
 double a_wide[ALEN];
 double b_wide[BLEN];
@@ -200,6 +208,12 @@ int main(void) {
   printf("RSB = %u, CSB = %u\n", RSB, CSB);
   printf("RSC = %u, CSC = %u\n", RSC, CSC);
 
+#if defined(SKL_TEST_MEMALIGN)
+  a = (_Float16 *)SKL_TEST_MEMALIGN(ALIGN, ALEN * sizeof(_Float16));
+  b = (_Float16 *)SKL_TEST_MEMALIGN(ALIGN, BLEN * sizeof(_Float16));
+  c = (float *)SKL_TEST_MEMALIGN(ALIGN, CLEN * sizeof(float));
+#endif
+
   /* Populate the matrices. */
   skl_test_init_f16(a, ALEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
   skl_test_init_f16(b, BLEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
@@ -216,6 +230,12 @@ int main(void) {
 
   SKL_BENCHMARK_RUN(skl_test_name, M * N * K, SKL_TEST_WARMUP, SKL_TEST_NAME, M,
                     N, K, ALPHA, a, RSA, CSA, b, RSB, CSB, BETA, c, RSC, CSC);
+
+#if defined(SKL_TEST_MEMALIGN) && defined(SKL_TEST_FREE)
+  SKL_TEST_FREE(a);
+  SKL_TEST_FREE(b);
+  SKL_TEST_FREE(c);
+#endif
 
   return res;
 }

--- a/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -158,9 +158,17 @@ enum {
           (N0 - 1) * CSB0 + 1),
   // NOLINTEND(misc-redundant-expression)
 };
+
+#if defined(SKL_TEST_MEMALIGN)
+_Float16 *a;
+_Float16 *b;
+float *c;
+#else
 _Alignas(ALIGN) _Float16 a[ALEN];
 _Alignas(ALIGN) _Float16 b[BLEN];
 _Alignas(ALIGN) float c[CLEN];
+#endif
+
 #if defined(ENABLE_TEST)
 double a_wide[ALEN];
 double b_wide[BLEN];
@@ -251,6 +259,12 @@ int main(void) {
   printf("RSC0 = %u, CSC0 = %u, RSC1 = %u, CSC1 = %u\n", RSC0, CSC0, RSC1,
          CSC1);
 
+#if defined(SKL_TEST_MEMALIGN)
+  a = (_Float16 *)SKL_TEST_MEMALIGN(ALIGN, ALEN * sizeof(_Float16));
+  b = (_Float16 *)SKL_TEST_MEMALIGN(ALIGN, BLEN * sizeof(_Float16));
+  c = (float *)SKL_TEST_MEMALIGN(ALIGN, CLEN * sizeof(float));
+#endif
+
   /* Populate the matrices. */
   skl_test_init_f16(a, ALEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
   skl_test_init_f16(b, BLEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
@@ -271,6 +285,12 @@ int main(void) {
                     (size_t)RSA1, (size_t)CSA1, b, RSB0, CSB0, (size_t)RSB1,
                     (size_t)CSB1, BETA, c, RSC0, CSC0, (size_t)RSC1,
                     (size_t)CSC1);
+
+#if defined(SKL_TEST_MEMALIGN) && defined(SKL_TEST_FREE)
+  SKL_TEST_FREE(a);
+  SKL_TEST_FREE(b);
+  SKL_TEST_FREE(c);
+#endif
 
   return res;
 }

--- a/test/gemm/gemm_f32rc_f32rc_f32rc.c
+++ b/test/gemm/gemm_f32rc_f32rc_f32rc.c
@@ -137,7 +137,7 @@ enum {
   BLEN = ((K - 1) * RSB + (N - 1) * CSB + 1),
 };
 
-#if defined(SKL_TEST_MALLOC)
+#if defined(SKL_TEST_MEMALIGN)
 float *a;
 float *b;
 float *c;
@@ -217,10 +217,10 @@ int check_error(void) {
 int main(void) {
   int res = EXIT_SUCCESS;
 
-#if defined(SKL_TEST_MALLOC)
-  a = (float *)SKL_TEST_MALLOC(ALIGN, ALEN * sizeof(float));
-  b = (float *)SKL_TEST_MALLOC(ALIGN, BLEN * sizeof(float));
-  c = (float *)SKL_TEST_MALLOC(ALIGN, CLEN * sizeof(float));
+#if defined(SKL_TEST_MEMALIGN)
+  a = (float *)SKL_TEST_MEMALIGN(ALIGN, ALEN * sizeof(float));
+  b = (float *)SKL_TEST_MEMALIGN(ALIGN, BLEN * sizeof(float));
+  c = (float *)SKL_TEST_MEMALIGN(ALIGN, CLEN * sizeof(float));
 #endif
 
   printf("%s:\n", skl_test_name);
@@ -248,7 +248,7 @@ int main(void) {
   SKL_BENCHMARK_RUN(skl_test_name, M * N * K, SKL_TEST_WARMUP, SKL_TEST_NAME, M,
                     N, K, ALPHA, a, RSA, CSA, b, RSB, CSB, BETA, c, RSC, CSC);
 
-#if defined(SKL_TEST_MALLOC) && defined(SKL_TEST_FREE)
+#if defined(SKL_TEST_MEMALIGN) && defined(SKL_TEST_FREE)
   SKL_TEST_FREE(a);
   SKL_TEST_FREE(b);
   SKL_TEST_FREE(c);

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -158,9 +158,17 @@ enum {
           (N0 - 1) * CSB0 + 1),
   // NOLINTEND(misc-redundant-expression)
 };
+
+#if defined(SKL_TEST_MEMALIGN)
+float *a;
+float *b;
+float *c;
+#else
 _Alignas(ALIGN) float a[ALEN];
 _Alignas(ALIGN) float b[BLEN];
 _Alignas(ALIGN) float c[CLEN];
+#endif
+
 #if defined(ENABLE_TEST)
 double a_wide[ALEN];
 double b_wide[BLEN];
@@ -251,6 +259,12 @@ int main(void) {
   printf("RSC0 = %u, CSC0 = %u, RSC1 = %u, CSC1 = %u\n", RSC0, CSC0, RSC1,
          CSC1);
 
+#if defined(SKL_TEST_MEMALIGN)
+  a = (float *)SKL_TEST_MEMALIGN(ALIGN, ALEN * sizeof(float));
+  b = (float *)SKL_TEST_MEMALIGN(ALIGN, BLEN * sizeof(float));
+  c = (float *)SKL_TEST_MEMALIGN(ALIGN, CLEN * sizeof(float));
+#endif
+
   /* Populate the matrices. */
   skl_test_init_f32(a, ALEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
   skl_test_init_f32(b, BLEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
@@ -271,6 +285,12 @@ int main(void) {
                     (size_t)RSA1, (size_t)CSA1, b, RSB0, CSB0, (size_t)RSB1,
                     (size_t)CSB1, BETA, c, RSC0, CSC0, (size_t)RSC1,
                     (size_t)CSC1);
+
+#if defined(SKL_TEST_MEMALIGN) && defined(SKL_TEST_FREE)
+  SKL_TEST_FREE(a);
+  SKL_TEST_FREE(b);
+  SKL_TEST_FREE(c);
+#endif
 
   return res;
 }

--- a/test/gemm/gemm_f64rc_f64rc_f64rc.c
+++ b/test/gemm/gemm_f64rc_f64rc_f64rc.c
@@ -100,9 +100,17 @@ enum {
   ALEN = ((M - 1) * RSA + (K - 1) * CSA + 1),
   BLEN = ((K - 1) * RSB + (N - 1) * CSB + 1),
 };
+
+#if defined(SKL_TEST_MEMALIGN)
+double *a;
+double *b;
+double *c;
+#else
 _Alignas(ALIGN) double a[ALEN];
 _Alignas(ALIGN) double b[BLEN];
 _Alignas(ALIGN) double c[CLEN];
+#endif
+
 #if defined(ENABLE_TEST)
 long double a_wide[ALEN];
 long double b_wide[BLEN];
@@ -181,6 +189,12 @@ int main(void) {
   printf("RSB = %u, CSB = %u\n", RSB, CSB);
   printf("RSC = %u, CSC = %u\n", RSC, CSC);
 
+#if defined(SKL_TEST_MEMALIGN)
+  a = (double *)SKL_TEST_MEMALIGN(ALIGN, ALEN * sizeof(double));
+  b = (double *)SKL_TEST_MEMALIGN(ALIGN, BLEN * sizeof(double));
+  c = (double *)SKL_TEST_MEMALIGN(ALIGN, CLEN * sizeof(double));
+#endif
+
   /* Populate the matrices. */
   skl_test_init_f64(a, ALEN, SKL_TEST_MIN_F64, SKL_TEST_MAX_F64);
   skl_test_init_f64(b, BLEN, SKL_TEST_MIN_F64, SKL_TEST_MAX_F64);
@@ -197,6 +211,12 @@ int main(void) {
 
   SKL_BENCHMARK_RUN(skl_test_name, M * N * K, SKL_TEST_WARMUP, SKL_TEST_NAME, M,
                     N, K, ALPHA, a, RSA, CSA, b, RSB, CSB, BETA, c, RSC, CSC);
+
+#if defined(SKL_TEST_MEMALIGN) && defined(SKL_TEST_FREE)
+  SKL_TEST_FREE(a);
+  SKL_TEST_FREE(b);
+  SKL_TEST_FREE(c);
+#endif
 
   return res;
 }

--- a/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
+++ b/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
@@ -113,9 +113,17 @@ enum {
   ALEN = ((M - 1) * RSA + (K - 1) * CSA + 1),
   BLEN = ((K - 1) * RSB + (N - 1) * CSB + 1),
 };
+
+#if defined(SKL_TEST_MEMALIGN)
+uint8_t *a;
+uint8_t *b;
+float *c;
+#else
 _Alignas(ALIGN) uint8_t a[ALEN];
 _Alignas(ALIGN) uint8_t b[BLEN];
 _Alignas(ALIGN) float c[CLEN];
+#endif
+
 #if defined(ENABLE_TEST)
 double a_wide[ALEN];
 double b_wide[BLEN];
@@ -275,6 +283,12 @@ int main(void) {
   printf("RSB = %u, CSB = %u\n", RSB, CSB);
   printf("RSC = %u, CSC = %u\n", RSC, CSC);
 
+#if defined(SKL_TEST_MEMALIGN)
+  a = (uint8_t *)SKL_TEST_MEMALIGN(ALIGN, ALEN * sizeof(uint8_t));
+  b = (uint8_t *)SKL_TEST_MEMALIGN(ALIGN, BLEN * sizeof(uint8_t));
+  c = (float *)SKL_TEST_MEMALIGN(ALIGN, CLEN * sizeof(float));
+#endif
+
   /* Populate the matrices. */
   skl_test_init_i8((int8_t *)a, ALEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
   skl_test_init_i8((int8_t *)b, BLEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
@@ -291,6 +305,12 @@ int main(void) {
 
   SKL_BENCHMARK_RUN(skl_test_name, M * N * K, SKL_TEST_WARMUP, SKL_TEST_NAME, M,
                     N, K, ALPHA, a, RSA, CSA, b, RSB, CSB, BETA, c, RSC, CSC);
+
+#if defined(SKL_TEST_MEMALIGN) && defined(SKL_TEST_FREE)
+  SKL_TEST_FREE(a);
+  SKL_TEST_FREE(b);
+  SKL_TEST_FREE(c);
+#endif
 
   return res;
 }

--- a/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -168,9 +168,17 @@ enum {
           (N0 - 1) * CSB0 + 1),
   // NOLINTEND(misc-redundant-expression)
 };
+
+#if defined(SKL_TEST_MEMALIGN)
+uint8_t *a;
+uint8_t *b;
+float *c;
+#else
 _Alignas(ALIGN) uint8_t a[ALEN];
 _Alignas(ALIGN) uint8_t b[BLEN];
 _Alignas(ALIGN) float c[CLEN];
+#endif
+
 #if defined(ENABLE_TEST)
 double a_wide[ALEN];
 double b_wide[BLEN];
@@ -329,6 +337,12 @@ int main(void) {
   printf("RSC0 = %u, CSC0 = %u, RSC1 = %u, CSC1 = %u\n", RSC0, CSC0, RSC1,
          CSC1);
 
+#if defined(SKL_TEST_MEMALIGN)
+  a = (uint8_t *)SKL_TEST_MEMALIGN(ALIGN, ALEN * sizeof(uint8_t));
+  b = (uint8_t *)SKL_TEST_MEMALIGN(ALIGN, BLEN * sizeof(uint8_t));
+  c = (float *)SKL_TEST_MEMALIGN(ALIGN, CLEN * sizeof(float));
+#endif
+
   /* Populate the matrices. */
   skl_test_init_i8((int8_t *)a, ALEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
   skl_test_init_i8((int8_t *)b, BLEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
@@ -349,6 +363,12 @@ int main(void) {
                     (size_t)RSA1, (size_t)CSA1, b, RSB0, CSB0, (size_t)RSB1,
                     (size_t)CSB1, BETA, c, RSC0, CSC0, (size_t)RSC1,
                     (size_t)CSC1);
+
+#if defined(SKL_TEST_MEMALIGN) && defined(SKL_TEST_FREE)
+  SKL_TEST_FREE(a);
+  SKL_TEST_FREE(b);
+  SKL_TEST_FREE(c);
+#endif
 
   return res;
 }

--- a/test/gemm/gemm_i8rc_i8rc_i32rc.c
+++ b/test/gemm/gemm_i8rc_i8rc_i32rc.c
@@ -114,9 +114,17 @@ enum {
   ALEN = ((M - 1) * RSA + (K - 1) * CSA + 1),
   BLEN = ((K - 1) * RSB + (N - 1) * CSB + 1),
 };
+
+#if defined(SKL_TEST_MEMALIGN)
+int8_t *a;
+int8_t *b;
+int32_t *c;
+#else
 _Alignas(ALIGN) int8_t a[ALEN];
 _Alignas(ALIGN) int8_t b[BLEN];
 _Alignas(ALIGN) int32_t c[CLEN];
+#endif
+
 #if defined(ENABLE_TEST)
 int32_t ref_c[CLEN], test_c[CLEN];
 #endif // ENABLE_TEST
@@ -157,6 +165,12 @@ int main(void) {
   printf("RSB = %u, CSB = %u\n", RSB, CSB);
   printf("RSC = %u, CSC = %u\n", RSC, CSC);
 
+#if defined(SKL_TEST_MEMALIGN)
+  a = (int8_t *)SKL_TEST_MEMALIGN(ALIGN, ALEN * sizeof(int8_t));
+  b = (int8_t *)SKL_TEST_MEMALIGN(ALIGN, BLEN * sizeof(int8_t));
+  c = (int32_t *)SKL_TEST_MEMALIGN(ALIGN, CLEN * sizeof(int32_t));
+#endif
+
   /* Populate the matrices. */
   skl_test_init_i8(a, ALEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
   skl_test_init_i8(b, BLEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
@@ -173,6 +187,12 @@ int main(void) {
 
   SKL_BENCHMARK_RUN(skl_test_name, M * N * K, SKL_TEST_WARMUP, SKL_TEST_NAME, M,
                     N, K, ALPHA, a, RSA, CSA, b, RSB, CSB, BETA, c, RSC, CSC);
+
+#if defined(SKL_TEST_MEMALIGN) && defined(SKL_TEST_FREE)
+  SKL_TEST_FREE(a);
+  SKL_TEST_FREE(b);
+  SKL_TEST_FREE(c);
+#endif
 
   return res;
 }

--- a/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -186,9 +186,17 @@ enum {
           (N0 - 1) * CSB0 + 1),
   // NOLINTEND(misc-redundant-expression)
 };
+
+#if defined(SKL_TEST_MEMALIGN)
+int8_t *a;
+int8_t *b;
+int32_t *c;
+#else
 _Alignas(ALIGN) int8_t a[ALEN];
 _Alignas(ALIGN) int8_t b[BLEN];
 _Alignas(ALIGN) int32_t c[CLEN];
+#endif
+
 #if defined(ENABLE_TEST)
 int32_t ref_c[CLEN], test_c[CLEN];
 #endif // ENABLE_TEST
@@ -242,6 +250,12 @@ int main(void) {
   printf("RSC0 = %u, CSC0 = %u, RSC1 = %u, CSC1 = %u\n", RSC0, CSC0, RSC1,
          CSC1);
 
+#if defined(SKL_TEST_MEMALIGN)
+  a = (int8_t *)SKL_TEST_MEMALIGN(ALIGN, ALEN * sizeof(int8_t));
+  b = (int8_t *)SKL_TEST_MEMALIGN(ALIGN, BLEN * sizeof(int8_t));
+  c = (int32_t *)SKL_TEST_MEMALIGN(ALIGN, CLEN * sizeof(int32_t));
+#endif
+
   /* Populate the matrices. */
   skl_test_init_i8(a, ALEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
   skl_test_init_i8(b, BLEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
@@ -264,6 +278,12 @@ int main(void) {
                     (size_t)RSB0, (size_t)CSB0, (size_t)RSB1, (size_t)CSB1,
                     BETA, c, (size_t)RSC0, (size_t)CSC0, (size_t)RSC1,
                     (size_t)CSC1);
+
+#if defined(SKL_TEST_MEMALIGN) && defined(SKL_TEST_FREE)
+  SKL_TEST_FREE(a);
+  SKL_TEST_FREE(b);
+  SKL_TEST_FREE(c);
+#endif
 
   return res;
 }

--- a/test/gemm/pack_b_i8_xsfvqdotq.c
+++ b/test/gemm/pack_b_i8_xsfvqdotq.c
@@ -69,8 +69,14 @@ enum {
   BLEN_PACKED = K1 * RSB1,
 };
 
+#if defined(SKL_TEST_MEMALIGN)
+int8_t *b;
+int8_t *b_pack;
+#else
 _Alignas(ALIGN) int8_t b[BLEN];
 _Alignas(ALIGN) int8_t b_pack[BLEN_PACKED];
+#endif
+
 #if defined(ENABLE_TEST)
 _Alignas(ALIGN) int8_t ref_b_pack[BLEN_PACKED];
 _Alignas(ALIGN) int8_t test_b_pack[BLEN_PACKED];
@@ -136,6 +142,11 @@ int main(void) {
   printf("K = %u, N = %u\n", K, N);
   printf("RSB = %u, RSB1 = %u\n", RSB, RSB1);
 
+#if defined(SKL_TEST_MEMALIGN)
+  b = (int8_t *)SKL_TEST_MEMALIGN(ALIGN, BLEN * sizeof(int8_t));
+  b_pack = (int8_t *)SKL_TEST_MEMALIGN(ALIGN, BLEN_PACKED * sizeof(int8_t));
+#endif
+
   /* Populate the matrices. */
   skl_test_init_i8(b, BLEN, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
   skl_test_init_i8(b_pack, BLEN_PACKED, SKL_TEST_MIN_I8, SKL_TEST_MAX_I8);
@@ -150,6 +161,11 @@ int main(void) {
 
   SKL_BENCHMARK_RUN(skl_test_name, K * N, SKL_TEST_WARMUP, SKL_TEST_NAME, K, N,
                     b, RSB, b_pack, (size_t)RSB1);
+
+#if defined(SKL_TEST_MEMALIGN) && defined(SKL_TEST_FREE)
+  SKL_TEST_FREE(b);
+  SKL_TEST_FREE(b_pack);
+#endif
 
   return res;
 }

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -902,7 +902,7 @@ SKL_TEST_INIT_FUNC(int32_t, i32, INT, unused)
  * it can name an arbitrary symbol in a linked translation unit without
  * modification to the benchmark source.
  */
-#if defined(SKL_TEST_MALLOC)
+#if defined(SKL_TEST_MEMALIGN)
 /**
  * @brief Aligned memory allocation function.
  *
@@ -910,20 +910,20 @@ SKL_TEST_INIT_FUNC(int32_t, i32, INT, unused)
  * @param size Size of memory to allocate in bytes
  * @return Pointer to allocated memory
  */
-void *SKL_TEST_MALLOC(size_t alignment, size_t size);
+void *SKL_TEST_MEMALIGN(size_t alignment, size_t size);
 #endif
 
 /**
  * @brief Custom memory free function
  *
  * If defined, this function will be used to free memory allocated
- * by SKL_TEST_MALLOC.
+ * by SKL_TEST_MEMALIGN.
  *
  * @note The prototype is declared by this macro so that
  * it can name an arbitrary symbol in a linked translation unit without
  * modification to the benchmark source.
  */
-#if defined(SKL_TEST_FREE) && defined(SKL_TEST_MALLOC)
+#if defined(SKL_TEST_FREE) && defined(SKL_TEST_MEMALIGN)
 /**
  * @brief Custom memory free function.
  *


### PR DESCRIPTION
The previous `SKL_TEST_MALLOC` macro's API is really that of `[posix_]memalign(size_t alignment, size_t size)`, so rename to reflect that reality and avoid confusion.  This PR changes the existing use of the old macro in GEMM tests, and converts all remaining GEMM tests to use the custom allocator if defined.