### PR TITLE
[GEMM] Add BF16 -> F32 Zvfbfwma kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,10 @@ set(SKL_ZVFH_SRCS
   src/softmax/softmax_f16_zvfh.c
 )
 
+set(SKL_ZVFBFWMA_SRCS
+  src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
+)
+
 set(SKL_ZVE32F_SRCS
   src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.c
   src/exp/exp_bf16_zve32f.c
@@ -187,6 +191,10 @@ endif()
 
 if(RISCV_ZVFH)
   target_sources(${SKL_LIBRARY} PRIVATE ${SKL_ZVFH_SRCS})
+endif()
+
+if(RISCV_ZVFBFWMA)
+  target_sources(${SKL_LIBRARY} PRIVATE ${SKL_ZVFBFWMA_SRCS})
 endif()
 
 if(RISCV_ZVE32F)
@@ -378,6 +386,10 @@ if (SKL_BUILD_TESTS OR SKL_BUILD_BENCHMARKS)
     skl_add_test(skl_gemm_f16_f16_f32_zvfh_x390_wrapper gemm/gemm_f16rc_f16rc_f32rc.c
       "-DM=32;-DN=32;-DK=32;-DALPHA=1.f;-DBETA=0.f")
     skl_add_test(logistic_f16 logistic/logistic_f16.c "-DRUN_ALL")
+  endif()
+  if(RISCV_ZVFBFWMA)
+    skl_add_test(skl_gemm_bf16_bf16_f32_zvfbfwma_wrapper gemm/gemm_bf16rc_bf16rc_f32rc.c
+      "-DRSA=128;-DCSA=1;-DM=4;-DN=16;-DK=128;-DALPHA=1.f;-DBETA=0.f")
   endif()
   skl_add_test(softmax_f16 softmax/softmax_f16.c "-DRUN_ALL;-DBETA=0.5")
   skl_add_test(softmax_bf16 softmax/softmax_bf16.c "-DRUN_ALL;-DBETA=0.5")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,7 +389,7 @@ if (SKL_BUILD_TESTS OR SKL_BUILD_BENCHMARKS)
   endif()
   if(RISCV_ZVFBFWMA)
     skl_add_test(skl_gemm_bf16_bf16_f32_zvfbfwma_wrapper gemm/gemm_bf16rc_bf16rc_f32rc.c
-      "-DRSA=128;-DCSA=1;-DM=4;-DN=16;-DK=128;-DALPHA=1.f;-DBETA=0.f")
+      "-DM=4;-DN=16;-DK=128;-DALPHA=1.f;-DBETA=0.f")
   endif()
   skl_add_test(softmax_f16 softmax/softmax_f16.c "-DRUN_ALL;-DBETA=0.5")
   skl_add_test(softmax_bf16 softmax/softmax_bf16.c "-DRUN_ALL;-DBETA=0.5")

--- a/cmake/get-riscv-extensions.cmake
+++ b/cmake/get-riscv-extensions.cmake
@@ -38,6 +38,13 @@ else()
   set(RISCV_ZVFH OFF)
 endif()
 
+if (${SKL_PREPROCESSOR_OUTPUT} MATCHES "__riscv_zvfbfwma")
+  set(RISCV_ZVFBFWMA ON)
+  list(APPEND SKL_QEMU_CPU_OPTIONS "zvfbfwma=true")
+else()
+  set(RISCV_ZVFBFWMA OFF)
+endif()
+
 if(${SKL_PREPROCESSOR_OUTPUT} MATCHES __riscv_zvfbfmin)
   list(APPEND SKL_QEMU_CPU_OPTIONS "zvfbfmin=true")
   set(RISCV_ZVFBFMIN ON)

--- a/cmake/riscv.cmake
+++ b/cmake/riscv.cmake
@@ -29,6 +29,7 @@ set(SKL_ARCH_EXTENSIONS
   # zvfofp4min0p1
   # xsfvqdotq
   zvfbfmin
+  zvfbfwma
   zihintntl
 )
 

