### PR TITLE
Add Xsfvfexp32e+Zvfbfmin BF16 softmax to libskl and test harness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,10 @@ set(SKL_XSFVFEXP32E_SRCS
   src/softmax/softmax_f32_xsfvfexp32e.c
 )
 
+set(SKL_XSFVFEXP32E_ZVFBFMIN_SRCS
+  src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.c
+)
+
 set(SKL_ZVE64D_SRCS
   src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.c
 )
@@ -259,6 +263,10 @@ endif()
 
 if(RISCV_XSFVFEXP32E)
   target_sources(${SKL_LIBRARY} PRIVATE ${SKL_XSFVFEXP32E_SRCS})
+endif()
+
+if(RISCV_XSFVFEXP32E AND RISCV_ZVFBFMIN)
+  target_sources(${SKL_LIBRARY} PRIVATE ${SKL_XSFVFEXP32E_ZVFBFMIN_SRCS})
 endif()
 
 if(RISCV_ZVFBFMIN)

--- a/include/skl.h
+++ b/include/skl.h
@@ -206,6 +206,9 @@
 #if defined(__riscv_xsfvfbfexp16e) && defined(__riscv_zvfbfmin)
 #include "../src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.h"
 #endif
+#if defined(__riscv_xsfvfexp32e) && defined(__riscv_zvfbfmin)
+#include "../src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.h"
+#endif
 #if defined(__riscv_xsfvfexpa) && defined(__riscv_xsfvfbfa)
 #include "../src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.h"
 #endif

--- a/test/softmax/softmax_bf16.c
+++ b/test/softmax/softmax_bf16.c
@@ -30,6 +30,7 @@
 #define RUN_VFEXPA_VFBFA 1
 #define RUN_VFEXP_BFMIN 1
 #define RUN_VFEXP_VFBFA 1
+#define RUN_VFEXP32E_BFMIN 1
 #endif
 
 enum { ALIGN = 4096 };
@@ -111,10 +112,15 @@ int main(void) {
     defined(RUN_VFEXP_VFBFA)
   RUN(skl_softmax_bf16_xsfvfbfexp16e_xsfvfbfa, "xsfvfbfexp16e+xsfvfbfa", 16);
 #endif
+#if defined(__riscv_xsfvfexp32e) && defined(__riscv_zvfbfmin) &&               \
+    defined(RUN_VFEXP32E_BFMIN)
+  RUN(skl_softmax_bf16_xsfvfexp32e_zvfbfmin, "xsfvfbfexp32e+zvfbfmin", 1);
+#endif
 
 #if !(defined(RUN_SCALAR) || defined(RUN_VFBFA) || defined(RUN_VFEXP_VFBFA) || \
       defined(RUN_VFEXP_BFMIN) || defined(RUN_VFEXPA_VFBFA) ||                 \
-      defined(RUN_VFEXPA_BFMIN) || defined(RUN_ZVE32F) || defined(RUN_BFMIN))
+      defined(RUN_VFEXPA_BFMIN) || defined(RUN_ZVE32F) ||                      \
+      defined(RUN_BFMIN) || defined(RUN_VFEXP32E_BFMIN))
 #error No tests or benchmarks enabled!
 #endif
 


### PR DESCRIPTION
This patch adds the already existing Xsfvfexp32e+Zvfbfmin BF16 softmax kernel to the build system, public header, and BF16 softmax test harness.