### PR TITLE
[GEMM] Add missing _clp wrapper & test for xsfvqdotq GEMM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,7 +452,7 @@ if (SKL_BUILD_TESTS OR SKL_BUILD_BENCHMARKS)
     skl_add_test(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq gemm/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c "-DM=128;-DN=128;-DK=256;-DBETA=1")
     skl_add_test(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_wrapper gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
       "-DM0=1;-DN0=1;-DK0=4;-DM1=12;-DN1=128;-DK1=8;-DRSB0=1;-DCSB0=0;-DALPHA=1;-DBETA=0;")
-    skl_add_test(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_clp_wrapper gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+    skl_add_test(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_x390_clp_wrapper gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
       "-DM0=1;-DN0=1;-DK0=4;-DM1=12;-DN1=128;-DK1=8;-DRSB0=1;-DCSB0=0;-DALPHA=1;-DBETA=0;")
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,5 +452,7 @@ if (SKL_BUILD_TESTS OR SKL_BUILD_BENCHMARKS)
     skl_add_test(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq gemm/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c "-DM=128;-DN=128;-DK=256;-DBETA=1")
     skl_add_test(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_wrapper gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
       "-DM0=1;-DN0=1;-DK0=4;-DM1=12;-DN1=128;-DK1=8;-DRSB0=1;-DCSB0=0;-DALPHA=1;-DBETA=0;")
+    skl_add_test(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_clp_wrapper gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+      "-DM0=1;-DN0=1;-DK0=4;-DM1=12;-DN1=128;-DK1=8;-DRSB0=1;-DCSB0=0;-DALPHA=1;-DBETA=0;")
   endif()
 endif()

--- a/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -134,6 +134,35 @@ void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_wrapper(
       m0 * m1, n0 * n1, k0 * k1, a_pack /* == a */, rsa1 /* == rsa */, b_pack,
       rsb1, c_pack /* == c */, rsc1 /* == rsc */, beta != 0);
 }
+
+void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_clp_wrapper(
+    size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
+    int32_t alpha, const int8_t *a_pack, __attribute__((unused)) size_t rsa0,
+    size_t csa0, size_t rsa1, size_t csa1, const int8_t *b_pack, size_t rsb0,
+    __attribute__((unused)) size_t csb0, size_t rsb1, size_t csb1, int32_t beta,
+    int32_t *c_pack, __attribute__((unused)) size_t rsc0,
+    __attribute__((unused)) size_t csc0, size_t rsc1, size_t csc1) {
+  int status = 0;
+  SKL_TEST_REQUIRE(status, m0 == 1);
+  SKL_TEST_REQUIRE(status, n0 == 1);
+  SKL_TEST_REQUIRE(status, k0 == 4);
+  SKL_TEST_REQUIRE(status, csa0 == 1);
+  SKL_TEST_REQUIRE(status, rsa1 >= k1 * csa1);
+  SKL_TEST_REQUIRE(status, csa1 == m0 * k0);
+  SKL_TEST_REQUIRE(status, rsb0 == 1);
+  SKL_TEST_REQUIRE(status, rsb1 >= n1 * csb1);
+  SKL_TEST_REQUIRE(status, csb1 == k0 * n0);
+  SKL_TEST_REQUIRE(status, rsc1 >= n1 * csc1);
+  SKL_TEST_REQUIRE(status, csc1 == m0 * n0);
+  SKL_TEST_REQUIRE(status, alpha == 1);
+  SKL_TEST_REQUIRE(status, beta == 0 || beta == 1);
+  if (status) {
+    exit(status);
+  }
+  skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_clp(
+      m0 * m1, n0 * n1, k0 * k1, a_pack /* == a */, rsa1 /* == rsa */, b_pack,
+      rsb1, c_pack /* == c */, rsc1 /* == rsc */, beta != 0);
+}
 #endif
 
 /* The macros below set the matrix strides. */

--- a/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -135,7 +135,7 @@ void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_wrapper(
       rsb1, c_pack /* == c */, rsc1 /* == rsc */, beta != 0);
 }
 
-void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_clp_wrapper(
+void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_x390_clp_wrapper(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
     int32_t alpha, const int8_t *a_pack, __attribute__((unused)) size_t rsa0,
     size_t csa0, size_t rsa1, size_t csa1, const int8_t *b_pack, size_t rsb0,
@@ -159,7 +159,7 @@ void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_clp_wrapper(
   if (status) {
     exit(status);
   }
-  skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_clp(
+  skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_x390_clp(
       m0 * m1, n0 * n1, k0 * k1, a_pack /* == a */, rsa1 /* == rsa */, b_pack,
       rsb1, c_pack /* == c */, rsc1 /* == rsc */, beta != 0);
 }


### PR DESCRIPTION
When the CLP-tuned variant of the Xsfvqdotq GEMM kernel was added, a corresponding wrapper + test were not, so this PR simply adds them.