--- a/include/skl.h
+++ b/include/skl.h
@@ -31,6 +31,10 @@
 #include "../src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.h"
 #endif
 
+#if defined(__riscv_zvfbfwma)
+#include "../src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.h"
+#endif
+
 #if defined(__riscv_zve32f)
 #include "../src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.h"
 #endif

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
@@ -52,103 +52,77 @@
 SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_bf16_bf16_f32_zvfbfwma(
     size_t m, size_t n, size_t k, float alpha, const __bf16 *a, size_t rsa,
     const __bf16 *b, size_t rsb, float beta, float *c, size_t rsc) {
+
   size_t jj_vl;
   size_t ii;
-  size_t jj;
-  size_t kk;
-  size_t ii0;
-  __bf16 a00;
-  __bf16 a01;
-  __bf16 a02;
-  __bf16 a03;
-  vbfloat16m2_t b0;
-  vfloat32m4_t acc0;
-  vfloat32m4_t acc1;
-  vfloat32m4_t acc2;
-  vfloat32m4_t acc3;
-  vfloat32m4_t c00;
-  vfloat32m4_t c01;
-  vfloat32m4_t c02;
-  vfloat32m4_t c03;
-  __bf16 a0;
-  vfloat32m4_t acc;
-  vfloat32m4_t c0;
+
   if (k == 0) {
-    for (ii = 0; (ii + 1) <= m; ii = ii + 1) {
-      for (jj = 0; jj < n; jj = jj + jj_vl) {
+    // C = beta * C
+    for (ii = 0; ii < m; ii++) {
+      for (size_t jj = 0; jj < n; jj += jj_vl) {
         jj_vl = __riscv_vsetvl_e32m4(n - jj);
-        c0 = __riscv_vle32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)),
-                                   jj_vl);
+        vfloat32m4_t c0 = __riscv_vle32_v_f32m4(c + ii * rsc + jj, jj_vl);
         c0 = __riscv_vfmul_vf_f32m4(c0, beta, jj_vl);
-        __riscv_vse32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)), c0,
-                              jj_vl);
+        __riscv_vse32_v_f32m4(c + ii * rsc + jj, c0, jj_vl);
       }
     }
     return;
   }
