### PR TITLE
[Softmax] Predicates beta-scaling.

### DIFF
--- a/src/softmax/softmax_bf16_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfbfa.c
@@ -30,7 +30,8 @@ SKL_FUNC void skl_softmax_bf16_xsfvfbfa(__bf16 *pDst, const __bf16 *pSrc,
     vl = __riscv_vsetvl_e16m8(n - i);
     vbfloat16m8_t vx = __riscv_vle16_v_bf16m8(pSrc + i, vl);
     vx = __riscv_vfsub_vf_bf16m8(vx, max, vl);
-    vx = __riscv_vfmul_vf_bf16m8(vx, beta, vl);
+    if (beta != (__bf16)1.0)
+      vx = __riscv_vfmul_vf_bf16m8(vx, beta, vl);
     /* 0. Clamp */
     const __bf16 LB = (__bf16)-0x1.6p6f; /* round_down(-126.5 * log(2)) */
     vx = __riscv_vfmax_vf_bf16m8(vx, LB, vl);

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.c
@@ -40,7 +40,8 @@ SKL_FUNC void skl_softmax_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *pDst,
     vl = __riscv_vsetvl_e16m8(n - i);
     vbfloat16m8_t vx = __riscv_vle16_v_bf16m8(pSrc + i, vl);
     vx = __riscv_vfsub_vf_bf16m8(vx, max, vl);
-    vx = __riscv_vfmul_vf_bf16m8(vx, beta, vl);
+    if (beta != (__bf16)1.0)
+      vx = __riscv_vfmul_vf_bf16m8(vx, beta, vl);
     vx = __riscv_sf_vfexp_v_bf16m8(vx, vl);
     vsum = __riscv_vfadd_vv_bf16m8_tu(vsum, vsum, vx, vl);
     __riscv_vse16_v_bf16m8(pDst + i, vx, vl);

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.c
@@ -33,7 +33,8 @@ SKL_FUNC void skl_softmax_bf16_xsfvfbfexp16e_zvfbfmin(__bf16 *pDst,
     vbfloat16m4_t vx = __riscv_vle16_v_bf16m4(pSrc + i, vl);
     vfloat32m8_t va = __riscv_vfwcvtbf16_f_f_v_f32m8(vx, vl);
     va = __riscv_vfsub_vf_f32m8(va, max, vl);
-    va = __riscv_vfmul_vf_f32m8(va, (float)beta, vl);
+    if (beta != (__bf16)1.0)
+      va = __riscv_vfmul_vf_f32m8(va, (float)beta, vl);
     vx = __riscv_vfncvtbf16_f_f_w_bf16m4(va, vl);
     vx = __riscv_sf_vfexp_v_bf16m4(vx, vl);
     va = __riscv_vfwcvtbf16_f_f_v_f32m8(vx, vl);

--- a/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.c
@@ -33,7 +33,8 @@ SKL_FUNC void skl_softmax_bf16_xsfvfexp32e_zvfbfmin(__bf16 *pDst,
     vbfloat16m4_t vx = __riscv_vle16_v_bf16m4(pSrc + i, vl);
     vfloat32m8_t va = __riscv_vfwcvtbf16_f_f_v_f32m8(vx, vl);
     va = __riscv_vfsub_vf_f32m8(va, max, vl);
-    va = __riscv_vfmul_vf_f32m8(va, beta, vl);
+    if (beta != (__bf16)1.0)
+      va = __riscv_vfmul_vf_f32m8(va, beta, vl);
     va = __riscv_sf_vfexp_v_f32m8(va, vl);
     vx = __riscv_vfncvtbf16_f_f_w_bf16m4(va, vl);
     vsum = __riscv_vfadd_vv_f32m8_tu(vsum, vsum, va, vl);

--- a/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.c
@@ -33,7 +33,8 @@ SKL_FUNC void skl_softmax_bf16_xsfvfexpa_zvfbfmin(__bf16 *pDst,
     vbfloat16m4_t vx = __riscv_vle16_v_bf16m4(pSrc + i, vl);
     vfloat32m8_t va = __riscv_vfwcvtbf16_f_f_v_f32m8(vx, vl);
     va = __riscv_vfsub_vf_f32m8(va, max, vl);
-    va = __riscv_vfmul_vf_f32m8(va, (float)beta, vl);
+    if (beta != (__bf16)1.0)
+      va = __riscv_vfmul_vf_f32m8(va, (float)beta, vl);
     /* 0. Clamp */
     const float LB = -0x1.6p6f; /* round_down(-126.5 * log(2)) */
     va = __riscv_vfmax_vf_f32m8(va, LB, vl);

--- a/src/softmax/softmax_bf16_zve32f.c
+++ b/src/softmax/softmax_bf16_zve32f.c
@@ -51,7 +51,8 @@ SKL_FUNC void skl_softmax_bf16_zve32f(__bf16 *pDst, const __bf16 *pSrc,
     vi = __riscv_vle16_v_i16m4((int16_t *)(pSrc + i), vl);
     vfloat32m8_t va = skl_softmax_vfwcvt_f_x_v_f32m8(vi, vl);
     va = __riscv_vfsub_vf_f32m8(va, max, vl);
-    va = __riscv_vfmul_vf_f32m8(va, (float)beta, vl);
+    if (beta != (__bf16)1.0)
+      va = __riscv_vfmul_vf_f32m8(va, (float)beta, vl);
     /* 0. Clamp */
     const float LB = -0x1.6p6f; /* round_down(-126.5 * log(2)) */
     va = __riscv_vfmax_vf_f32m8(va, LB, vl);

--- a/src/softmax/softmax_bf16_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_zvfbfmin.c
@@ -30,7 +30,8 @@ SKL_FUNC void skl_softmax_bf16_zvfbfmin(__bf16 *pDst, const __bf16 *pSrc,
     vbfloat16m4_t vx = __riscv_vle16_v_bf16m4(pSrc + i, vl);
     vfloat32m8_t va = __riscv_vfwcvtbf16_f_f_v_f32m8(vx, vl);
     va = __riscv_vfsub_vf_f32m8(va, max, vl);
-    va = __riscv_vfmul_vf_f32m8(va, (float)beta, vl);
+    if (beta != (__bf16)1.0)
+      va = __riscv_vfmul_vf_f32m8(va, (float)beta, vl);
     /* 0. Clamp */
     vbool4_t nn = __riscv_vmfeq_vv_f32m8_b4(va, va, vl);
     const float LB = -0x1.6p6f; /* round_down(-126.5 * log(2)) */

--- a/src/softmax/softmax_f16_xsfvfexp16e.c
+++ b/src/softmax/softmax_f16_xsfvfexp16e.c
@@ -28,7 +28,8 @@ SKL_FUNC void skl_softmax_f16_xsfvfexp16e(_Float16 *pDst, const _Float16 *pSrc,
     vl = __riscv_vsetvl_e16m8(n - i);
     vfloat16m8_t vx = __riscv_vle16_v_f16m8(pSrc + i, vl);
     vx = __riscv_vfsub_vf_f16m8(vx, max, vl);
-    vx = __riscv_vfmul_vf_f16m8(vx, beta, vl);
+    if (beta != 1.0f16)
+      vx = __riscv_vfmul_vf_f16m8(vx, beta, vl);
     vx = __riscv_sf_vfexp_v_f16m8(vx, vl);
     vsum = __riscv_vfadd_vv_f16m8_tu(vsum, vsum, vx, vl);
     __riscv_vse16_v_f16m8(pDst + i, vx, vl);

--- a/src/softmax/softmax_f16_xsfvfexpa_zvfh.c
+++ b/src/softmax/softmax_f16_xsfvfexpa_zvfh.c
@@ -32,7 +32,8 @@ SKL_FUNC void skl_softmax_f16_xsfvfexpa_zvfh(_Float16 *pDst,
     vl = __riscv_vsetvl_e16m8(n - i);
     vfloat16m8_t vx = __riscv_vle16_v_f16m8(pSrc + i, vl);
     vx = __riscv_vfsub_vf_f16m8(vx, max, vl);
-    vx = __riscv_vfmul_vf_f16m8(vx, beta, vl);
+    if (beta != 1.0f16)
+      vx = __riscv_vfmul_vf_f16m8(vx, beta, vl);
 
     /* 0. Clamp */
     const _Float16 xmin = -0x1.4c8p+3f16;

--- a/src/softmax/softmax_f16_zvfh.c
+++ b/src/softmax/softmax_f16_zvfh.c
@@ -45,8 +45,10 @@ SKL_FUNC void skl_softmax_f16_zvfh(_Float16 *pDst, const _Float16 *pSrc,
     /* We have vl0 >= vl1, so use vl0, until sum accumulation. */
     vx0 = __riscv_vfsub_vf_f16m4(vx0, max, vl0);
     vx1 = __riscv_vfsub_vf_f16m4(vx1, max, vl0);
-    vx0 = __riscv_vfmul_vf_f16m4(vx0, beta, vl0);
-    vx1 = __riscv_vfmul_vf_f16m4(vx1, beta, vl0);
+    if (beta != 1.0f16) {
+      vx0 = __riscv_vfmul_vf_f16m4(vx0, beta, vl0);
+      vx1 = __riscv_vfmul_vf_f16m4(vx1, beta, vl0);
+    }
 
     /* Clamp */
     const _Float16 xmin = -0x1.4c8p3f16;

--- a/src/softmax/softmax_f32_xsfvfexp32e.c
+++ b/src/softmax/softmax_f32_xsfvfexp32e.c
@@ -48,7 +48,8 @@ SKL_FUNC void skl_softmax_f32_xsfvfexp32e(float *pDst, const float *pSrc,
     vl = __riscv_vsetvl_e32m8(n - i);
     vfloat32m8_t vx = __riscv_vle32_v_f32m8(pSrc + i, vl);
     vx = __riscv_vfsub_vf_f32m8(vx, max, vl);
-    vx = __riscv_vfmul_vf_f32m8(vx, beta, vl);
+    if (beta != 1.0f)
+      vx = __riscv_vfmul_vf_f32m8(vx, beta, vl);
     vx = __riscv_sf_vfexp_v_f32m8(vx, vl);
     vsum = __riscv_vfadd_vv_f32m8_tu(vsum, vsum, vx, vl);
     __riscv_vse32_v_f32m8(pDst + i, vx, vl);

--- a/src/softmax/softmax_f32_xsfvfexpa.c
+++ b/src/softmax/softmax_f32_xsfvfexpa.c
@@ -30,7 +30,8 @@ SKL_FUNC void skl_softmax_f32_xsfvfexpa(float *pDst, const float *pSrc,
     vl = __riscv_vsetvl_e32m8(n - i);
     vfloat32m8_t vx = __riscv_vle32_v_f32m8(pSrc + i, vl);
     vx = __riscv_vfsub_vf_f32m8(vx, max, vl);
-    vx = __riscv_vfmul_vf_f32m8(vx, beta, vl);
+    if (beta != 1.0f)
+      vx = __riscv_vfmul_vf_f32m8(vx, beta, vl);
 
     /* Clamp inputs: */
     const float xmin = -0x1.6018dep6f;

--- a/src/softmax/softmax_f32_zve32f.c
+++ b/src/softmax/softmax_f32_zve32f.c
@@ -33,7 +33,8 @@ SKL_FUNC void skl_softmax_f32_zve32f(float *pDst, const float *pSrc,
     vfloat32m8_t vp = __riscv_vfmv_v_f_f32m8(c4, vl);
 
     vx = __riscv_vfsub_vf_f32m8(vx, max, vl);
-    vx = __riscv_vfmul_vf_f32m8(vx, beta, vl);
+    if (beta != 1.0f)
+      vx = __riscv_vfmul_vf_f32m8(vx, beta, vl);
 
     /* Clamp inputs: */
     const float xmin = -0x1.5ebb86p6f;


### PR DESCRIPTION
Skipping the `vfmul.vf` when beta==1 improves performance.