### PR TITLE
[Softmax] Updates Xsfvfbfa intrinsics.

### DIFF
--- a/src/exp/exp_bf16_xsfvfbfa.c
+++ b/src/exp/exp_bf16_xsfvfbfa.c
@@ -25,13 +25,13 @@ SKL_FUNC void skl_exp_1u_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in,
     /* 1. Reduce */
     vbfloat16m4_t v = __riscv_vfmul_vf_bf16m4(vx, (__bf16)0x1.72p0, vl);
     vint8m2_t j = __riscv_vmv_v_x_i8m2(0, vl);
-    j = __riscv_vfncvt_x_f_w_bf16m4_mu(nn, j, v, vl);
+    j = __riscv_vfncvt_x_f_w_bf16m4_i8m2_mu(nn, j, v, vl);
     j = __riscv_vmax_vx_i8m2(j, -126, vl);
-    vbfloat16m4_t w = __riscv_vfwcvt_bf_x_v_bf16m4(j, vl);
+    vbfloat16m4_t w = __riscv_vfwcvt_f_x_v_bf16m4(j, vl);
     v = __riscv_vfsub_vv_bf16m4(v, w, vl);
     vint8m2_t k = __riscv_vmv_v_x_i8m2(0, vl);
-    k = __riscv_vfncvt_x_f_w_bf16m4_mu(nn, k, v, vl);
-    vbfloat16m4_t y = __riscv_vfwcvt_bf_x_v_bf16m4(k, vl);
+    k = __riscv_vfncvt_x_f_w_bf16m4_i8m2_mu(nn, k, v, vl);
+    vbfloat16m4_t y = __riscv_vfwcvt_f_x_v_bf16m4(k, vl);
     vbfloat16m4_t z = __riscv_vfadd_vv_bf16m4(w, y, vl);
     vbfloat16m4_t s = __riscv_vfnmsac_vf_bf16m4(vx, (__bf16)0x1.6p-1, z, vl);
     s = __riscv_vfnmsac_vf_bf16m4(s, (__bf16)0x1.72p-8, z, vl);

--- a/src/exp/exp_bf16_xsfvfbfa.c
+++ b/src/exp/exp_bf16_xsfvfbfa.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright 2026 SiFive, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #if !defined(__riscv_xsfvfbfa)

--- a/src/softmax/softmax_bf16_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfbfa.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright 2026 SiFive, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #if !defined(__riscv_xsfvfbfa)
@@ -20,7 +20,7 @@ SKL_FUNC void skl_softmax_bf16_xsfvfbfa(__bf16 *pDst, const __bf16 *pSrc,
     vmax = __riscv_vfmax_vv_bf16m4_tu(vmax, vmax, vx, vl);
   }
   /* Xsfvfbfa does not have bf16 reductions, so reduce in f32 */
-  vfloat32m8_t vMAX = __riscv_vfwcvtbf16_f_f_v_f32m8(vmax, vl);
+  vfloat32m8_t vMAX = __riscv_vfwcvt_f_f_v_bf16m4_f32m8(vmax, vl);
   vfloat32m1_t sMAX = __riscv_vlmul_trunc_v_f32m8_f32m1(vMAX);
   sMAX = __riscv_vfredmax_vs_f32m8_f32m1(vMAX, sMAX, n);
   __bf16 max = (__bf16)__riscv_vfmv_f_s_f32m1_f32(sMAX);