-  for (ii = 0; (ii + 4) <= m; ii = ii + 4) {
-    for (jj = 0; jj < n; jj = jj + jj_vl) {
+
+  for (ii = 0; ii + 4 <= m; ii += 4) {
+    for (size_t jj = 0; jj < n; jj = jj + jj_vl) {
       jj_vl = __riscv_vsetvl_e16m2(n - jj);
-      float zero = 0.f;
-      acc0 = __riscv_vfmv_v_f_f32m4(zero, jj_vl);
-      acc1 = __riscv_vfmv_v_f_f32m4(zero, jj_vl);
-      acc2 = __riscv_vfmv_v_f_f32m4(zero, jj_vl);
-      acc3 = __riscv_vfmv_v_f_f32m4(zero, jj_vl);
-      for (kk = 0; (kk + 1) <= k; kk = kk + 1) {
-        a00 = a[((ii + 0) * rsa) + ((kk + 0) * 1)];
-        a01 = a[((ii + 1) * rsa) + ((kk + 0) * 1)];
-        a02 = a[((ii + 2) * rsa) + ((kk + 0) * 1)];
-        a03 = a[((ii + 3) * rsa) + ((kk + 0) * 1)];
-        b0 = __riscv_vle16_v_bf16m2(b + (((kk + 0) * rsb) + ((jj + 0) * 1)),
-                                    jj_vl);
+      vfloat32m4_t acc0 = __riscv_vfmv_v_f_f32m4(0.f, jj_vl);
+      vfloat32m4_t acc1 = __riscv_vfmv_v_f_f32m4(0.f, jj_vl);
+      vfloat32m4_t acc2 = __riscv_vfmv_v_f_f32m4(0.f, jj_vl);
+      vfloat32m4_t acc3 = __riscv_vfmv_v_f_f32m4(0.f, jj_vl);
+      for (size_t kk = 0; kk < k; kk++) {
+        __bf16 a00 = a[(ii + 0) * rsa + kk];
+        __bf16 a01 = a[(ii + 1) * rsa + kk];
+        __bf16 a02 = a[(ii + 2) * rsa + kk];
+        __bf16 a03 = a[(ii + 3) * rsa + kk];
+        vbfloat16m2_t b0 = __riscv_vle16_v_bf16m2(b + kk * rsb + jj, jj_vl);
         acc0 = __riscv_vfwmaccbf16_vf_f32m4(acc0, a00, b0, jj_vl);
         acc1 = __riscv_vfwmaccbf16_vf_f32m4(acc1, a01, b0, jj_vl);
         acc2 = __riscv_vfwmaccbf16_vf_f32m4(acc2, a02, b0, jj_vl);
         acc3 = __riscv_vfwmaccbf16_vf_f32m4(acc3, a03, b0, jj_vl);
       }
-      c00 =
-          __riscv_vle32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)), jj_vl);
-      c01 =
-          __riscv_vle32_v_f32m4(c + (((ii + 1) * rsc) + ((jj + 0) * 1)), jj_vl);
-      c02 =
-          __riscv_vle32_v_f32m4(c + (((ii + 2) * rsc) + ((jj + 0) * 1)), jj_vl);
-      c03 =
-          __riscv_vle32_v_f32m4(c + (((ii + 3) * rsc) + ((jj + 0) * 1)), jj_vl);
+      vfloat32m4_t c00 = __riscv_vle32_v_f32m4(c + (ii + 0) * rsc + jj, jj_vl);
+      vfloat32m4_t c01 = __riscv_vle32_v_f32m4(c + (ii + 1) * rsc + jj, jj_vl);
+      vfloat32m4_t c02 = __riscv_vle32_v_f32m4(c + (ii + 2) * rsc + jj, jj_vl);
+      vfloat32m4_t c03 = __riscv_vle32_v_f32m4(c + (ii + 3) * rsc + jj, jj_vl);
+
       c00 = __riscv_vfmul_vf_f32m4(c00, beta, jj_vl);
       c00 = __riscv_vfmacc_vf_f32m4(c00, alpha, acc0, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)), c00,
-                            jj_vl);
+      __riscv_vse32_v_f32m4(c + (ii + 0) * rsc + jj, c00, jj_vl);
+
       c01 = __riscv_vfmul_vf_f32m4(c01, beta, jj_vl);
       c01 = __riscv_vfmacc_vf_f32m4(c01, alpha, acc1, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii + 1) * rsc) + ((jj + 0) * 1)), c01,
-                            jj_vl);
+      __riscv_vse32_v_f32m4(c + (ii + 1) * rsc + jj, c01, jj_vl);
+
       c02 = __riscv_vfmul_vf_f32m4(c02, beta, jj_vl);
       c02 = __riscv_vfmacc_vf_f32m4(c02, alpha, acc2, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii + 2) * rsc) + ((jj + 0) * 1)), c02,
-                            jj_vl);
+      __riscv_vse32_v_f32m4(c + (ii + 2) * rsc + jj, c02, jj_vl);
+
       c03 = __riscv_vfmul_vf_f32m4(c03, beta, jj_vl);
       c03 = __riscv_vfmacc_vf_f32m4(c03, alpha, acc3, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii + 3) * rsc) + ((jj + 0) * 1)), c03,
-                            jj_vl);
+      __riscv_vse32_v_f32m4(c + (ii + 3) * rsc + jj, c03, jj_vl);
     }
   }
