### PR TITLE
[Test] SKL_TEST_INIT_BF16 & remaining FP GEMM test conversions

### DIFF
--- a/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
+++ b/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
@@ -183,9 +183,9 @@ int main(void) {
   printf("RSC = %u, CSC = %u\n", RSC, CSC);
 
   /* Populate the matrices. */
-  skl_test_init_bf16(a, ALEN, SKL_TEST_MIN_BF16, SKL_TEST_MAX_BF16);
-  skl_test_init_bf16(b, BLEN, SKL_TEST_MIN_BF16, SKL_TEST_MAX_BF16);
-  skl_test_init_f32(c, CLEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
+  SKL_TEST_INIT_BF16(a, ALEN);
+  SKL_TEST_INIT_BF16(b, BLEN);
+  SKL_TEST_INIT_F32(c, CLEN);
 
 #if defined(ENABLE_TEST)
   /* Make copies of C to write the reference and test outputs to. */

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -252,9 +252,9 @@ int main(void) {
          CSC1);
 
   /* Populate the matrices. */
-  skl_test_init_bf16(a, ALEN, SKL_TEST_MIN_BF16, SKL_TEST_MAX_BF16);
-  skl_test_init_bf16(b, BLEN, SKL_TEST_MIN_BF16, SKL_TEST_MAX_BF16);
-  skl_test_init_f32(c, CLEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
+  SKL_TEST_INIT_BF16(a, ALEN);
+  SKL_TEST_INIT_BF16(b, BLEN);
+  SKL_TEST_INIT_F32(c, CLEN);
 
 #if defined(ENABLE_TEST)
   /* Make copies of C to write the reference and test outputs to. */

--- a/test/gemm/gemm_f16rc_f16rc_f16rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f16rc.c
@@ -180,9 +180,9 @@ int main(void) {
   printf("RSC = %u, CSC = %u\n", RSC, CSC);
 
   /* Populate the matrices. */
-  skl_test_init_f16(a, ALEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
-  skl_test_init_f16(b, BLEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
-  skl_test_init_f16(c, CLEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
+  SKL_TEST_INIT_F16(a, ALEN);
+  SKL_TEST_INIT_F16(b, BLEN);
+  SKL_TEST_INIT_F16(c, CLEN);
 
 #if defined(ENABLE_TEST)
   /* Make copies of C to write the reference and test outputs to. */

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -201,9 +201,9 @@ int main(void) {
   printf("RSC = %u, CSC = %u\n", RSC, CSC);
 
   /* Populate the matrices. */
-  skl_test_init_f16(a, ALEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
-  skl_test_init_f16(b, BLEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
-  skl_test_init_f32(c, CLEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
+  SKL_TEST_INIT_F16(a, ALEN);
+  SKL_TEST_INIT_F16(b, BLEN);
+  SKL_TEST_INIT_F32(c, CLEN);
 
 #if defined(ENABLE_TEST)
   /* Make copies of C to write the reference and test outputs to. */

--- a/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -252,9 +252,9 @@ int main(void) {
          CSC1);
 
   /* Populate the matrices. */
-  skl_test_init_f16(a, ALEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
-  skl_test_init_f16(b, BLEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
-  skl_test_init_f32(c, CLEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
+  SKL_TEST_INIT_F16(a, ALEN);
+  SKL_TEST_INIT_F16(b, BLEN);
+  SKL_TEST_INIT_F32(c, CLEN);
 
 #if defined(ENABLE_TEST)
   /* Make copies of C to write the reference and test outputs to. */

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -252,9 +252,9 @@ int main(void) {
          CSC1);
 
   /* Populate the matrices. */
-  skl_test_init_f32(a, ALEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
-  skl_test_init_f32(b, BLEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
-  skl_test_init_f32(c, CLEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
+  SKL_TEST_INIT_F32(a, ALEN);
+  SKL_TEST_INIT_F32(b, BLEN);
+  SKL_TEST_INIT_F32(c, CLEN);
 
 #if defined(ENABLE_TEST)
   /* Make copies of C to write the reference and test outputs to. */

--- a/test/gemm/gemm_f64rc_f64rc_f64rc.c
+++ b/test/gemm/gemm_f64rc_f64rc_f64rc.c
@@ -182,9 +182,9 @@ int main(void) {
   printf("RSC = %u, CSC = %u\n", RSC, CSC);
 
   /* Populate the matrices. */
-  skl_test_init_f64(a, ALEN, SKL_TEST_MIN_F64, SKL_TEST_MAX_F64);
-  skl_test_init_f64(b, BLEN, SKL_TEST_MIN_F64, SKL_TEST_MAX_F64);
-  skl_test_init_f64(c, CLEN, SKL_TEST_MIN_F64, SKL_TEST_MAX_F64);
+  SKL_TEST_INIT_F64(a, ALEN);
+  SKL_TEST_INIT_F64(b, BLEN);
+  SKL_TEST_INIT_F64(c, CLEN);
 
 #if defined(ENABLE_TEST)
   /* Make copies of C to write the reference and test outputs to. */

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -824,6 +824,9 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
  * documentation.
  * @{
  */
+#define SKL_TEST_INIT_BF16(BUF, LEN)                                            \
+  SKL_TEST_INIT(BUF, LEN, __bf16, BF16, FLOAT, float)
+
 #define SKL_TEST_INIT_F16(BUF, LEN)                                            \
   SKL_TEST_INIT(BUF, LEN, _Float16, F16, FLOAT, float)
 

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -824,7 +824,7 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
  * documentation.
  * @{
  */
-#define SKL_TEST_INIT_BF16(BUF, LEN)                                            \
+#define SKL_TEST_INIT_BF16(BUF, LEN)                                           \
   SKL_TEST_INIT(BUF, LEN, __bf16, BF16, FLOAT, float)
 
 #define SKL_TEST_INIT_F16(BUF, LEN)                                            \


### PR DESCRIPTION
Building on https://github.com/sifive/skl/pull/34 and alongside https://github.com/sifive/skl/pull/46, this PR adds the missing `SKL_TEST_INIT_BF16` initialization macro, and converts the initialization code in all the floating-point GEMM tests to use the appropriate one.