@@ -36,8 +36,8 @@ SKL_FUNC void skl_softmax_bf16_xsfvfbfa(__bf16 *pDst, const __bf16 *pSrc,
     vx = __riscv_vfmax_vf_bf16m8(vx, LB, vl);
     /* 1. Reduce */
     vbfloat16m8_t v = __riscv_vfmul_vf_bf16m8(vx, (__bf16)0x1.72p0, vl);
-    vint8m4_t q = __riscv_vfncvt_x_f_w_bf16m8(v, vl);
-    vbfloat16m8_t z = __riscv_vfwcvt_bf_x_v_bf16m8(q, vl);
+    vint8m4_t q = __riscv_vfncvt_x_f_w_bf16m8_i8m4(v, vl);
+    vbfloat16m8_t z = __riscv_vfwcvt_f_x_v_bf16m8(q, vl);
     vbfloat16m8_t s = __riscv_vfnmsac_vf_bf16m8(vx, (__bf16)0x1.6p-1, z, vl);
     s = __riscv_vfnmsac_vf_bf16m8(s, (__bf16)0x1.72p-8, z, vl);
     /* 2. Approximate exp(s) */
@@ -62,7 +62,7 @@ SKL_FUNC void skl_softmax_bf16_xsfvfbfa(__bf16 *pDst, const __bf16 *pSrc,
   vbfloat16m4_t vsum1 = __riscv_vget_v_bf16m8_bf16m4(vsum, 1);
   vsum0 = __riscv_vfadd_vv_bf16m4_tu(vsum0, vsum0, vsum1, vl1);
 
-  vfloat32m8_t vSUM = __riscv_vfwcvtbf16_f_f_v_f32m8(vsum0, vl0);
+  vfloat32m8_t vSUM = __riscv_vfwcvt_f_f_v_bf16m4_f32m8(vsum0, vl0);
   vfloat32m1_t ssum = __riscv_vfmv_s_f_f32m1(0.0f, vl0);
   ssum = __riscv_vfredusum_vs_f32m8_f32m1(vSUM, ssum, vl0);
   float sum = __riscv_vfmv_f_s_f32m1_f32(ssum);

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.c
@@ -30,7 +30,7 @@ SKL_FUNC void skl_softmax_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *pDst,
     vbfloat16m4_t vx = __riscv_vle16_v_bf16m4(pSrc + i, vl);
     vmax = __riscv_vfmax_vv_bf16m4_tu(vmax, vmax, vx, vl);
   }
-  vfloat32m8_t vMAX = __riscv_vfwcvtbf16_f_f_v_f32m8(vmax, vl);
+  vfloat32m8_t vMAX = __riscv_vfwcvt_f_f_v_bf16m4_f32m8(vmax, vl);
   vfloat32m1_t sMAX = __riscv_vlmul_trunc_v_f32m8_f32m1(vMAX);
   sMAX = __riscv_vfredmax_vs_f32m8_f32m1(vMAX, sMAX, n);
   __bf16 max = (__bf16)__riscv_vfmv_f_s_f32m1_f32(sMAX);
@@ -53,7 +53,7 @@ SKL_FUNC void skl_softmax_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *pDst,
   vbfloat16m4_t vsum1 = __riscv_vget_v_bf16m8_bf16m4(vsum, 1);
   vsum0 = __riscv_vfadd_vv_bf16m4_tu(vsum0, vsum0, vsum1, vl1);
 
-  vfloat32m8_t vSUM = __riscv_vfwcvtbf16_f_f_v_f32m8(vsum0, vl0);
+  vfloat32m8_t vSUM = __riscv_vfwcvt_f_f_v_bf16m4_f32m8(vsum0, vl0);
   vfloat32m1_t ssum = __riscv_vfmv_s_f_f32m1(0.0f, vl0);
   ssum = __riscv_vfredusum_vs_f32m8_f32m1(vSUM, ssum, vl0);
   float sum = __riscv_vfmv_f_s_f32m1_f32(ssum);

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright 2026 SiFive, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #if !defined(__riscv_xsfvfbfexp16e) || !defined(__riscv_xsfvfbfa)

--- a/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.c
@@ -21,7 +21,7 @@ SKL_FUNC void skl_softmax_bf16_xsfvfexpa_xsfvfbfa(__bf16 *pDst,
     vbfloat16m4_t vx = __riscv_vle16_v_bf16m4(pSrc + i, vl);
     vmax = __riscv_vfmax_vv_bf16m4_tu(vmax, vmax, vx, vl);
   }
-  vfloat32m8_t vMAX = __riscv_vfwcvtbf16_f_f_v_f32m8(vmax, vl);
+  vfloat32m8_t vMAX = __riscv_vfwcvt_f_f_v_bf16m4_f32m8(vmax, vl);
   vfloat32m1_t sMAX = __riscv_vlmul_trunc_v_f32m8_f32m1(vMAX);
   sMAX = __riscv_vfredmax_vs_f32m8_f32m1(vMAX, sMAX, n);
   __bf16 max = (__bf16)__riscv_vfmv_f_s_f32m1_f32(sMAX);
@@ -39,8 +39,8 @@ SKL_FUNC void skl_softmax_bf16_xsfvfexpa_xsfvfbfa(__bf16 *pDst,
     vbfloat16m4_t vx0 = __riscv_vget_v_bf16m8_bf16m4(vx, 0);
     vbfloat16m4_t vx1 = __riscv_vget_v_bf16m8_bf16m4(vx, 1);
     size_t vl0 = __riscv_vsetvl_e16m4(vl >= vlmax4 ? vlmax4 : vl);
-    vfloat32m8_t A0 = __riscv_vfwmul_vf_f32m8_bf16(vx0, beta, vl0);
-    vfloat32m8_t A1 = __riscv_vfwmul_vf_f32m8_bf16(vx1, beta, vl0);
+    vfloat32m8_t A0 = __riscv_vfwmul_vf_bf16m4_f32m8(vx0, beta, vl0);
+    vfloat32m8_t A1 = __riscv_vfwmul_vf_bf16m4_f32m8(vx1, beta, vl0);
     /* 1. Reduce & Evaluate */
     const float R = 0x1.715476p0f;
     vfloat32m8_t Q = __riscv_vfmv_v_f_f32m8(0x1.003f80p17f, vl0);
@@ -49,8 +49,8 @@ SKL_FUNC void skl_softmax_bf16_xsfvfexpa_xsfvfbfa(__bf16 *pDst,
     vfloat32m8_t F0 = __riscv_sf_vfexpa_v_f32m8(V0, vl0);
     vfloat32m8_t F1 = __riscv_sf_vfexpa_v_f32m8(V1, vl0);
     /* 2. Narrow */
-    vbfloat16m4_t vy0 = __riscv_vfncvtbf16_f_f_w_bf16m4(F0, vl0);
-    vbfloat16m4_t vy1 = __riscv_vfncvtbf16_f_f_w_bf16m4(F1, vl0);
+    vbfloat16m4_t vy0 = __riscv_vfncvt_f_f_w_bf16m4(F0, vl0);
+    vbfloat16m4_t vy1 = __riscv_vfncvt_f_f_w_bf16m4(F1, vl0);
     vbfloat16m8_t vy = __riscv_vundefined_bf16m8();
     vy = __riscv_vset_v_bf16m4_bf16m8(vy, 0, vy0);
     vy = __riscv_vset_v_bf16m4_bf16m8(vy, 1, vy1);
@@ -65,7 +65,7 @@ SKL_FUNC void skl_softmax_bf16_xsfvfexpa_xsfvfbfa(__bf16 *pDst,
   vbfloat16m4_t vsum1 = __riscv_vget_v_bf16m8_bf16m4(vsum, 1);
   vsum0 = __riscv_vfadd_vv_bf16m4_tu(vsum0, vsum0, vsum1, vl1);
 
-  vfloat32m8_t vSUM = __riscv_vfwcvtbf16_f_f_v_f32m8(vsum0, vl0);
+  vfloat32m8_t vSUM = __riscv_vfwcvt_f_f_v_bf16m4_f32m8(vsum0, vl0);
   vfloat32m1_t ssum = __riscv_vfmv_s_f_f32m1(0.0f, vl0);
   ssum = __riscv_vfredusum_vs_f32m8_f32m1(vSUM, ssum, vl0);
   float sum = __riscv_vfmv_f_s_f32m1_f32(ssum);

--- a/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright 2026 SiFive, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_xsfvfbfa)


### PR DESCRIPTION
Xsfvfbfa "SiFive custom additional BF16 vector compute support" intrinsics were previously experimental and in flux.  Intrinsics have now stabilized with better handling of ambiguous cases and names more consistent with existing vector intrinsics.
This updates affected kernels.  Will require an up-to-date toolchain.