-  for (ii0 = ii; (ii0 + 1) <= m; ii0 = ii0 + 1) {
-    for (jj = 0; jj < n; jj = jj + jj_vl) {
+
+  for (; ii < m; ii++) {
+    for (size_t jj = 0; jj < n; jj += jj_vl) {
       jj_vl = __riscv_vsetvl_e16m2(n - jj);
-      float zero = 0.f;
-      acc = __riscv_vfmv_v_f_f32m4(zero, jj_vl);
-      for (kk = 0; (kk + 1) <= k; kk = kk + 1) {
-        a0 = a[((ii0 + 0) * rsa) + ((kk + 0) * 1)];
-        b0 = __riscv_vle16_v_bf16m2(b + (((kk + 0) * rsb) + ((jj + 0) * 1)),
-                                    jj_vl);
+      vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.f, jj_vl);
+      for (size_t kk = 0; kk < k; kk++) {
+        __bf16 a0 = a[ii * rsa + kk];
+        vbfloat16m2_t b0 = __riscv_vle16_v_bf16m2(b + kk * rsb + jj, jj_vl);
         acc = __riscv_vfwmaccbf16_vf_f32m4(acc, a0, b0, jj_vl);
       }
-      c0 = __riscv_vle32_v_f32m4(c + (((ii0 + 0) * rsc) + ((jj + 0) * 1)),
-                                 jj_vl);
+      vfloat32m4_t c0 = __riscv_vle32_v_f32m4(c + ii * rsc + jj, jj_vl);
       c0 = __riscv_vfmul_vf_f32m4(c0, beta, jj_vl);
       c0 = __riscv_vfmacc_vf_f32m4(c0, alpha, acc, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii0 + 0) * rsc) + ((jj + 0) * 1)), c0,
-                            jj_vl);
+      __riscv_vse32_v_f32m4(c + ii * rsc + jj, c0, jj_vl);
     }
   }
 }

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
@@ -73,7 +73,6 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_bf16_bf16_f32_zvfbfwma(
   __bf16 a0;
   vfloat32m4_t acc;
   vfloat32m4_t c0;
-  // clang-format off
   if (k == 0) {
     for (ii = 0; (ii + 1) <= m; ii = ii + 1) {
       for (jj = 0; jj < n; jj = jj + jj_vl) {
@@ -100,28 +99,37 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_bf16_bf16_f32_zvfbfwma(
         a01 = a[((ii + 1) * rsa) + ((kk + 0) * 1)];
         a02 = a[((ii + 2) * rsa) + ((kk + 0) * 1)];
         a03 = a[((ii + 3) * rsa) + ((kk + 0) * 1)];
-        b0 = __riscv_vle16_v_bf16m2(b + (((kk + 0) * rsb) + ((jj + 0) * 1)), jj_vl);
+        b0 = __riscv_vle16_v_bf16m2(b + (((kk + 0) * rsb) + ((jj + 0) * 1)),
+                                    jj_vl);
         acc0 = __riscv_vfwmaccbf16_vf_f32m4(acc0, a00, b0, jj_vl);
         acc1 = __riscv_vfwmaccbf16_vf_f32m4(acc1, a01, b0, jj_vl);
         acc2 = __riscv_vfwmaccbf16_vf_f32m4(acc2, a02, b0, jj_vl);
         acc3 = __riscv_vfwmaccbf16_vf_f32m4(acc3, a03, b0, jj_vl);
       }
-      c00 = __riscv_vle32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)), jj_vl);
-      c01 = __riscv_vle32_v_f32m4(c + (((ii + 1) * rsc) + ((jj + 0) * 1)), jj_vl);
-      c02 = __riscv_vle32_v_f32m4(c + (((ii + 2) * rsc) + ((jj + 0) * 1)), jj_vl);
-      c03 = __riscv_vle32_v_f32m4(c + (((ii + 3) * rsc) + ((jj + 0) * 1)), jj_vl);
+      c00 =
+          __riscv_vle32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)), jj_vl);
+      c01 =
+          __riscv_vle32_v_f32m4(c + (((ii + 1) * rsc) + ((jj + 0) * 1)), jj_vl);
+      c02 =
+          __riscv_vle32_v_f32m4(c + (((ii + 2) * rsc) + ((jj + 0) * 1)), jj_vl);
+      c03 =
+          __riscv_vle32_v_f32m4(c + (((ii + 3) * rsc) + ((jj + 0) * 1)), jj_vl);
       c00 = __riscv_vfmul_vf_f32m4(c00, beta, jj_vl);
       c00 = __riscv_vfmacc_vf_f32m4(c00, alpha, acc0, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)), c00, jj_vl);
+      __riscv_vse32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)), c00,
+                            jj_vl);
       c01 = __riscv_vfmul_vf_f32m4(c01, beta, jj_vl);
       c01 = __riscv_vfmacc_vf_f32m4(c01, alpha, acc1, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii + 1) * rsc) + ((jj + 0) * 1)), c01, jj_vl);
+      __riscv_vse32_v_f32m4(c + (((ii + 1) * rsc) + ((jj + 0) * 1)), c01,
+                            jj_vl);
       c02 = __riscv_vfmul_vf_f32m4(c02, beta, jj_vl);
       c02 = __riscv_vfmacc_vf_f32m4(c02, alpha, acc2, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii + 2) * rsc) + ((jj + 0) * 1)), c02, jj_vl);
+      __riscv_vse32_v_f32m4(c + (((ii + 2) * rsc) + ((jj + 0) * 1)), c02,
+                            jj_vl);
       c03 = __riscv_vfmul_vf_f32m4(c03, beta, jj_vl);
       c03 = __riscv_vfmacc_vf_f32m4(c03, alpha, acc3, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii + 3) * rsc) + ((jj + 0) * 1)), c03, jj_vl);
+      __riscv_vse32_v_f32m4(c + (((ii + 3) * rsc) + ((jj + 0) * 1)), c03,
+                            jj_vl);
     }
   }
   for (ii0 = ii; (ii0 + 1) <= m; ii0 = ii0 + 1) {
@@ -132,16 +140,17 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_bf16_bf16_f32_zvfbfwma(
       for (kk = 0; (kk + 1) <= k; kk = kk + 1) {
         a0 = a[((ii0 + 0) * rsa) + ((kk + 0) * 1)];
         b0 = __riscv_vle16_v_bf16m2(b + (((kk + 0) * rsb) + ((jj + 0) * 1)),
-                                   jj_vl);
+                                    jj_vl);
         acc = __riscv_vfwmaccbf16_vf_f32m4(acc, a0, b0, jj_vl);
       }
-      c0 = __riscv_vle32_v_f32m4(c + (((ii0 + 0) * rsc) + ((jj + 0) * 1)), jj_vl);
+      c0 = __riscv_vle32_v_f32m4(c + (((ii0 + 0) * rsc) + ((jj + 0) * 1)),
+                                 jj_vl);
       c0 = __riscv_vfmul_vf_f32m4(c0, beta, jj_vl);
       c0 = __riscv_vfmacc_vf_f32m4(c0, alpha, acc, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii0 + 0) * rsc) + ((jj + 0) * 1)), c0, jj_vl);
+      __riscv_vse32_v_f32m4(c + (((ii0 + 0) * rsc) + ((jj + 0) * 1)), c0,
+                            jj_vl);
     }
   }
-  // clang-format on
 }
 
 SKL_FUNC void skl_gemm_bf16_bf16_f32_zvfbfwma(size_t m, size_t n, size_t k,

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright 2026 SiFive, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #if !defined(__riscv_zvfbfwma)

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
@@ -1,0 +1,154 @@
+// Copyright 2025 SiFive, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#if !defined(__riscv_zvfbfwma)
+#error This file requires the RISC-V Zvfbfwma extension.
+#endif
+
+#if !defined(__riscv_zve32f)
+#error This file requires the RISC-V Zve32f extension.
+#endif
+
+#include <riscv_vector.h>
+#include <stddef.h>
+
+#include "skl-common.h"
+
+/**
+ * @brief RVV bfloat16 matrix-matrix multiplication with float32 output for
+ * row-major matrices.
+ *
+ * @param m - Number of rows in matrices A and C.
+ * @param n - Number of columns in matrices B and C.
+ * @param k - Number of columns in A and rows in B (inner dimension).
+ * @param alpha - Scalar multiplier for A*B product.
+ * @param a - Pointer to matrix A.
+ * @param rsa - Row stride of matrix A in elements.
+ * @param b - Pointer to matrix B.
+ * @param rsb - Row stride of matrix B in elements.
+ * @param beta - Scalar multiplier for matrix C.
+ * @param c - Pointer to matrix C.
+ * @param rsc - Row stride of matrix C in elements.
+ *
+ * Computes `C = alpha * A * B + beta * C` for BF16 row-major matrices A and B
+ * and FP32 row-major output matrix C.
+ *
+ * Functionally equivalent to scalar call:
+ * ```
+ * skl_gemm_bf16rc_bf16rc_f32rc_scalar(
+ *     m, n, k,
+ *     alpha,
+ *     a, rsa, 1,
+ *     b, rsb, 1,
+ *     beta,
+ *     c, rsc, 1
+ * );
+ * ```
+ * Uses a 4 x LMUL=4 x 1 register tile. Vectorized across the N dimension.
+ *
+ * @note
+ * Works best when `m >= 4` and `n >= __riscv_vsetvlmax_e32m4()`.
+ */
+SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_bf16_bf16_f32_zvfbfwma(
+    size_t m, size_t n, size_t k, float alpha, const __bf16 *a, size_t rsa,
+    const __bf16 *b, size_t rsb, float beta, float *c, size_t rsc) {
+  size_t jj_vl;
+  size_t ii;
+  size_t jj;
+  size_t kk;
+  size_t ii0;
+  __bf16 a00;
+  __bf16 a01;
+  __bf16 a02;
+  __bf16 a03;
+  vbfloat16m2_t b0;
+  vfloat32m4_t acc0;
+  vfloat32m4_t acc1;
+  vfloat32m4_t acc2;
+  vfloat32m4_t acc3;
+  vfloat32m4_t c00;
+  vfloat32m4_t c01;
+  vfloat32m4_t c02;
+  vfloat32m4_t c03;
+  __bf16 a0;
+  vfloat32m4_t acc;
+  vfloat32m4_t c0;
+  // clang-format off
+  if (k == 0) {
+    for (ii = 0; (ii + 1) <= m; ii = ii + 1) {
+      for (jj = 0; jj < n; jj = jj + jj_vl) {
+        jj_vl = __riscv_vsetvl_e32m4(n - jj);
+        c0 = __riscv_vle32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)),
+                                   jj_vl);
+        c0 = __riscv_vfmul_vf_f32m4(c0, beta, jj_vl);
+        __riscv_vse32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)), c0,
+                              jj_vl);
+      }
+    }
+    return;
+  }
+  for (ii = 0; (ii + 4) <= m; ii = ii + 4) {
+    for (jj = 0; jj < n; jj = jj + jj_vl) {
+      jj_vl = __riscv_vsetvl_e16m2(n - jj);
+      float zero = 0.f;
+      acc0 = __riscv_vfmv_v_f_f32m4(zero, jj_vl);
+      acc1 = __riscv_vfmv_v_f_f32m4(zero, jj_vl);
+      acc2 = __riscv_vfmv_v_f_f32m4(zero, jj_vl);
+      acc3 = __riscv_vfmv_v_f_f32m4(zero, jj_vl);
+      for (kk = 0; (kk + 1) <= k; kk = kk + 1) {
+        a00 = a[((ii + 0) * rsa) + ((kk + 0) * 1)];
+        a01 = a[((ii + 1) * rsa) + ((kk + 0) * 1)];
+        a02 = a[((ii + 2) * rsa) + ((kk + 0) * 1)];
+        a03 = a[((ii + 3) * rsa) + ((kk + 0) * 1)];
+        b0 = __riscv_vle16_v_bf16m2(b + (((kk + 0) * rsb) + ((jj + 0) * 1)), jj_vl);
+        acc0 = __riscv_vfwmaccbf16_vf_f32m4(acc0, a00, b0, jj_vl);
+        acc1 = __riscv_vfwmaccbf16_vf_f32m4(acc1, a01, b0, jj_vl);
+        acc2 = __riscv_vfwmaccbf16_vf_f32m4(acc2, a02, b0, jj_vl);
+        acc3 = __riscv_vfwmaccbf16_vf_f32m4(acc3, a03, b0, jj_vl);
+      }
+      c00 = __riscv_vle32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)), jj_vl);
+      c01 = __riscv_vle32_v_f32m4(c + (((ii + 1) * rsc) + ((jj + 0) * 1)), jj_vl);
+      c02 = __riscv_vle32_v_f32m4(c + (((ii + 2) * rsc) + ((jj + 0) * 1)), jj_vl);
+      c03 = __riscv_vle32_v_f32m4(c + (((ii + 3) * rsc) + ((jj + 0) * 1)), jj_vl);
+      c00 = __riscv_vfmul_vf_f32m4(c00, beta, jj_vl);
+      c00 = __riscv_vfmacc_vf_f32m4(c00, alpha, acc0, jj_vl);
+      __riscv_vse32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)), c00, jj_vl);
+      c01 = __riscv_vfmul_vf_f32m4(c01, beta, jj_vl);
+      c01 = __riscv_vfmacc_vf_f32m4(c01, alpha, acc1, jj_vl);
+      __riscv_vse32_v_f32m4(c + (((ii + 1) * rsc) + ((jj + 0) * 1)), c01, jj_vl);
+      c02 = __riscv_vfmul_vf_f32m4(c02, beta, jj_vl);
+      c02 = __riscv_vfmacc_vf_f32m4(c02, alpha, acc2, jj_vl);
+      __riscv_vse32_v_f32m4(c + (((ii + 2) * rsc) + ((jj + 0) * 1)), c02, jj_vl);
+      c03 = __riscv_vfmul_vf_f32m4(c03, beta, jj_vl);
+      c03 = __riscv_vfmacc_vf_f32m4(c03, alpha, acc3, jj_vl);
+      __riscv_vse32_v_f32m4(c + (((ii + 3) * rsc) + ((jj + 0) * 1)), c03, jj_vl);
+    }
+  }
+  for (ii0 = ii; (ii0 + 1) <= m; ii0 = ii0 + 1) {
+    for (jj = 0; jj < n; jj = jj + jj_vl) {
+      jj_vl = __riscv_vsetvl_e16m2(n - jj);
+      float zero = 0.f;
+      acc = __riscv_vfmv_v_f_f32m4(zero, jj_vl);
+      for (kk = 0; (kk + 1) <= k; kk = kk + 1) {
+        a0 = a[((ii0 + 0) * rsa) + ((kk + 0) * 1)];
+        b0 = __riscv_vle16_v_bf16m2(b + (((kk + 0) * rsb) + ((jj + 0) * 1)),
+                                   jj_vl);
+        acc = __riscv_vfwmaccbf16_vf_f32m4(acc, a0, b0, jj_vl);
+      }
+      c0 = __riscv_vle32_v_f32m4(c + (((ii0 + 0) * rsc) + ((jj + 0) * 1)), jj_vl);
+      c0 = __riscv_vfmul_vf_f32m4(c0, beta, jj_vl);
+      c0 = __riscv_vfmacc_vf_f32m4(c0, alpha, acc, jj_vl);
+      __riscv_vse32_v_f32m4(c + (((ii0 + 0) * rsc) + ((jj + 0) * 1)), c0, jj_vl);
+    }
+  }
+  // clang-format on
+}
+
+SKL_FUNC void skl_gemm_bf16_bf16_f32_zvfbfwma(size_t m, size_t n, size_t k,
+                                              float alpha, const __bf16 *a,
+                                              size_t rsa, const __bf16 *b,
+                                              size_t rsb, float beta, float *c,
+                                              size_t rsc) {
+  skl_gemm_4xm4x1_bf16_bf16_f32_zvfbfwma(m, n, k, alpha, a, rsa, b, rsb, beta,
+                                         c, rsc);
+}

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.h
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.h
@@ -1,0 +1,54 @@
+// Copyright 2025 SiFive, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if !defined(__riscv_zvfbfwma) || __riscv_zvfbfwma < 1000000
+#error This file requires the RISC-V Zvfbfwma extension, version 1000000.
+#endif
+
+#include <stddef.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * @brief RVV bfloat16 matrix-matrix multiplication with float32 output for
+ * row-major matrices.
+ *
+ * @param m - Number of rows in matrices A and C.
+ * @param n - Number of columns in matrices B and C.
+ * @param k - Number of columns in A and rows in B (inner dimension).
+ * @param alpha - Scalar multiplier for A*B product.
+ * @param a - Pointer to matrix A.
+ * @param rsa - Row stride of matrix A in elements.
+ * @param b - Pointer to matrix B.
+ * @param rsb - Row stride of matrix B in elements.
+ * @param beta - Scalar multiplier for matrix C.
+ * @param c - Pointer to matrix C.
+ * @param rsc - Row stride of matrix C in elements.
+ *
+ * Computes `C = alpha * A * B + beta * C` for BF16 row-major matrices A and B
+ * and FP32 row-major output matrix C.
+ *
+ * Functionally equivalent to scalar call:
+ * ```
+ * skl_gemm_bf16rc_bf16rc_f32rc_scalar(
+ *     m, n, k,
+ *     alpha,
+ *     a, rsa, 1,
+ *     b, rsb, 1,
+ *     beta,
+ *     c, rsc, 1
+ * );
+ * ```
+ */
+void skl_gemm_bf16_bf16_f32_zvfbfwma(size_t m, size_t n, size_t k, float alpha,
+                                     const __bf16 *a, size_t rsa,
+                                     const __bf16 *b, size_t rsb, float beta,
+                                     float *c, size_t rsc);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.h
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright 2026 SiFive, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
+++ b/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
@@ -75,6 +75,24 @@ void skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f_wrapper(
 }
 #endif
 
+#if defined(__riscv_zvfbfwma)
+void skl_gemm_bf16_bf16_f32_zvfbfwma_wrapper(size_t m, size_t n, size_t k,
+                                             float alpha, const __bf16 *a,
+                                             size_t rsa, size_t csa,
+                                             const __bf16 *b, size_t rsb,
+                                             size_t csb, float beta, float *c,
+                                             size_t rsc, size_t csc) {
+  int status = 0;
+  SKL_TEST_REQUIRE(status, csa == 1);
+  SKL_TEST_REQUIRE(status, csb == 1);
+  SKL_TEST_REQUIRE(status, csc == 1);
+  if (status) {
+    exit(status);
+  }
+  skl_gemm_bf16_bf16_f32_zvfbfwma(m, n, k, alpha, a, rsa, b, rsb, beta, c, rsc);
+}
+#endif
+
 /* The macros below set the matrix strides. */
 #if !defined(RSA) && !defined(CSA)
 #define RSA K // Default to row major


### PR DESCRIPTION
This adds a general GEMM kernel for BF16 input types with F32 accumulator and output type, using the Zvfbfwma extension, in intrinsics. In particular, the `vfwmaccbf16` intrinsic is used for accumulation, and a `vfmv` with 0 is used for initialization instead of a widening multiply.

This kernel uses no micro-architectural suffix in its name since it's intended to be a general purpose kernel for the Zvfbfwma extension. For this initial PR the kernel uses a standard `4xm4x1` tile size, which has shown to give sufficiently high performance.

Some CMake logic is added to support Zvfbfwma, and a test is also added.