### PR TITLE
[Test] Refactor `gemm_f16rc_f16rc_f32rc` to new test structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,8 +375,6 @@ if (SKL_BUILD_TESTS OR SKL_BUILD_BENCHMARKS)
     skl_add_test_legacy(exp_f16 exp/exp_f16.c "-DRUN_ZVFH;-DRUN_VFEXPA;-DRUN_VFEXP")
     skl_add_test_legacy(skl_gemm_f16_f16_f16_zvfh_x390_wrapper gemm/gemm_f16rc_f16rc_f16rc.c
       "-DM=32;-DN=32;-DK=32;-DALPHA=1.f;-DBETA=0.f")
-    skl_add_test_legacy(skl_gemm_f16_f16_f32_zvfh_x390_wrapper gemm/gemm_f16rc_f16rc_f32rc.c
-      "-DM=32;-DN=32;-DK=32;-DALPHA=1.f;-DBETA=0.f")
     skl_add_test_legacy(logistic_f16 logistic/logistic_f16.c "-DRUN_ALL")
   endif()
   skl_add_test_legacy(softmax_f16 softmax/softmax_f16.c "-DRUN_ALL;-DBETA=0.5")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,7 +295,7 @@ endif()
 
 set(SKL_TEST_LIBS m)
 
-function(skl_add_test TEST_NAME TEST_SRC OPTS)
+function(skl_add_test_legacy TEST_NAME TEST_SRC OPTS)
   add_executable(test-${TEST_NAME} test/${TEST_SRC})
   target_link_libraries(test-${TEST_NAME} PRIVATE ${SKL_LIBRARY} ${SKL_TEST_LIBS})
   target_compile_options(test-${TEST_NAME} PRIVATE
@@ -362,94 +362,94 @@ if (SKL_BUILD_TESTS OR SKL_BUILD_BENCHMARKS)
   endif()
 
   if(RISCV_ZVE32X)
-    skl_add_test(skl_depthwise_conv2d_i8_i8_i32_zve32x depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c "")
-    skl_add_test(skl_gemm_i8_i8_i32_zve32x_x390_wrapper gemm/gemm_i8rc_i8rc_i32rc.c
+    skl_add_test_legacy(skl_depthwise_conv2d_i8_i8_i32_zve32x depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c "")
+    skl_add_test_legacy(skl_gemm_i8_i8_i32_zve32x_x390_wrapper gemm/gemm_i8rc_i8rc_i32rc.c
       "-DM=32;-DN=32;-DK=32;-DALPHA=1;-DBETA=0")
-    skl_add_test(skl_transpose_e8_zve32x transpose/transpose_e8.c "")
-    skl_add_test(skl_transpose_e16_zve32x transpose/transpose_e16.c "")
-    skl_add_test(skl_transpose_e32_zve32x transpose/transpose_e32.c "")
-    skl_add_test(skl_pack_b_i8_xsfvqdotq gemm/pack_b_i8_xsfvqdotq.c "-DK=126;-DN=128")
+    skl_add_test_legacy(skl_transpose_e8_zve32x transpose/transpose_e8.c "")
+    skl_add_test_legacy(skl_transpose_e16_zve32x transpose/transpose_e16.c "")
+    skl_add_test_legacy(skl_transpose_e32_zve32x transpose/transpose_e32.c "")
+    skl_add_test_legacy(skl_pack_b_i8_xsfvqdotq gemm/pack_b_i8_xsfvqdotq.c "-DK=126;-DN=128")
   endif()
   if(RISCV_ZVFH)
-    skl_add_test(skl_depthwise_conv2d_f16_f16_f16_zvfh depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c "")
-    skl_add_test(exp_f16 exp/exp_f16.c "-DRUN_ZVFH;-DRUN_VFEXPA;-DRUN_VFEXP")
-    skl_add_test(skl_gemm_f16_f16_f16_zvfh_x390_wrapper gemm/gemm_f16rc_f16rc_f16rc.c
+    skl_add_test_legacy(skl_depthwise_conv2d_f16_f16_f16_zvfh depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c "")
+    skl_add_test_legacy(exp_f16 exp/exp_f16.c "-DRUN_ZVFH;-DRUN_VFEXPA;-DRUN_VFEXP")
+    skl_add_test_legacy(skl_gemm_f16_f16_f16_zvfh_x390_wrapper gemm/gemm_f16rc_f16rc_f16rc.c
       "-DM=32;-DN=32;-DK=32;-DALPHA=1.f;-DBETA=0.f")
-    skl_add_test(skl_gemm_f16_f16_f32_zvfh_x390_wrapper gemm/gemm_f16rc_f16rc_f32rc.c
+    skl_add_test_legacy(skl_gemm_f16_f16_f32_zvfh_x390_wrapper gemm/gemm_f16rc_f16rc_f32rc.c
       "-DM=32;-DN=32;-DK=32;-DALPHA=1.f;-DBETA=0.f")
-    skl_add_test(logistic_f16 logistic/logistic_f16.c "-DRUN_ALL")
+    skl_add_test_legacy(logistic_f16 logistic/logistic_f16.c "-DRUN_ALL")
   endif()
-  skl_add_test(softmax_f16 softmax/softmax_f16.c "-DRUN_ALL;-DBETA=0.5")
-  skl_add_test(softmax_bf16 softmax/softmax_bf16.c "-DRUN_ALL;-DBETA=0.5")
-  skl_add_test(softmax_f32 softmax/softmax_f32.c "-DRUN_ALL;-DBETA=0.5")
-  skl_add_test(softmax_2d_f32 softmax/softmax_2d_f32.c
+  skl_add_test_legacy(softmax_f16 softmax/softmax_f16.c "-DRUN_ALL;-DBETA=0.5")
+  skl_add_test_legacy(softmax_bf16 softmax/softmax_bf16.c "-DRUN_ALL;-DBETA=0.5")
+  skl_add_test_legacy(softmax_f32 softmax/softmax_f32.c "-DRUN_ALL;-DBETA=0.5")
+  skl_add_test_legacy(softmax_2d_f32 softmax/softmax_2d_f32.c
     "-DRUN_ALL;-DM=64;-DN=128;-DBETA=0.5")
   if (RISCV_ZVE32F)
-    skl_add_test(skl_depthwise_conv2d_f32_f32_f32_zve32f depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c "")
-    skl_add_test(exp_f32 exp/exp_f32.c "-DRUN_ZVE32F;-DRUN_VFEXPA;-DRUN_VFEXP")
-    skl_add_test(exp_bf16 exp/exp_bf16.c "-DRUN_ZVE32F;-DRUN_VFBFA;-DRUN_VFEXP;-DRUN_VFEXPA")
-    skl_add_test(skl_gemm_f32_f32_f32_zve32f_x390_wrapper gemm/gemm_f32rc_f32rc_f32rc.c
+    skl_add_test_legacy(skl_depthwise_conv2d_f32_f32_f32_zve32f depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c "")
+    skl_add_test_legacy(exp_f32 exp/exp_f32.c "-DRUN_ZVE32F;-DRUN_VFEXPA;-DRUN_VFEXP")
+    skl_add_test_legacy(exp_bf16 exp/exp_bf16.c "-DRUN_ZVE32F;-DRUN_VFBFA;-DRUN_VFEXP;-DRUN_VFEXPA")
+    skl_add_test_legacy(skl_gemm_f32_f32_f32_zve32f_x390_wrapper gemm/gemm_f32rc_f32rc_f32rc.c
       "-DM=32;-DN=32;-DK=32;-DALPHA=1.f;-DBETA=0.f")
-    skl_add_test(logistic_f32_zve32f logistic/logistic_f32.c "-DRUN_ALL")
-    skl_add_test(gelu_f32 gelu/gelu_f32.c "")
+    skl_add_test_legacy(logistic_f32_zve32f logistic/logistic_f32.c "-DRUN_ALL")
+    skl_add_test_legacy(gelu_f32 gelu/gelu_f32.c "")
   endif()
   if(RISCV_ZVE64D)
-    skl_add_test(skl_gemm_f64_f64_f64_zve64d_x390_wrapper gemm/gemm_f64rc_f64rc_f64rc.c
+    skl_add_test_legacy(skl_gemm_f64_f64_f64_zve64d_x390_wrapper gemm/gemm_f64rc_f64rc_f64rc.c
       "-DM=32;-DN=32;-DK=32;-DALPHA=1.;-DBETA=0.")
   endif()
   if(RISCV_XSFMM32A8F)
-    skl_add_test(skl_gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f_wrapper gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
+    skl_add_test_legacy(skl_gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f_wrapper gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
       "-DRSA=1;-DCSA=128;-DM=128;-DN=128;-DK=32;-DALPHA=1.f;-DBETA=0.f")
-    skl_add_test(skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f_wrapper gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+    skl_add_test_legacy(skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f_wrapper gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
       "-DM0=${XSFMM_TE};-DN0=${XSFMM_TE};-DK0=1;-DM1=2;-DN1=2;-DK1=32;-DRSA0=1;-DCSA0=0;-DRSB0=0;-DCSB0=1;-DRSB1=(K0 * N0);-DCSB1=(K0 * N0 * K1);-DALPHA=1.f;-DBETA=0.f")
   endif()
   if(RISCV_XSFMM32A8I)
-    skl_add_test(skl_gemm_a1b01_i8c_i8_i32_xsfmm32a8i_wrapper gemm/gemm_i8rc_i8rc_i32rc.c
+    skl_add_test_legacy(skl_gemm_a1b01_i8c_i8_i32_xsfmm32a8i_wrapper gemm/gemm_i8rc_i8rc_i32rc.c
       "-DRSA=1;-DCSA=128;-DM=128;-DN=128;-DK=32;-DALPHA=1;-DBETA=0")
-    skl_add_test(skl_gemm_a1b01_i8pc_i8cp_i32rcp_xsfmm32a8i_wrapper gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+    skl_add_test_legacy(skl_gemm_a1b01_i8pc_i8cp_i32rcp_xsfmm32a8i_wrapper gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
       "-DM0=${XSFMM_TE};-DN0=${XSFMM_TE};-DK0=1;-DM1=2;-DN1=2;-DK1=32;-DRSA0=1;-DCSA0=0;-DRSB0=0;-DCSB0=1;-DRSB1=(K0 * N0);-DCSB1=(K0 * N0 * K1);-DALPHA=1;-DBETA=0")
   endif()
   if(RISCV_XSFMM32A16F)
-    skl_add_test(skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f_wrapper gemm/gemm_bf16rc_bf16rc_f32rc.c
+    skl_add_test_legacy(skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f_wrapper gemm/gemm_bf16rc_bf16rc_f32rc.c
       "-DRSA=1;-DCSA=128;-DM=128;-DN=128;-DK=32;-DALPHA=1.f;-DBETA=0.f")
-    skl_add_test(skl_gemm_a1b01_f16c_f16_f32_xsfmm32a16f_wrapper gemm/gemm_f16rc_f16rc_f32rc.c
+    skl_add_test_legacy(skl_gemm_a1b01_f16c_f16_f32_xsfmm32a16f_wrapper gemm/gemm_f16rc_f16rc_f32rc.c
       "-DRSA=1;-DCSA=128;-DM=128;-DN=128;-DK=32;-DALPHA=1.f;-DBETA=0.f")
-    skl_add_test(skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f_wrapper gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+    skl_add_test_legacy(skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f_wrapper gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
       "-DM0=${XSFMM_TE};-DN0=${XSFMM_TE};-DK0=1;-DM1=2;-DN1=2;-DK1=32;-DRSA0=1;-DCSA0=0;-DRSB0=0;-DCSB0=1;-DRSB1=(K0 * N0);-DCSB1=(K0 * N0 * K1);-DALPHA=1.f;-DBETA=0.f")
-    skl_add_test(skl_gemm_a1b01_f16pc_f16cp_f32rcp_xsfmm32a16f_wrapper gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+    skl_add_test_legacy(skl_gemm_a1b01_f16pc_f16cp_f32rcp_xsfmm32a16f_wrapper gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
       "-DM0=${XSFMM_TE};-DN0=${XSFMM_TE};-DK0=1;-DM1=2;-DN1=2;-DK1=32;-DRSA0=1;-DCSA0=0;-DRSB0=0;-DCSB0=1;-DRSB1=(K0 * N0);-DCSB1=(K0 * N0 * K1);-DALPHA=1.f;-DBETA=0.f")
   endif()
   if(RISCV_XSFMM32A32F)
-    skl_add_test(skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f_wrapper gemm/gemm_f32rc_f32rc_f32rc.c
-      "-DRSA=1;-DCSA=128;-DM=128;-DM=128;-DN=128;-DK=32;-DALPHA=1.f;-DBETA=0.f")
-    skl_add_test(skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f_wrapper gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+    skl_add_test_legacy(skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f_wrapper gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
       "-DM0=${XSFMM_TE};-DN0=${XSFMM_TE};-DK0=1;-DM1=2;-DN1=2;-DK1=32;-DRSA0=1;-DCSA0=0;-DRSB0=0;-DCSB0=1;-DRSB1=(K0 * N0);-DCSB1=(K0 * N0 * K1);-DALPHA=1.f;-DBETA=0.f")
   endif()
   if(RISCV_XSFMM)
-    skl_add_test(skl_transpose_e8_xsfmmbase transpose/transpose_e8.c "")
-    skl_add_test(skl_transpose_e16_xsfmmbase transpose/transpose_e16.c "")
-    skl_add_test(skl_transpose_e32_xsfmmbase transpose/transpose_e32.c "")
+    skl_add_test_legacy(skl_transpose_e8_xsfmmbase transpose/transpose_e8.c "")
+    skl_add_test_legacy(skl_transpose_e16_xsfmmbase transpose/transpose_e16.c "")
+    skl_add_test_legacy(skl_transpose_e32_xsfmmbase transpose/transpose_e32.c "")
   endif()
   if(RISCV_ZVFOFP8MIN)
     #For SCALING_TEST_MODE, 1: no scaling, 2: scaling, 3: both
     #For SATURATION_TEST_MODE, 1: no saturation, 2: saturation, 3: both
-    skl_add_test(skl_cvt_zvfofp8min cvt/cvt_ofp_zvfofp8min.c
+    skl_add_test_legacy(skl_cvt_zvfofp8min cvt/cvt_ofp_zvfofp8min.c
       "-DRUN_F32_E4M3;-DRUN_F32_E5M2;-DRUN_E4M3_BF16;-DRUN_E5M2_BF16;-DSCALING_TEST_MODE=3;-DSATURATION_TEST_MODE=3")
   endif()
   if(RISCV_ZVFOFP8MIN AND RISCV_ZVFBFMIN)
     #For SCALING_TEST_MODE, 1: no scaling, 2: scaling, 3: both
     #For SATURATION_TEST_MODE, 1: no saturation, 2: saturation, 3: both
-    skl_add_test(skl_cvt_zvfofp8min_zvfbfmin cvt/cvt_ofp_zvfofp8min_zvfbfmin.c
+    skl_add_test_legacy(skl_cvt_zvfofp8min_zvfbfmin cvt/cvt_ofp_zvfofp8min_zvfbfmin.c
       "-DRUN_BF16_E4M3;-DRUN_BF16_E5M2;-DSCALING_TEST_MODE=3;-DSATURATION_TEST_MODE=3")
   endif()
   if(RISCV_ZVFOFP4MIN)
-    skl_add_test(skl_cvt_zvfofp4min cvt/cvt_ofp_zvfofp4min.c "")
+    skl_add_test_legacy(skl_cvt_zvfofp4min cvt/cvt_ofp_zvfofp4min.c "")
   endif()
   if(RISCV_XSFVQDOTQ)
-    skl_add_test(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq gemm/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c "-DM=128;-DN=128;-DK=256;-DBETA=1")
-    skl_add_test(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_wrapper gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+    skl_add_test_legacy(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq gemm/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c "-DM=128;-DN=128;-DK=256;-DBETA=1")
+    skl_add_test_legacy(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_wrapper gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
       "-DM0=1;-DN0=1;-DK0=4;-DM1=12;-DN1=128;-DK1=8;-DRSB0=1;-DCSB0=0;-DALPHA=1;-DBETA=0;")
     skl_add_test(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_x390_clp_wrapper gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
       "-DM0=1;-DN0=1;-DK0=4;-DM1=12;-DN1=128;-DK1=8;-DRSB0=1;-DCSB0=0;-DALPHA=1;-DBETA=0;")
   endif()
+
+  add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,8 +388,6 @@ if (SKL_BUILD_TESTS OR SKL_BUILD_BENCHMARKS)
     skl_add_test_legacy(skl_depthwise_conv2d_f32_f32_f32_zve32f depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c "")
     skl_add_test_legacy(exp_f32 exp/exp_f32.c "-DRUN_ZVE32F;-DRUN_VFEXPA;-DRUN_VFEXP")
     skl_add_test_legacy(exp_bf16 exp/exp_bf16.c "-DRUN_ZVE32F;-DRUN_VFBFA;-DRUN_VFEXP;-DRUN_VFEXPA")
-    skl_add_test_legacy(skl_gemm_f32_f32_f32_zve32f_x390_wrapper gemm/gemm_f32rc_f32rc_f32rc.c
-      "-DM=32;-DN=32;-DK=32;-DALPHA=1.f;-DBETA=0.f")
     skl_add_test_legacy(logistic_f32_zve32f logistic/logistic_f32.c "-DRUN_ALL")
     skl_add_test_legacy(gelu_f32 gelu/gelu_f32.c "")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,7 +445,7 @@ if (SKL_BUILD_TESTS OR SKL_BUILD_BENCHMARKS)
     skl_add_test_legacy(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq gemm/gemm_a1b01_i8_i8pc_i32_xsfvqdotq.c "-DM=128;-DN=128;-DK=256;-DBETA=1")
     skl_add_test_legacy(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_wrapper gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
       "-DM0=1;-DN0=1;-DK0=4;-DM1=12;-DN1=128;-DK1=8;-DRSB0=1;-DCSB0=0;-DALPHA=1;-DBETA=0;")
-    skl_add_test(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_x390_clp_wrapper gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+    skl_add_test_legacy(skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq_x390_clp_wrapper gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
       "-DM0=1;-DN0=1;-DK0=4;-DM1=12;-DN1=128;-DK1=8;-DRSB0=1;-DCSB0=0;-DALPHA=1;-DBETA=0;")
   endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,14 @@ function(skl_add_test TEST_NAME HARNESS_SRC TEST_SRC OPTS)
     )
 endfunction()
 
+if(RISCV_ZVFH)
+  skl_add_test(
+    skl_gemm_f16_f16_f32_zvfh_x390
+    gemm/gemm_f16rc_f16rc_f32rc.c
+    gemm/rvv/skl_gemm_f16_f16_f32_zvfh_x390.c
+    ""
+  )
+endif()
 if(RISCV_ZVE32F)
     skl_add_test(
         skl_gemm_f32_f32_f32_zve32f_x390

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,40 @@
+set(SKL_TEST_LOG_LEVEL SKL_TEST_LOG_INFO CACHE STRING "Test log level")
+
+function(skl_add_test TEST_NAME HARNESS_SRC TEST_SRC OPTS)
+    add_executable(test-${TEST_NAME} ${HARNESS_SRC} ${TEST_SRC} skl-test-driver.c)
+    target_link_libraries(
+        test-${TEST_NAME}
+        PRIVATE ${SKL_LIBRARY} ${SKL_TEST_LIBS}
+    )
+    target_compile_options(
+        test-${TEST_NAME}
+        PRIVATE ${SKL_COMPILE_OPTIONS} ${SKL_TEST_COMPILE_OPTIONS} ${OPTS}
+    )
+    target_compile_definitions(
+        test-${TEST_NAME}
+        PRIVATE SKL_TEST_NAME=${TEST_NAME} SKL_TEST_LOG_LEVEL=${SKL_TEST_LOG_LEVEL}
+    )
+    target_include_directories(test-${TEST_NAME} PRIVATE . ../src)
+    add_test(
+        NAME test-${TEST_NAME}
+        COMMAND
+            ${SKL_TESTER} ${SKL_TESTER_OPTIONS} $<TARGET_FILE:test-${TEST_NAME}>
+    )
+endfunction()
+
+if(RISCV_ZVE32F)
+    skl_add_test(
+        skl_gemm_f32_f32_f32_zve32f_x390
+        gemm/gemm_f32rc_f32rc_f32rc.c
+        gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
+        ""
+    )
+endif()
+if(RISCV_XSFMM32A32F)
+    skl_add_test(
+        skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f
+        gemm/gemm_f32rc_f32rc_f32rc.c
+        gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
+        ""
+    )
+endif()

--- a/test/PR.md
+++ b/test/PR.md
@@ -1,0 +1,19 @@
+# SKL Test & Benchmark Framework Redesign
+
+
+This PR introduces a new test driver framework that replaces the legacy monolithic test files with a three-layer architecture:
+
+1. **Driver** (`skl-test-driver.{c,h}`) - Environment-specific test execution engine (provides memory allocation, performance counters, I/O)
+2. **Harness** (e.g., [gemm/gemm_f32rc_f32rc_f32rc.{c,h}](gemm/gemm_f32rc_f32rc_f32rc.h)) - Operation-specific test logic shared across all kernel variants in a family (init, verify, report, cleanup callbacks)
+3. **Test Suite** (e.g., [gemm/xsfmm/skl_gemm_*.c](gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c)) - Kernel-specific test definitions (array of test configs + execute callback)
+
+See [README.md](README.md) for detailed usage guide, examples, and buffer management.
+See [skl-test-driver.h](skl-test-driver.h) for complete API reference.
+
+## Status
+
+This PR only converts FP32 GEMM tests to the new framework as an example.
+I would like to hear everyone's feedback and suggestions now based on this initial example.
+Once we all agree on the design, I will ask individual owners of each kernel family to migrate their tests to this new framework.
+
+Ultimately, we want to eliminate the legacy `skl-test.h` framework, and possibly that file itself unless we keep some utility functions in there.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,195 @@
+# SKL Test and Benchmark Collection
+
+## Goals and Coverage
+
+SKL provides a set of tests and benchmarks for each family of kernels that can be used to test their operation and performance.
+These can be located within the `test/` directory.
+Each kernel family (defined by a scalar reference routine) has a corresponding test program that can exercise all of its variants, as supported by a given compilation target.
+
+The tests are intended to demonstrate proper usage of each kernel and to provide a minimal level of validation for CI purposes.
+They are not intended to be exhaustive, and are not suitable for use as a standalone validation suite.
+The only requirement to run the tests, aside from a compatible toolchain, is RISC-V QEMU with appropriate ISA support.
+
+The benchmarks are intended to showcase kernel performance, and illustrate optimal parameter settings for chosen platforms.
+Use of the benchmarks requires either access to RISC-V silicon or a cycle-accurate simulator.
+
+## Test Driver Framework
+
+The test and benchmark collection is structured to make writing tests as simple as possible.
+It provides an abstraction layer for common test-related functionality, such as allocating and initializing test data buffers, and measuring runtime.
+This abstraction is implemented in the form of a test driver framework, consisting of three parts:
+- **Harness**: A test harness is a C file that defines the test configuration and callbacks for a given kernel family.
+  It is responsible for setting up the test data, executing the kernel, and verifying the results based on the configured parameters.
+  The harness is the only part of the test that is specific to a given kernel family.
+- **Test Suite**: A test suite is a list of test cases that share a common harness.
+  Each test case is defined by a set of parameters, and is executed by the harness.
+  The test suite is responsible for defining the test cases, and for executing the harness for each test case.
+- **Driver**: The test driver is a C program that executes a test suite and interfaces with the system environment.
+  It provides functions for I/O, memory allocation, and performance measurement, and calls the harness callbacks to execute the tests.
+
+### Test Harness
+
+A harness encapsulates all of the test logic for a given kernel family, and defines a _test configuration_ structure that is used to parametrize individual test cases.
+For example, the `gemm_f32rc_f32rc_f32rc` [harness](gemm/gemm_f32rc_f32rc_f32rc.h) defines a configuration structure that contains the matrix dimensions, strides, and scaling factors for a GEMM test case:
+```c
+typedef struct {
+  // Test mode
+  bool warmup;
+  bool verify;
+
+  // Configurable parameters (arguments to GEMM function)
+  size_t m, n, k;
+  float alpha;
+  size_t rsa, csa;
+  size_t rsb, csb;
+  float beta;
+  size_t rsc, csc;
+
+  // Buffer generation settings for A, B, C
+  SKL_TEST_BUFFER(float) a, b, c;
+
+  // Derived parameters & buffers (private to the test harness)
+  struct {
+    double *a_wide, *b_wide;
+    float *ref_c;
+    double *bound;
+  } ctx;
+} gemm_f32rc_f32rc_f32rc_t;
+```
+
+Generally, such structures will separate configurable settings from derived parameters and test state, with the latter contained in a nested structure as shown above.
+Test buffers are an exception, because the `SKL_TEST_BUFFER` structure contains both the buffer pointer and the configuration parameters for buffer generation (see [Buffer Management](#buffer-management) below).
+
+The harness must implement a set of _callback functions_ that are called by the driver to execute the test.
+The callback functions are:
+- `init`: Initialization function called at the start of each test case.
+  It is responsible for allocating and initializing the test data buffers, and for setting up any other test-specific state, as well as computing any derived parameters.
+- `warmup`: Warmup function called before the main test execution.
+  It is responsible for any necessary warmup iterations, such as to ensure that the instruction cache is fully loaded.
+- `execute`: The main test execution function.
+  It is responsible for calling the kernel function with the appropriate parameters.
+- `verify`: Verification function called after the test execution.
+  It is responsible for checking the results of the test against a reference implementation.
+- `report`: Reporting function called after the test execution.
+  It is responsible for printing any test-specific results or statistics.
+- `cleanup`: Cleanup function called at the end of each test case.
+  It is responsible for freeing any test-specific resources.
+
+Most of these functions should be reusable across different kernels in the same family, so only the `execute` function needs to be customized for each kernel variant to call the appropriate kernel function and pass it the correct parameters.
+
+All callback functions take a `skl_test_t` pointer as their only argument, which is a generic test context structure defined in [skl-test.h](skl-test.h).
+The `skl_test_t` structure contains a pointer to the test configuration structure defined by the harness, as well as other fields used by the driver for bookkeeping and reporting:
+```c
+typedef struct skl_test_t {
+  const skl_test_suite_t *suite;  // Test suite (set by driver before init)
+  void *harness;                  // Harness-specific data (set by harness in init)
+  int log_level;                  // Logging verbosity level (set by driver before init)
+  skl_test_counters_t counters;   // Performance counters (updated by driver)
+  skl_test_status_t status;       // Test pass/fail status
+} skl_test_t;
+```
+In order to access the test configuration structure, the callback function should cast the `harness` pointer to the appropriate type.
+For example, the `gemm_f32rc_f32rc_f32rc` harness uses the following pattern in its `init` function:
+```c
+gemm_f32rc_f32rc_f32rc_t *h = t->harness;
+```
+
+### Test Suite
+
+A test suite is a collection of related tests that share a common harness, and may be intended for use with a specific driver or environment.
+
+These tests are enumerated in a C file as an array of test configuration structures.
+For example, the `skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f` [test suite](gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c) defines an array of `gemm_f32rc_f32rc_f32rc_t` structures, each of which configures a different set of matrix dimensions and strides for the GEMM test case:
+```c
+#define TEST GEMM_F32RC_F32RC_F32RC_DEFAULTS, .warmup = false, .verify = true
+#define BENCH GEMM_F32RC_F32RC_F32RC_DEFAULTS, .warmup = true, .verify = false
+static int execute(skl_test_t *t);
+
+// clang-format off
+gemm_f32rc_f32rc_f32rc_t tests[] = {
+    // Benchmark tests
+    {BENCH, .m = 128, .n = 128, .k = 2048, .beta = 0.f},
+    {BENCH, .m = 128, .n = 128, .k = 2048, .beta = 1.f},
+    ...
+    // Verification tests
+    {TEST, .m = 16,  .n = 16,  .k = 16},
+    {TEST, .m = 16,  .n = 16,  .k = 16,  .beta = 1.f},
+    ...
+};
+```
+The list of test cases may include both correctness tests and performance benchmarks, distinguished by harness-specific flags such as `warmup` and `verify` in the example above.
+That pattern is considered idiomatic for this repository.
+
+The test suite must also define a `skl_test_suite_t` structure that describes the test suite to the driver, and includes the array of test configurations:
+```c
+skl_test_suite_t suite = {
+    .name = "skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f",
+    .tests = tests,
+    .num_tests = sizeof(tests) / sizeof(tests[0]),
+    .test_size = sizeof(tests[0]),
+    .init = init,
+    .warmup = gemm_f32rc_f32rc_f32rc_warmup, // defined in the harness
+    .execute = execute, // defined in the test suite C file
+    .verify = gemm_f32rc_f32rc_f32rc_verify, // defined in the harness
+    .report = gemm_f32rc_f32rc_f32rc_report, // defined in the harness
+    .cleanup = gemm_f32rc_f32rc_f32rc_cleanup, // defined in the harness
+};
+```
+The suite struct definition sets pointers to callback functions, most of which are implemented in the harness.
+The `execute` function is the generally only one that needs to be implemented in the test suite C file, because it is the only one that is specific to a given kernel variant, but it is possible to override any of the harness callbacks by setting them to non-NULL values in the suite struct.
+(Some harnesses may want to override the report function to customize output formatting for parsing by automatic test runners etc.)
+
+The test suite C file must also call `skl_test_driver_run_suite` to execute the test suite, generally inside its own `main` function:
+```c
+int main() {
+  return skl_test_driver_run_suite(&suite);
+}
+```
+
+### Driver
+
+The test driver is a C program that executes a test suite and interfaces with the system environment.
+It provides functions for I/O, memory allocation, and performance measurement, and calls the harness callbacks to execute the tests.
+
+The SKL repo provides its own simple driver implementation in [skl-test-driver.c](skl-test-driver.c), which is sufficient for running the tests in QEMU.
+Other environments will need to provide their own driver implementation that overrides the default implementations as needed.
+However, all drivers share the same interface, defined in [skl-test-driver.h](skl-test-driver.h).
+
+Functions provided by the driver are:
+- `skl_test_driver_run_suite`: Runs a test suite.
+- `skl_test_driver_alloc`: Allocates memory for a test buffer.
+- `skl_test_driver_free`: Frees memory for a test buffer.
+- `skl_test_driver_update_counters`: Reads the current values of the performance counters and records the delta since the last update.
+- `skl_test_driver_log`: Prints a log message with a given log level.
+- `skl_test_driver_error`: Prints an error message and sets the test status to `SKL_TEST_FAIL`.
+
+
+### Buffer Management
+
+SKL _test buffers_ refer to arrays of input data used by tests, and defined by how they are initialized as well as where they are stored in memory.
+The `SKL_TEST_BUFFER` macro is used to define a test buffer in a test configuration structure, and the `SKL_TEST_BUF_CREATE` macro is used to allocate and initialize the buffer at runtime.
+This pair of abstractions allows tests to express succinct data ranges of interest (min, max, random, sequential, etc.) in their configurations.
+It also allows test suites to tell a driver that they want buffers to be allocated in a particular way, for example to exercise different memory regions or alignment constraints.
+
+The `SKL_TEST_BUFFER` macro defines a structure that contains the following members:
+```c
+// For TYPE given by the SKL_TEST_BUFFER macro:
+struct {
+  TYPE *data; // Pointer to the buffer data (set by driver)
+  size_t len; // Length of the buffer (set by test configuration)
+  skl_test_init_mode_t mode; // enum: random, static, sequential
+  TYPE min, max;
+  const TYPE *static_data; // Contains actual data for static mode
+  size_t static_data_len;
+  size_t region; // Meaning defined by the driver
+};
+```
+Test configurations will populate the `len`, `mode`, `min`, and `max` fields typically, though some harnesses may also provide configuration options for `static_data` and `region` as well.
+The range fields allow targeted test specification, while static data serves two purposes:
+- It allows for the definition of "special" input patterns that are difficult to express with ranges alone, such as all-zero or all-one vectors.
+- It allows for fast initialization by memcpy, and avoids constly calls to `rand()` in slow simulation environments.
+
+The `SKL_TEST_BUF_CREATE` macro should be called in the `init` function of the test harness to allocate and initialize each test buffer.
+It injects type-dependent code to initialize the buffer according to the `mode` field of the `SKL_TEST_BUFFER` structure.
+All buffers must be freed in the `cleanup` function with the `SKL_TEST_BUF_FREE` macro.
+

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -1,221 +1,145 @@
 // Copyright 2025 SiFive, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
+/**
+ * @brief Implementation of the gemm_f16rc_f16rc_f32rc test harness.
  *
- * A is M x K with row stride RSA and column stride CSA.
- * B is K x N with row stride RSB and column stride CSB.
- * C is M x N with row stride RSC and column stride CSC.
- *
- * Users must provide the values of the following as compiler flags using -D:
- *  - All dimensions M, N, and K;
- *  - Both RSA and CSA; or neither (implying RSA = K, CSA = 1)
- *  - Both RSB and CSB; or neither (implying RSB = N, CSB = 1)
- *  - Both RSC and CSC; or neither (implying RSC = N, CSC = 1)
- *  - Both ALPHA and BETA, as floating point literals.
+ * This file defines all harness functions _except_ `skl_test_execute`, which is
+ * defined in the test file (e.g. rvv/skl_gemm_f16_f16_f32_zvfh_x390.c).
  */
-
-#if !(defined(ENABLE_TEST) || defined(ENABLE_BENCHMARK))
-#error Must define at least one of ENABLE_TEST and ENABLE_BENCHMARK
-#endif
-
-#ifndef M
-#error Must define M
-#endif
-
-#ifndef N
-#error Must define N
-#endif
-
-#ifndef K
-#error Must define K
-#endif
-
-#ifndef ALPHA
-#error Must define ALPHA
-#endif
-
-#ifndef BETA
-#error Must define BETA
-#endif
-
-#if defined(ENABLE_TEST)
-#include <math.h>
-#endif
-
-#ifndef SKL_TEST_PERF_REPORT
-#define SKL_TEST_PERF_REPORT report_perf_mpc
-#endif
-
-#include "skl-test.h"
+#include "gemm_f16rc_f16rc_f32rc.h"
+#include "skl-test-driver.h"
 #include "skl.h"
-#include <inttypes.h>
+
+#include <math.h>
 #include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(__riscv_zvfh)
-void skl_gemm_f16_f16_f32_zvfh_x390_wrapper(size_t m, size_t n, size_t k,
-                                            float alpha, const _Float16 *a,
-                                            size_t rsa, size_t csa,
-                                            const _Float16 *b, size_t rsb,
-                                            size_t csb, float beta, float *c,
-                                            size_t rsc, size_t csc) {
-  int status = 0;
-  SKL_TEST_REQUIRE(status, csa == 1);
-  SKL_TEST_REQUIRE(status, csb == 1);
-  SKL_TEST_REQUIRE(status, csc == 1);
-  if (status) {
-    exit(status);
+int gemm_f16rc_f16rc_f32rc_init(skl_test_t *t) {
+  gemm_f16rc_f16rc_f32rc_t *h = (gemm_f16rc_f16rc_f32rc_t *)t->harness;
+
+  // Set buffer lengths.
+  // Handle zero dimensions to avoid size_t underflow in (dim - 1) expressions
+  if (h->m == 0 || h->n == 0 || h->k == 0) {
+    h->a.len = 0;
+    h->b.len = 0;
+  } else {
+    h->a.len = (h->m - 1) * h->rsa + (h->k - 1) * h->csa + 1;
+    h->b.len = (h->k - 1) * h->rsb + (h->n - 1) * h->csb + 1;
   }
-  skl_gemm_f16_f16_f32_zvfh_x390(m, n, k, alpha, a, rsa, b, rsb, beta, c, rsc);
+  if (h->m == 0 || h->n == 0) {
+    h->c.len = 0;
+  } else {
+    h->c.len = (h->m - 1) * h->rsc + (h->n - 1) * h->csc + 1;
+  }
+
+  SKL_TEST_BUF_CREATE(t, _Float16, &h->a);
+  SKL_TEST_BUF_CREATE(t, _Float16, &h->b);
+  SKL_TEST_BUF_CREATE(t, float, &h->c);
+
+  if (h->verify) {
+    // Only allocate if lengths are non-zero to avoid malloc(0)
+    h->ctx.a_wide = h->a.len > 0 ? malloc(h->a.len * sizeof(double)) : NULL;
+    h->ctx.b_wide = h->b.len > 0 ? malloc(h->b.len * sizeof(double)) : NULL;
+    h->ctx.ref_c = h->c.len > 0 ? malloc(h->c.len * sizeof(float)) : NULL;
+    h->ctx.bound = h->c.len > 0 ? malloc(h->c.len * sizeof(double)) : NULL;
+    // Copy initial C values to ref_c for the beta*C term in reference GEMM
+    memcpy(h->ctx.ref_c, h->c.data, h->c.len * sizeof(float));
+  }
+
+  return 0;
 }
-#endif
 
-#if defined(__riscv_xsfmm32a16f)
-void skl_gemm_a1b01_f16c_f16_f32_xsfmm32a16f_wrapper(
-    size_t m, size_t n, size_t k, float alpha, const _Float16 *a, size_t rsa,
-    size_t csa, const _Float16 *b, size_t rsb, size_t csb, float beta, float *c,
-    size_t rsc, size_t csc) {
-  int status = 0;
-  SKL_TEST_REQUIRE(status, rsa == 1);
-  SKL_TEST_REQUIRE(status, csb == 1);
-  SKL_TEST_REQUIRE(status, csc == 1);
-  SKL_TEST_REQUIRE(status, alpha == 1.f);
-  SKL_TEST_REQUIRE(status, beta == 0.f || beta == 1.f);
-  if (status) {
-    exit(status);
+int gemm_f16rc_f16rc_f32rc_warmup(skl_test_t *t) {
+  gemm_f16rc_f16rc_f32rc_t *h = (gemm_f16rc_f16rc_f32rc_t *)t->harness;
+  if (h->warmup) {
+    return t->suite->execute(t);
   }
-  skl_gemm_a1b01_f16c_f16_f32_xsfmm32a16f(m, n, k, a, csa, b, rsb, c, rsc,
-                                          beta != 0.f);
+  return 0;
 }
-#endif
 
-/* The macros below set the matrix strides. */
-#if !defined(RSA) && !defined(CSA)
-#define RSA K // Default to row major
-#define CSA 1
-#elif !defined(RSA) || !defined(CSA)
-#error Must define both RSA and CSA, or neither
-#endif
-#if !defined(RSB) && !defined(CSB)
-#define RSB N // Default to row major
-#define CSB 1
-#elif !defined(RSB) || !defined(CSB)
-#error Must define both RSB and CSB, or neither
-#endif
-#if !defined(RSC) && !defined(CSC)
-#define RSC N // Default to row major
-#define CSC 1
-#elif !defined(RSC) || !defined(CSC)
-#error Must define both RSC and CSC, or neither
-#endif
+int gemm_f16rc_f16rc_f32rc_verify(skl_test_t *t) {
+  gemm_f16rc_f16rc_f32rc_t *h = (gemm_f16rc_f16rc_f32rc_t *)t->harness;
 
-/* Input, output, reference, and error bound arrays */
-enum {
-  ALIGN = 4096,
-  CLEN = ((M - 1) * RSC + (N - 1) * CSC + 1),
-  ALEN = ((M - 1) * RSA + (K - 1) * CSA + 1),
-  BLEN = ((K - 1) * RSB + (N - 1) * CSB + 1),
-};
-_Alignas(ALIGN) _Float16 a[ALEN];
-_Alignas(ALIGN) _Float16 b[BLEN];
-_Alignas(ALIGN) float c[CLEN];
-#if defined(ENABLE_TEST)
-double a_wide[ALEN];
-double b_wide[BLEN];
-float ref_c[CLEN], test_c[CLEN];
-double bound[CLEN];
-#endif // ENABLE_TEST
-
-#if defined(ENABLE_TEST)
-/* Check result after executing test and reference functions.
- *
- * Compares the test_c and ref_c matrices based on a bound derived from
- * problem parameters. Returns nonzero in case of an error, and prints
- * first incorrect output matrix element. */
-int check_error(void) {
-  /* Compute the reference (scalar) matrix output. */
-  skl_gemm_f16rc_f16rc_f32rc_scalar(M, N, K, ALPHA, a, RSA, CSA, b, RSB, CSB,
-                                    BETA, ref_c, RSC, CSC);
-
-  //
-  // Compute the error bound array for comparing test vs reference results.
-  //
-  // For any matrix M, define |M| as the matrix of absolute values where:
-  //     |M|(i,j) = |M(i,j)|
-  //
-  // Let u = 2^-P be the maximum relative roundoff error for a floating-point
-  // type with P-1 mantissa bits.
-  //
-  // For GEMM operations, the error between computed and exact results is
-  // bounded by:
-  //     ((1 + u)^(K + 2) - 1) * (|alpha| * |A| * |B| + |beta| * |C|)
-  //
-  // Since both test and reference results have roundoff errors, we double this
-  // bound using the triangle inequality to get the final comparison threshold.
-  //
-  for (size_t i = 0; i < ALEN; ++i) {
-    a_wide[i] = fabsf((float)a[i]);
+  if (!h->verify) {
+    return 0;
   }
-  for (size_t i = 0; i < BLEN; ++i) {
-    b_wide[i] = fabsf((float)b[i]);
+
+  for (size_t i = 0; i < h->a.len; ++i) {
+    h->ctx.a_wide[i] = fabs((double)h->a.data[i]);
   }
-  for (size_t i = 0; i < CLEN; ++i) {
-    bound[i] = fabsf(c[i]);
+  for (size_t i = 0; i < h->b.len; ++i) {
+    h->ctx.b_wide[i] = fabs((double)h->b.data[i]);
   }
+  for (size_t i = 0; i < h->c.len; ++i) {
+    h->ctx.bound[i] = fabs((double)h->c.data[i]);
+  }
+
   const int P = 24; // 23 bits of mantissa for float32 accumulator
   const double u = ldexp(1.0, -P); // Maximum relative roundoff error
   // Compute 2 * ((1 + u)^(K + 2) - 1) by change of base formula:
-  const double roundoff_scaling = 2 * expm1((K + 2) * log1p(u));
+  const double roundoff_scaling = 2 * expm1((double)(h->k + 2) * log1p(u));
   skl_gemm_f64rc_f64rc_f64rc_scalar(
-      M, N, K, roundoff_scaling * fabs((double)ALPHA), a_wide, RSA, CSA, b_wide,
-      RSB, CSB, roundoff_scaling * fabs((double)BETA), bound, RSC, CSC);
+      h->m, h->n, h->k, roundoff_scaling * fabs((double)h->alpha),
+      h->ctx.a_wide, h->rsa, h->csa, h->ctx.b_wide, h->rsb, h->csb,
+      roundoff_scaling * fabs((double)h->beta), h->ctx.bound, h->rsc, h->csc);
 
-  /* Compare the reference and test outputs. */
-  for (size_t i = 0; i < M; ++i) {
-    for (size_t j = 0; j < N; ++j) {
-      size_t idx = i * RSC + j * CSC;
-      if (fabs((double)test_c[idx] - (double)ref_c[idx]) > bound[idx]) {
-        printf("result [%zu, %zu] (%f) != reference (%f)\n", i, j, test_c[idx],
-               ref_c[idx]);
-        return 1;
+  skl_gemm_f16rc_f16rc_f32rc_scalar(h->m, h->n, h->k, h->alpha, h->a.data,
+                                    h->rsa, h->csa, h->b.data, h->rsb, h->csb,
+                                    h->beta, h->ctx.ref_c, h->rsc, h->csc);
+
+  for (size_t i = 0; i < h->m; ++i) {
+    for (size_t j = 0; j < h->n; ++j) {
+      size_t idx = i * h->rsc + j * h->csc;
+      float res = h->c.data[idx];
+      float ref = h->ctx.ref_c[idx];
+      double bnd = h->ctx.bound[idx];
+      if (fabs((double)res - (double)ref) > bnd) {
+        skl_test_driver_error(
+            t, "result [%zu, %zu] (%f) != reference (%f) [bound = %f]\n", i, j,
+            res, ref, bnd);
+        return 1; // Error
       }
     }
   }
 
   return 0;
 }
-#endif // ENABLE_TEST
 
-int main(void) {
-  int res = EXIT_SUCCESS;
+int gemm_f16rc_f16rc_f32rc_report(skl_test_t *t) {
+  gemm_f16rc_f16rc_f32rc_t *h = (gemm_f16rc_f16rc_f32rc_t *)t->harness;
 
-  printf("%s:\n", skl_test_name);
-  printf("M = %u, N = %u, K = %u\n", M, N, K);
-  printf("ALPHA = %f, BETA = %f\n", ALPHA, BETA);
-  printf("RSA = %u, CSA = %u\n", RSA, CSA);
-  printf("RSB = %u, CSB = %u\n", RSB, CSB);
-  printf("RSC = %u, CSC = %u\n", RSC, CSC);
+  size_t maccs = h->m * h->n * h->k;
+  float mpc = (float)maccs / (float)t->counters.cycles;
 
-  /* Populate the matrices. */
-  skl_test_init_f16(a, ALEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
-  skl_test_init_f16(b, BLEN, SKL_TEST_MIN_F16, SKL_TEST_MAX_F16);
-  skl_test_init_f32(c, CLEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
+#define INFO(fmt, ...) SKL_TEST_LOG(t, SKL_TEST_LOG_INFO, fmt, __VA_ARGS__)
+  INFO("M: %zd, N: %zd, K: %zd\n", h->m, h->n, h->k);
+  INFO("RSA: %zd, CSA: %zd\n", h->rsa, h->csa);
+  INFO("RSB: %zd, CSB: %zd\n", h->rsb, h->csb);
+  INFO("RSC: %zd, CSC: %zd\n", h->rsc, h->csc);
+  INFO("Alpha: %f, Beta: %f\n", (float)h->alpha, (float)h->beta);
+  INFO("%s", "\n");
+  INFO("Warmup: %s\n", h->warmup ? "yes" : "no");
+  INFO("Cycles: %zd\n", t->counters.cycles);
+  INFO("Instructions: %zd\n", t->counters.instret);
+  INFO("MACs/Cycle: %f\n", mpc);
+#undef INFO
 
-#if defined(ENABLE_TEST)
-  /* Make copies of C to write the reference and test outputs to. */
-  memcpy(ref_c, c, CLEN * sizeof(float));
-  memcpy(test_c, c, CLEN * sizeof(float));
-  SKL_TEST_NAME(M, N, K, ALPHA, a, RSA, CSA, b, RSB, CSB, BETA, test_c, RSC,
-                CSC);
-  res += check_error();
-#endif // ENABLE_TEST
+  return 0;
+}
 
-  SKL_BENCHMARK_RUN(skl_test_name, M * N * K, SKL_TEST_WARMUP, SKL_TEST_NAME, M,
-                    N, K, ALPHA, a, RSA, CSA, b, RSB, CSB, BETA, c, RSC, CSC);
+int gemm_f16rc_f16rc_f32rc_cleanup(skl_test_t *t) {
+  gemm_f16rc_f16rc_f32rc_t *h = (gemm_f16rc_f16rc_f32rc_t *)t->harness;
 
-  return res;
+  SKL_TEST_BUF_FREE(t, &h->a);
+  SKL_TEST_BUF_FREE(t, &h->b);
+  SKL_TEST_BUF_FREE(t, &h->c);
+  if (h->verify) {
+    free(h->ctx.a_wide);
+    free(h->ctx.b_wide);
+    free(h->ctx.ref_c);
+    free(h->ctx.bound);
+  }
+  return 0;
 }

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -7,6 +7,7 @@
  * This file defines all harness functions _except_ `skl_test_execute`, which is
  * defined in the test file (e.g. rvv/skl_gemm_f16_f16_f32_zvfh_x390.c).
  */
+
 #include "gemm_f16rc_f16rc_f32rc.h"
 #include "skl-test-driver.h"
 #include "skl.h"
@@ -34,6 +35,7 @@ int gemm_f16rc_f16rc_f32rc_init(skl_test_t *t) {
     h->c.len = (h->m - 1) * h->rsc + (h->n - 1) * h->csc + 1;
   }
 
+  // Allocate buffers
   SKL_TEST_BUF_CREATE(t, _Float16, &h->a);
   SKL_TEST_BUF_CREATE(t, _Float16, &h->b);
   SKL_TEST_BUF_CREATE(t, float, &h->c);
@@ -66,6 +68,11 @@ int gemm_f16rc_f16rc_f32rc_verify(skl_test_t *t) {
     return 0;
   }
 
+  //
+  // Compute the error bound array for comparing test vs reference results.
+  // Since both test and reference results have roundoff errors, we double this
+  // bound using the triangle inequality to get the final comparison threshold.
+  //
   for (size_t i = 0; i < h->a.len; ++i) {
     h->ctx.a_wide[i] = fabs((double)h->a.data[i]);
   }
@@ -85,10 +92,14 @@ int gemm_f16rc_f16rc_f32rc_verify(skl_test_t *t) {
       h->ctx.a_wide, h->rsa, h->csa, h->ctx.b_wide, h->rsb, h->csb,
       roundoff_scaling * fabs((double)h->beta), h->ctx.bound, h->rsc, h->csc);
 
+  // Compute the reference result using h->ctx.ref_c.
+  // h->ctx.ref_c contains the original C values (copied during init).
+  // After this call, h->ctx.ref_c will contain the reference result.
   skl_gemm_f16rc_f16rc_f32rc_scalar(h->m, h->n, h->k, h->alpha, h->a.data,
                                     h->rsa, h->csa, h->b.data, h->rsb, h->csb,
                                     h->beta, h->ctx.ref_c, h->rsc, h->csc);
 
+  // Compare the reference and test outputs using error bound.
   for (size_t i = 0; i < h->m; ++i) {
     for (size_t j = 0; j < h->n; ++j) {
       size_t idx = i * h->rsc + j * h->csc;
@@ -104,7 +115,7 @@ int gemm_f16rc_f16rc_f32rc_verify(skl_test_t *t) {
     }
   }
 
-  return 0;
+  return 0; // Success
 }
 
 int gemm_f16rc_f16rc_f32rc_report(skl_test_t *t) {
@@ -132,6 +143,7 @@ int gemm_f16rc_f16rc_f32rc_report(skl_test_t *t) {
 int gemm_f16rc_f16rc_f32rc_cleanup(skl_test_t *t) {
   gemm_f16rc_f16rc_f32rc_t *h = (gemm_f16rc_f16rc_f32rc_t *)t->harness;
 
+  // Free buffers
   SKL_TEST_BUF_FREE(t, &h->a);
   SKL_TEST_BUF_FREE(t, &h->b);
   SKL_TEST_BUF_FREE(t, &h->c);

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.h
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.h
@@ -1,0 +1,33 @@
+
+
+#include "skl-test-driver.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+  bool warmup;
+  bool verify;
+
+  size_t m, n, k;
+  _Float16 alpha;
+  SKL_TEST_BUFFER(_Float16) a;
+  size_t rsa, csa;
+  SKL_TEST_BUFFER(_Float16) b;
+  size_t rsb, csb;
+  _Float16 beta;
+  SKL_TEST_BUFFER(float) c;
+  size_t rsc, csc;
+
+  struct {
+    double *a_wide, *b_wide;
+    float *ref_c;
+    double *bound;
+  } ctx;
+} gemm_f16rc_f16rc_f32rc_t;
+
+int gemm_f16rc_f16rc_f32rc_init(skl_test_t *t);
+int gemm_f16rc_f16rc_f32rc_warmup(skl_test_t *t);
+int gemm_f16rc_f16rc_f32rc_verify(skl_test_t *t);
+int gemm_f16rc_f16rc_f32rc_report(skl_test_t *t);
+int gemm_f16rc_f16rc_f32rc_cleanup(skl_test_t *t);

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.h
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.h
@@ -52,3 +52,15 @@ int gemm_f16rc_f16rc_f32rc_warmup(skl_test_t *t);
 int gemm_f16rc_f16rc_f32rc_verify(skl_test_t *t);
 int gemm_f16rc_f16rc_f32rc_report(skl_test_t *t);
 int gemm_f16rc_f16rc_f32rc_cleanup(skl_test_t *t);
+
+#define GEMM_F16RC_F16RC_F32RC_DEFAULTS                                        \
+  .a = {.min = (_Float16)-1.0f,                                                \
+        .max = (_Float16)1.0f,                                                 \
+        .mode = SKL_TEST_RANDOM},                                              \
+  .b = {.min = (_Float16)-1.0f,                                                \
+        .max = (_Float16)1.0f,                                                 \
+        .mode = SKL_TEST_RANDOM},                                              \
+  .c = {.min = (_Float16)-1.0f,                                                \
+        .max = (_Float16)1.0f,                                                 \
+        .mode = SKL_TEST_RANDOM},                                              \
+  .alpha = (_Float16)2.f, .beta = (_Float16)3.f

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.h
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.h
@@ -60,7 +60,5 @@ int gemm_f16rc_f16rc_f32rc_cleanup(skl_test_t *t);
   .b = {.min = (_Float16)-1.0f,                                                \
         .max = (_Float16)1.0f,                                                 \
         .mode = SKL_TEST_RANDOM},                                              \
-  .c = {.min = (_Float16)-1.0f,                                                \
-        .max = (_Float16)1.0f,                                                 \
-        .mode = SKL_TEST_RANDOM},                                              \
+  .c = {.min = -1.0f, .max = 1.0f, .mode = SKL_TEST_RANDOM},                   \
   .alpha = (_Float16)2.f, .beta = (_Float16)3.f

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.h
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.h
@@ -1,4 +1,22 @@
+// Copyright 2026 SiFive, Inc.
+// SPDX-License-Identifier: Apache-2.0
 
+/**
+ * @brief Test and benchmark for GEMM: C = alpha * A * B + beta * C.
+ *
+ * This test uses a table-driven approach where test configurations are defined
+ * in the `tests` array. Each test specifies:
+ *  - Matrix dimensions M, N, and K
+ *  - Scalar coefficients ALPHA and BETA
+ *  - Row and column strides (RSA, CSA, RSB, CSB, RSC, CSC)
+ *  - The GEMM kernel function to test
+ *
+ * Matrix layouts:
+ *  - A is M x K with row stride RSA and column stride CSA
+ *  - B is K x N with row stride RSB and column stride CSB
+ *  - C is M x N with row stride RSC and column stride CSC
+ */
+#pragma once
 
 #include "skl-test-driver.h"
 #include <stdbool.h>
@@ -6,9 +24,11 @@
 #include <stdint.h>
 
 typedef struct {
+  // Test configuration
   bool warmup;
   bool verify;
 
+  // Kernel parameters
   size_t m, n, k;
   _Float16 alpha;
   SKL_TEST_BUFFER(_Float16) a;
@@ -19,6 +39,7 @@ typedef struct {
   SKL_TEST_BUFFER(float) c;
   size_t rsc, csc;
 
+  // Derived parameters & buffers (private to the test harness)
   struct {
     double *a_wide, *b_wide;
     float *ref_c;

--- a/test/gemm/gemm_f32rc_f32rc_f32rc.c
+++ b/test/gemm/gemm_f32rc_f32rc_f32rc.c
@@ -1,154 +1,73 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright 2026 SiFive, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
+/**
+ * @brief Implementation of the gemm_f32rc_f32rc_f32rc test harness.
  *
- * A is M x K with row stride RSA and column stride CSA.
- * B is K x N with row stride RSB and column stride CSB.
- * C is M x N with row stride RSC and column stride CSC.
- *
- * Users must provide the values of the following as compiler flags using -D:
- *  - All dimensions M, N, and K;
- *  - Both RSA and CSA; or neither (implying RSA = K, CSA = 1)
- *  - Both RSB and CSB; or neither (implying RSB = N, CSB = 1)
- *  - Both RSC and CSC; or neither (implying RSC = N, CSC = 1)
- *  - Both ALPHA and BETA, as floating point literals.
+ * This file defines all harness functions _except_ `skl_test_execute`, which is
+ * defined in the test file (e.g. rvv/skl_gemm_f32_f32_f32_zve32f_x390.c).
  */
 
-#if !(defined(ENABLE_TEST) || defined(ENABLE_BENCHMARK))
-#error Must define at least one of ENABLE_TEST and ENABLE_BENCHMARK
-#endif
-
-#ifndef M
-#error Must define M
-#endif
-
-#ifndef N
-#error Must define N
-#endif
-
-#ifndef K
-#error Must define K
-#endif
-
-#ifndef ALPHA
-#error Must define ALPHA
-#endif
-
-#ifndef BETA
-#error Must define BETA
-#endif
-
-#if defined(ENABLE_TEST)
-#include <math.h>
-#endif
-
-#ifndef SKL_TEST_PERF_REPORT
-#define SKL_TEST_PERF_REPORT report_perf_mpc
-#endif
-
-#include "skl-test.h"
+#include "gemm_f32rc_f32rc_f32rc.h"
+#include "skl-test-driver.h"
 #include "skl.h"
 #include <inttypes.h>
+#include <math.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(__riscv_zve32f)
-void skl_gemm_f32_f32_f32_zve32f_x390_wrapper(size_t m, size_t n, size_t k,
-                                              float alpha, const float *a,
-                                              size_t rsa, size_t csa,
-                                              const float *b, size_t rsb,
-                                              size_t csb, float beta, float *c,
-                                              size_t rsc, size_t csc) {
-  int status = 0;
-  SKL_TEST_REQUIRE(status, csa == 1);
-  SKL_TEST_REQUIRE(status, csb == 1);
-  SKL_TEST_REQUIRE(status, csc == 1);
-  if (status) {
-    exit(status);
+int gemm_f32rc_f32rc_f32rc_init(skl_test_t *t) {
+  gemm_f32rc_f32rc_f32rc_t *h = (gemm_f32rc_f32rc_f32rc_t *)t->harness;
+
+  // Allow default strides:
+  // Handle zero dimensions to avoid size_t underflow in (dim - 1) expressions
+  if (h->m == 0 || h->n == 0 || h->k == 0) {
+    h->a.len = 0;
+    h->b.len = 0;
+  } else {
+    h->a.len = (h->m - 1) * h->rsa + (h->k - 1) * h->csa + 1;
+    h->b.len = (h->k - 1) * h->rsb + (h->n - 1) * h->csb + 1;
   }
-  skl_gemm_f32_f32_f32_zve32f_x390(m, n, k, alpha, a, rsa, b, rsb, beta, c,
-                                   rsc);
-}
-#endif
-
-#if defined(__riscv_xsfmm32a32f)
-void skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f_wrapper(
-    size_t m, size_t n, size_t k, float alpha, const float *a, size_t rsa,
-    size_t csa, const float *b, size_t rsb, size_t csb, float beta, float *c,
-    size_t rsc, size_t csc) {
-  int status = 0;
-  SKL_TEST_REQUIRE(status, rsa == 1);
-  SKL_TEST_REQUIRE(status, csb == 1);
-  SKL_TEST_REQUIRE(status, csc == 1);
-  SKL_TEST_REQUIRE(status, alpha == 1.f);
-  SKL_TEST_REQUIRE(status, beta == 0.f || beta == 1.f);
-  if (status) {
-    exit(status);
+  if (h->m == 0 || h->n == 0) {
+    h->c.len = 0;
+  } else {
+    h->c.len = (h->m - 1) * h->rsc + (h->n - 1) * h->csc + 1;
   }
-  skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f(m, n, k, a, csa, b, rsb, c, rsc,
-                                          beta != 0.f);
+
+  // Allocate buffers
+  SKL_TEST_BUF_CREATE(t, float, &h->a);
+  SKL_TEST_BUF_CREATE(t, float, &h->b);
+  SKL_TEST_BUF_CREATE(t, float, &h->c);
+  if (h->verify) {
+    // Only allocate if lengths are non-zero to avoid malloc(0)
+    h->ctx.a_wide = h->a.len > 0 ? malloc(h->a.len * sizeof(double)) : NULL;
+    h->ctx.b_wide = h->b.len > 0 ? malloc(h->b.len * sizeof(double)) : NULL;
+    h->ctx.ref_c = h->c.len > 0 ? malloc(h->c.len * sizeof(float)) : NULL;
+    h->ctx.bound = h->c.len > 0 ? malloc(h->c.len * sizeof(double)) : NULL;
+    // Copy initial C values to ref_c for the beta*C term in reference GEMM
+    memcpy(h->ctx.ref_c, h->c.data, h->c.len * sizeof(float));
+  }
+
+  return 0;
 }
-#endif
 
-/* The macros below set the matrix strides. */
-#if !defined(RSA) && !defined(CSA)
-#define RSA K // Default to row major
-#define CSA 1
-#elif !defined(RSA) || !defined(CSA)
-#error Must define both RSA and CSA, or neither
-#endif
-#if !defined(RSB) && !defined(CSB)
-#define RSB N // Default to row major
-#define CSB 1
-#elif !defined(RSB) || !defined(CSB)
-#error Must define both RSB and CSB, or neither
-#endif
-#if !defined(RSC) && !defined(CSC)
-#define RSC N // Default to row major
-#define CSC 1
-#elif !defined(RSC) || !defined(CSC)
-#error Must define both RSC and CSC, or neither
-#endif
+int gemm_f32rc_f32rc_f32rc_warmup(skl_test_t *t) {
+  gemm_f32rc_f32rc_f32rc_t *h = (gemm_f32rc_f32rc_f32rc_t *)t->harness;
+  if (h->warmup) {
+    return t->suite->execute(t);
+  }
+  return 0;
+}
 
-/* Input, output, reference, and error bound arrays */
-enum {
-  ALIGN = 4096,
-  CLEN = ((M - 1) * RSC + (N - 1) * CSC + 1),
-  ALEN = ((M - 1) * RSA + (K - 1) * CSA + 1),
-  BLEN = ((K - 1) * RSB + (N - 1) * CSB + 1),
-};
-
-#if defined(SKL_TEST_MALLOC)
-float *a;
-float *b;
-float *c;
-#else
-_Alignas(ALIGN) float a[ALEN];
-_Alignas(ALIGN) float b[BLEN];
-_Alignas(ALIGN) float c[CLEN];
-#endif
-
-#if defined(ENABLE_TEST)
-double a_wide[ALEN];
-double b_wide[BLEN];
-float ref_c[CLEN], test_c[CLEN];
-double bound[CLEN];
-#endif // ENABLE_TEST
-
-#if defined(ENABLE_TEST)
-/* Check result after executing test and reference functions.
- *
- * Compares the test_c and ref_c matrices based on a bound derived from
- * problem parameters. Returns nonzero in case of an error, and prints
- * first incorrect output matrix element. */
-int check_error(void) {
+int gemm_f32rc_f32rc_f32rc_verify(skl_test_t *t) {
   /* Compute the reference (scalar) matrix output. */
-  skl_gemm_f32rc_f32rc_f32rc_scalar(M, N, K, ALPHA, a, RSA, CSA, b, RSB, CSB,
-                                    BETA, ref_c, RSC, CSC);
+  gemm_f32rc_f32rc_f32rc_t *h = (gemm_f32rc_f32rc_f32rc_t *)t->harness;
+  if (!h->verify) {
+    return 0;
+  }
 
   //
   // Compute the error bound array for comparing test vs reference results.
@@ -166,78 +85,84 @@ int check_error(void) {
   // Since both test and reference results have roundoff errors, we double this
   // bound using the triangle inequality to get the final comparison threshold.
   //
-  for (size_t i = 0; i < ALEN; ++i) {
-    a_wide[i] = fabsf(a[i]);
+  // Note: h->ctx.ref_c contains the original C values (copied in
+  // skl_test_init) which are needed for the |beta| * |C| term in the error
+  // bound.
+  //
+  for (size_t i = 0; i < h->a.len; ++i) {
+    h->ctx.a_wide[i] = fabsf(h->a.data[i]);
   }
-  for (size_t i = 0; i < BLEN; ++i) {
-    b_wide[i] = fabsf(b[i]);
+  for (size_t i = 0; i < h->b.len; ++i) {
+    h->ctx.b_wide[i] = fabsf(h->b.data[i]);
   }
-  for (size_t i = 0; i < CLEN; ++i) {
-    bound[i] = fabs((double)c[i]);
+  for (size_t i = 0; i < h->c.len; ++i) {
+    h->ctx.bound[i] = fabsf(h->ctx.ref_c[i]);
   }
   const int P = 24; // 23 bits of mantissa for float32 accumulator
   const double u = ldexp(1.0, -P); // Maximum relative roundoff error
   // Compute 2 * ((1 + u)^(K + 2) - 1) by change of base formula:
-  const double roundoff_scaling = 2 * expm1((K + 2) * log1p(u));
+  const double roundoff_scaling = 2 * expm1((double)(h->k + 2) * log1p(u));
   skl_gemm_f64rc_f64rc_f64rc_scalar(
-      M, N, K, roundoff_scaling * fabs((double)ALPHA), a_wide, RSA, CSA, b_wide,
-      RSB, CSB, roundoff_scaling * fabs((double)BETA), bound, RSC, CSC);
+      h->m, h->n, h->k, roundoff_scaling * fabs((double)h->alpha),
+      h->ctx.a_wide, h->rsa, h->csa, h->ctx.b_wide, h->rsb, h->csb,
+      roundoff_scaling * fabs((double)h->beta), h->ctx.bound, h->rsc, h->csc);
+
+  // Compute the reference result using h->ctx.ref_c
+  // h->ctx.ref_c contains the original C values (copied in skl_test_init)
+  // After this call, h->ctx.ref_c will contain the reference result
+  skl_gemm_f32rc_f32rc_f32rc_scalar(h->m, h->n, h->k, h->alpha, h->a.data,
+                                    h->rsa, h->csa, h->b.data, h->rsb, h->csb,
+                                    h->beta, h->ctx.ref_c, h->rsc, h->csc);
 
   /* Compare the reference and test outputs. */
-  for (size_t i = 0; i < M; ++i) {
-    for (size_t j = 0; j < N; ++j) {
-      size_t idx = i * RSC + j * CSC;
-      if (fabs((double)test_c[idx] - (double)ref_c[idx]) > bound[idx]) {
-        printf("result [%zu, %zu] (%f) != reference (%f)\n", i, j, test_c[idx],
-               ref_c[idx]);
-        return 1;
+  for (size_t i = 0; i < h->m; ++i) {
+    for (size_t j = 0; j < h->n; ++j) {
+      size_t idx = i * h->rsc + j * h->csc;
+      if (fabs((double)h->c.data[idx] - (double)h->ctx.ref_c[idx]) >
+          h->ctx.bound[idx]) {
+        skl_test_driver_error(
+            t, "result [%zu, %zu] (%f) != reference (%f) [bound = %f]\n", i, j,
+            h->c.data[idx], h->ctx.ref_c[idx], h->ctx.bound[idx]);
+        return 1; // Error
       }
     }
   }
 
+  return 0; // Success
+}
+
+int gemm_f32rc_f32rc_f32rc_report(skl_test_t *t) {
+  gemm_f32rc_f32rc_f32rc_t *h = (gemm_f32rc_f32rc_f32rc_t *)t->harness;
+
+  size_t maccs = h->m * h->n * h->k;
+  float mpc = (float)maccs / (float)t->counters.cycles;
+
+#define INFO(fmt, ...) SKL_TEST_LOG(t, SKL_TEST_LOG_INFO, fmt, __VA_ARGS__)
+
+  INFO("M: %zd, N: %zd, K: %zd\n", h->m, h->n, h->k);
+  INFO("CSA: %zd, RSB: %zd, RSC: %zd\n", h->csa, h->rsb, h->rsc);
+  INFO("Alpha: %f, Beta: %f\n", h->alpha, h->beta);
+  INFO("\n", );
+  INFO("Warmup: %s\n", h->warmup ? "yes" : "no");
+  INFO("Cycles: %zd\n", t->counters.cycles);
+  INFO("Instructions: %zd\n", t->counters.instret);
+  INFO("MACs/Cycle: %f\n", mpc);
+
   return 0;
 }
-#endif // ENABLE_TEST
 
-int main(void) {
-  int res = EXIT_SUCCESS;
+int gemm_f32rc_f32rc_f32rc_cleanup(skl_test_t *t) {
+  gemm_f32rc_f32rc_f32rc_t *h = (gemm_f32rc_f32rc_f32rc_t *)t->harness;
 
-#if defined(SKL_TEST_MALLOC)
-  a = (float *)SKL_TEST_MALLOC(ALIGN, ALEN * sizeof(float));
-  b = (float *)SKL_TEST_MALLOC(ALIGN, BLEN * sizeof(float));
-  c = (float *)SKL_TEST_MALLOC(ALIGN, CLEN * sizeof(float));
-#endif
-
-  printf("%s:\n", skl_test_name);
-  printf("M = %u, N = %u, K = %u\n", M, N, K);
-  printf("ALPHA = %f, BETA = %f\n", ALPHA, BETA);
-  printf("RSA = %u, CSA = %u\n", RSA, CSA);
-  printf("RSB = %u, CSB = %u\n", RSB, CSB);
-  printf("RSC = %u, CSC = %u\n", RSC, CSC);
-  printf("a = %p, b = %p, c = %p\n", (void *)a, (void *)b, (void *)c);
-
-  /* Populate the matrices. */
-  SKL_TEST_INIT_F32(a, ALEN);
-  SKL_TEST_INIT_F32(b, BLEN);
-  SKL_TEST_INIT_F32(c, CLEN);
-
-#if defined(ENABLE_TEST)
-  /* Make copies of C to write the reference and test outputs to. */
-  memcpy(ref_c, c, CLEN * sizeof(float));
-  memcpy(test_c, c, CLEN * sizeof(float));
-  SKL_TEST_NAME(M, N, K, ALPHA, a, RSA, CSA, b, RSB, CSB, BETA, test_c, RSC,
-                CSC);
-  res += check_error();
-#endif // ENABLE_TEST
-
-  SKL_BENCHMARK_RUN(skl_test_name, M * N * K, SKL_TEST_WARMUP, SKL_TEST_NAME, M,
-                    N, K, ALPHA, a, RSA, CSA, b, RSB, CSB, BETA, c, RSC, CSC);
-
-#if defined(SKL_TEST_MALLOC) && defined(SKL_TEST_FREE)
-  SKL_TEST_FREE(a);
-  SKL_TEST_FREE(b);
-  SKL_TEST_FREE(c);
-#endif
-
-  return res;
+  // Free buffers
+  SKL_TEST_BUF_FREE(t, &h->a);
+  SKL_TEST_BUF_FREE(t, &h->b);
+  SKL_TEST_BUF_FREE(t, &h->c);
+  if (h->verify) {
+    free(h->ctx.a_wide);
+    free(h->ctx.b_wide);
+    free(h->ctx.ref_c);
+    free(h->ctx.bound);
+  }
+  return 0;
 }

--- a/test/gemm/gemm_f32rc_f32rc_f32rc.c
+++ b/test/gemm/gemm_f32rc_f32rc_f32rc.c
@@ -142,7 +142,7 @@ int gemm_f32rc_f32rc_f32rc_report(skl_test_t *t) {
   INFO("M: %zd, N: %zd, K: %zd\n", h->m, h->n, h->k);
   INFO("CSA: %zd, RSB: %zd, RSC: %zd\n", h->csa, h->rsb, h->rsc);
   INFO("Alpha: %f, Beta: %f\n", h->alpha, h->beta);
-  INFO("\n", );
+  INFO("%s", "\n");
   INFO("Warmup: %s\n", h->warmup ? "yes" : "no");
   INFO("Cycles: %zd\n", t->counters.cycles);
   INFO("Instructions: %zd\n", t->counters.instret);

--- a/test/gemm/gemm_f32rc_f32rc_f32rc.h
+++ b/test/gemm/gemm_f32rc_f32rc_f32rc.h
@@ -1,0 +1,58 @@
+// Copyright 2026 SiFive, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @brief Test and benchmark for GEMM: C = alpha * A * B + beta * C.
+ *
+ * This test uses a table-driven approach where test configurations are defined
+ * in the `tests` array. Each test specifies:
+ *  - Matrix dimensions M, N, and K
+ *  - Scalar coefficients ALPHA and BETA
+ *  - Row and column strides (RSA, CSA, RSB, CSB, RSC, CSC)
+ *  - The GEMM kernel function to test
+ *
+ * Matrix layouts:
+ *  - A is M x K with row stride RSA and column stride CSA
+ *  - B is K x N with row stride RSB and column stride CSB
+ *  - C is M x N with row stride RSC and column stride CSC
+ */
+
+#include "skl-test-driver.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+  // Test mode
+  bool warmup;
+  bool verify;
+
+  // Configurable parameters (arguments to GEMM function)
+  size_t m, n, k;
+  float alpha;
+  size_t rsa, csa;
+  size_t rsb, csb;
+  float beta;
+  size_t rsc, csc;
+
+  // Buffer generation settings for A, B, C
+  SKL_TEST_BUFFER(float) a, b, c;
+
+  // Derived parameters & buffers (private to the test harness)
+  struct {
+    double *a_wide, *b_wide;
+    float *ref_c;
+    double *bound;
+  } ctx;
+} gemm_f32rc_f32rc_f32rc_t;
+
+int gemm_f32rc_f32rc_f32rc_init(skl_test_t *t);
+int gemm_f32rc_f32rc_f32rc_warmup(skl_test_t *t);
+int gemm_f32rc_f32rc_f32rc_verify(skl_test_t *t);
+int gemm_f32rc_f32rc_f32rc_report(skl_test_t *t);
+int gemm_f32rc_f32rc_f32rc_cleanup(skl_test_t *t);
+
+#define GEMM_F32RC_F32RC_F32RC_DEFAULTS                                        \
+  .a = {.min = -1.0f, .max = 1.0f, .mode = SKL_TEST_RANDOM},                   \
+  .b = {.min = -1.0f, .max = 1.0f, .mode = SKL_TEST_RANDOM},                   \
+  .c = {.min = -1.0f, .max = 1.0f, .mode = SKL_TEST_RANDOM}, .alpha = 1.0f

--- a/test/gemm/rvv/skl_gemm_f16_f16_f32_zvfh_x390.c
+++ b/test/gemm/rvv/skl_gemm_f16_f16_f32_zvfh_x390.c
@@ -18,24 +18,41 @@
 
 static int execute(skl_test_t *t);
 
+// Uses defaults from gemm_f16rc_f16rc_f32rc.h
+#define TEST GEMM_F16RC_F16RC_F32RC_DEFAULTS, .warmup = false, .verify = true
+#define BENCH GEMM_F16RC_F16RC_F32RC_DEFAULTS, .warmup = true, .verify = false
+
+// clang-format off
 gemm_f16rc_f16rc_f32rc_t tests[] = {
-    {.warmup = false,
-     .verify = true,
-     .alpha = (_Float16)2.0f,
-     .beta = (_Float16)3.0f,
-     .a = {.min = (_Float16)-1.0f,
-           .max = (_Float16)1.0f,
-           .mode = SKL_TEST_RANDOM},
-     .b = {.min = (_Float16)-1.0f,
-           .max = (_Float16)1.0f,
-           .mode = SKL_TEST_RANDOM},
-     .c = {.min = (_Float16)-1.0f,
-           .max = (_Float16)1.0f,
-           .mode = SKL_TEST_RANDOM},
-     .m = 32,
-     .n = 32,
-     .k = 32},
+    // Benchmark tests
+    {BENCH, .m =  64, .n = 128, .k = 128},
+
+    // Verifcation tests - comprehensive coverage for RVV GEMM
+    /* Edge cases: minimal dimensions */
+    {TEST, .m =   1, .n =   1, .k =   0},
+    {TEST, .m =   1, .n =   1, .k =   1},
+    /* Small odd dimensions for remainder handling */
+    {TEST, .m =   7, .n =   7, .k =   7},
+    {TEST, .m =  17, .n =  17, .k =  17},
+    /* Skinny matrices (one dimension = 1) */
+    {TEST, .m =   1, .n =  33, .k =  31},
+    {TEST, .m =  33, .n =   1, .k =  31},
+    /* k=0 edge case (C = beta*C, no A*B contribution) */
+    {TEST, .m =  33, .n =  33, .k =   0},
+    {TEST, .m =  16, .n =  16, .k =   0},
+    /* Vector length boundary tests (multiples of 4, 8, 16, 32) */
+    {TEST, .m =  16, .n =  16, .k =  16},
+    {TEST, .m =  32, .n =  32, .k =  32},
+    {TEST, .m =  32, .n = 128, .k =  32},
+    /* Near-boundary tests (±1 from vector length multiples) */
+    {TEST, .m =  15, .n =  17, .k =  31},
+    {TEST, .m =  31, .n =  33, .k =  15},
+    /* Wide and tall matrices */
+    {TEST, .m =  33, .n = 129, .k =  32},
+    {TEST, .m = 129, .n =  33, .k =  32},
+    {TEST, .m =  31, .n = 133, .k =  32},
 };
+// clang-format on
 
 static skl_test_suite_t suite = {
     .name = "skl_gemm_f16_f16_f32_zvfh_x390",

--- a/test/gemm/rvv/skl_gemm_f16_f16_f32_zvfh_x390.c
+++ b/test/gemm/rvv/skl_gemm_f16_f16_f32_zvfh_x390.c
@@ -1,0 +1,71 @@
+#include "gemm/gemm_f16rc_f16rc_f32rc.h"
+#include "skl-test-driver.h"
+#include "skl.h"
+
+#include <stddef.h>
+
+#if !defined(__riscv_zvfh)
+#error This file requires the Zvfh extension.
+#endif
+
+static int execute(skl_test_t *t);
+
+gemm_f16rc_f16rc_f32rc_t tests[] = {
+    {.warmup = false,
+     .verify = true,
+     .alpha = (_Float16)2.0f,
+     .beta = (_Float16)3.0f,
+     .a = {.min = (_Float16)-1.0f,
+           .max = (_Float16)1.0f,
+           .mode = SKL_TEST_RANDOM},
+     .b = {.min = (_Float16)-1.0f,
+           .max = (_Float16)1.0f,
+           .mode = SKL_TEST_RANDOM},
+     .c = {.min = (_Float16)-1.0f,
+           .max = (_Float16)1.0f,
+           .mode = SKL_TEST_RANDOM},
+     .m = 32,
+     .n = 32,
+     .k = 32},
+};
+
+static skl_test_suite_t suite = {
+    .name = "skl_gemm_f16_f16_f32_zvfh_x390",
+    .num_tests = sizeof(tests) / sizeof(tests[0]),
+    .test_size = sizeof(gemm_f16rc_f16rc_f32rc_t),
+    .tests = tests,
+    .init = gemm_f16rc_f16rc_f32rc_init,
+    .warmup = gemm_f16rc_f16rc_f32rc_warmup,
+    .execute = execute,
+    .verify = gemm_f16rc_f16rc_f32rc_verify,
+    .report = gemm_f16rc_f16rc_f32rc_report,
+    .cleanup = gemm_f16rc_f16rc_f32rc_cleanup,
+};
+
+static int execute(skl_test_t *t) {
+  const gemm_f16rc_f16rc_f32rc_t *h = (gemm_f16rc_f16rc_f32rc_t *)t->harness;
+
+  SKL_TEST_REQUIRE(t, h->csa == 1);
+  SKL_TEST_REQUIRE(t, h->csb == 1);
+  SKL_TEST_REQUIRE(t, h->csc == 1);
+  skl_gemm_f16_f16_f32_zvfh_x390(h->m, h->n, h->k, h->alpha, h->a.data, h->rsa,
+                                 h->b.data, h->rsb, h->beta, h->c.data, h->rsc);
+
+  return (t->status == SKL_TEST_PASS) ? 0 : 1;
+}
+
+int main(void) {
+
+  for (size_t i = 0; i < suite.num_tests; i++) {
+    tests[i].rsa = tests[i].rsa ? tests[i].rsa : tests[i].k;
+    tests[i].rsb = tests[i].rsb ? tests[i].rsb : tests[i].n;
+    tests[i].rsc = tests[i].rsc ? tests[i].rsc : tests[i].n;
+    // Make sure we still generate an error if a column stride is set
+    // accidentally
+    tests[i].csa = tests[i].csa ? tests[i].csa : 1;
+    tests[i].csb = tests[i].csb ? tests[i].csb : 1;
+    tests[i].csc = tests[i].csc ? tests[i].csc : 1;
+  }
+
+  return skl_test_driver_run_suite(&suite);
+}

--- a/test/gemm/rvv/skl_gemm_f16_f16_f32_zvfh_x390.c
+++ b/test/gemm/rvv/skl_gemm_f16_f16_f32_zvfh_x390.c
@@ -8,6 +8,14 @@
 #error This file requires the Zvfh extension.
 #endif
 
+/**
+ * @brief Test cases for skl_gemm_f16_f16_f32_zvfh_x390.
+ *
+ * This test uses the gemm_f32rc_f32rc_f32rc harness with the following
+ * restrictions on the input parameters:
+ *  - All matrices are row-major (csa == 1, csb == 1, csc == 1)
+ */
+
 static int execute(skl_test_t *t);
 
 gemm_f16rc_f16rc_f32rc_t tests[] = {
@@ -57,6 +65,7 @@ static int execute(skl_test_t *t) {
 int main(void) {
 
   for (size_t i = 0; i < suite.num_tests; i++) {
+    // Set default row stride to row length
     tests[i].rsa = tests[i].rsa ? tests[i].rsa : tests[i].k;
     tests[i].rsb = tests[i].rsb ? tests[i].rsb : tests[i].n;
     tests[i].rsc = tests[i].rsc ? tests[i].rsc : tests[i].n;

--- a/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
+++ b/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
@@ -1,0 +1,95 @@
+#include "gemm/gemm_f32rc_f32rc_f32rc.h"
+#include "skl-test-driver.h"
+#include "skl.h"
+#include <stddef.h>
+
+#if !defined(__riscv_zve32f)
+#error This file requires the Zve32f extension
+#endif
+
+/**
+ * @brief Test cases for GEMM with Zve32f extension.
+ *
+ * This test uses the gemm_f32rc_f32rc_f32rc harness with the following
+ * restrictions on the input parameters:
+ *  - All matrices are row-major (csa == 1, csb == 1, csc == 1)
+ */
+
+#define TEST GEMM_F32RC_F32RC_F32RC_DEFAULTS, .warmup = false, .verify = true
+#define BENCH GEMM_F32RC_F32RC_F32RC_DEFAULTS, .warmup = true, .verify = false
+
+static int execute(skl_test_t *t);
+
+// clang-format off
+gemm_f32rc_f32rc_f32rc_t tests[] = {
+    // Benchmark tests
+    {BENCH, .m =  64, .n = 128, .k = 128},
+
+    // Verification tests - comprehensive coverage for RVV GEMM
+    /* Edge cases: minimal dimensions */
+    {TEST, .m = 1,   .n = 1,   .k = 0},
+    {TEST, .m = 1,   .n = 1,   .k = 1},
+    /* Small odd dimensions for remainder handling */
+    {TEST, .m = 7,   .n = 7,   .k = 7},
+    {TEST, .m = 17,  .n = 17,  .k = 17},
+    /* Skinny matrices (one dimension = 1) */
+    {TEST, .m = 1,   .n = 33,  .k = 31},
+    {TEST, .m = 33,  .n = 1,   .k = 31},
+    /* k=0 edge case (C = beta*C, no A*B contribution) */
+    {TEST, .m = 33,  .n = 33,  .k = 0},
+    {TEST, .m = 16,  .n = 16,  .k = 0,   .beta = 1.f},
+    /* Vector length boundary tests (multiples of 4, 8, 16, 32) */
+    {TEST, .m = 16,  .n = 16,  .k = 16},
+    {TEST, .m = 32,  .n = 32,  .k = 32},
+    /* Near-boundary tests (±1 from vector length multiples) */
+    {TEST, .m = 15,  .n = 17,  .k = 31},
+    {TEST, .m = 31,  .n = 33,  .k = 15},
+    /* Wide and tall matrices */
+    {TEST, .m = 33,  .n = 129, .k = 32},
+    {TEST, .m = 129, .n = 33,  .k = 32},
+    {TEST, .m = 31,  .n = 133, .k = 32},
+    /* Beta scaling test (beta=1, accumulate into existing C) */
+    {TEST, .m = 32,  .n = 32,  .k = 32,  .beta = 1.f},
+};
+// clang-format on
+
+static skl_test_suite_t suite = {
+    .name = "skl_gemm_f32_f32_f32_zve32f_x390",
+    .num_tests = sizeof(tests) / sizeof(tests[0]),
+    .test_size = sizeof(gemm_f32rc_f32rc_f32rc_t),
+    .tests = tests,
+    .init = gemm_f32rc_f32rc_f32rc_init,
+    .warmup = gemm_f32rc_f32rc_f32rc_warmup,
+    .execute = execute,
+    .verify = gemm_f32rc_f32rc_f32rc_verify,
+    .report = gemm_f32rc_f32rc_f32rc_report,
+    .cleanup = gemm_f32rc_f32rc_f32rc_cleanup,
+};
+
+static int execute(skl_test_t *t) {
+  const gemm_f32rc_f32rc_f32rc_t *h = (gemm_f32rc_f32rc_f32rc_t *)t->harness;
+
+  SKL_TEST_REQUIRE(t, h->csa == 1);
+  SKL_TEST_REQUIRE(t, h->csb == 1);
+  SKL_TEST_REQUIRE(t, h->csc == 1);
+  skl_gemm_f32_f32_f32_zve32f_x390(h->m, h->n, h->k, h->alpha, h->a.data,
+                                   h->rsa, h->b.data, h->rsb, h->beta,
+                                   h->c.data, h->rsc);
+  return (t->status == SKL_TEST_PASS) ? 0 : 1;
+}
+
+int main(void) {
+  // Set default strides: all matrices are row-major
+  for (size_t i = 0; i < suite.num_tests; i++) {
+    tests[i].rsa = tests[i].rsa ? tests[i].rsa : tests[i].k;
+    tests[i].rsb = tests[i].rsb ? tests[i].rsb : tests[i].n;
+    tests[i].rsc = tests[i].rsc ? tests[i].rsc : tests[i].n;
+    // Make sure we still generate an error if a column stride is set
+    // accidentally
+    tests[i].csa = tests[i].csa ? tests[i].csa : 1;
+    tests[i].csb = tests[i].csb ? tests[i].csb : 1;
+    tests[i].csc = tests[i].csc ? tests[i].csc : 1;
+  }
+
+  return skl_test_driver_run_suite(&suite);
+}

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
@@ -1,0 +1,115 @@
+// Copyright 2026 SiFive, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gemm/gemm_f32rc_f32rc_f32rc.h"
+#include "skl-test-driver.h"
+#include "skl.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+#if !defined(__riscv_xsfmm32a32f)
+#error This file requires the Xsfmm32a32f extension
+#endif
+
+/**
+ * @brief Test cases for GEMM with Xsfmm32a32f extension.
+ *
+ * This test uses the gemm_f32rc_f32rc_f32rc harness with the following
+ * restrictions on the input parameters:
+ *  - Matrix A is column-major (rsa == 1)
+ *  - Matrix B is row-major (csb == 1)
+ *  - Matrix C is row-major (csc == 1)
+ *  - Alpha must be 1.0
+ *  - Beta must be 0.0 or 1.0
+ *
+ * The kernel computes C = A * B (beta=0) or C += A * B (beta=1).
+ */
+
+#define TEST GEMM_F32RC_F32RC_F32RC_DEFAULTS, .warmup = false, .verify = true
+#define BENCH GEMM_F32RC_F32RC_F32RC_DEFAULTS, .warmup = true, .verify = false
+static int execute(skl_test_t *t);
+
+// clang-format off
+gemm_f32rc_f32rc_f32rc_t tests[] = {
+    // Benchmark tests
+    {BENCH, .m = 128, .n = 128, .k = 2048, .beta = 0.f},
+    {BENCH, .m = 128, .n = 128, .k = 2048, .beta = 1.f},
+
+    // Verification tests - comprehensive coverage for Xsfmm A1B01 layout (TE=64)
+    /* Edge case: 1x1 matrix with k=0 (no computation, C = beta*C) */
+    {TEST, .rsa = 1, .m = 1,   .n = 1,   .k = 0},
+    /* Edge case: 1x1 matrix with k=1 (minimal computation) */
+    {TEST, .rsa = 1, .m = 1,   .n = 1,   .k = 1},
+    /* TE-1 boundary: 63 = 64-1, tests just below tile edge */
+    {TEST, .rsa = 1, .m = 63,  .n = 63,  .k = 1},
+    {TEST, .rsa = 1, .m = 63,  .n = 63,  .k = 2},
+    {TEST, .rsa = 1, .m = 63,  .n = 63,  .k = 5},
+    /* Exact TE boundary: 64x64 tiles */
+    {TEST, .rsa = 1, .m = 64,  .n = 64,  .k = 1},
+    {TEST, .rsa = 1, .m = 64,  .n = 64,  .k = 5},
+    /* TE+1 boundary: 65 = 64+1, tests just past tile edge */
+    {TEST, .rsa = 1, .m = 65,  .n = 65,  .k = 1},
+    {TEST, .rsa = 1, .m = 65,  .n = 65,  .k = 5},
+    /* Multi-tile: 2*TE = 128 */
+    {TEST, .rsa = 1, .m = 128, .n = 128, .k = 1},
+    {TEST, .rsa = 1, .m = 128, .n = 128, .k = 5},
+    /* Multi-tile+1: 2*TE+1 = 129 */
+    {TEST, .rsa = 1, .m = 129, .n = 129, .k = 1},
+    {TEST, .rsa = 1, .m = 129, .n = 129, .k = 5},
+    /* Non-square matrices (rectangular tiles) */
+    {TEST, .rsa = 1, .m = 129, .n = 63,  .k = 1},
+    {TEST, .rsa = 1, .m = 65,  .n = 129, .k = 2},
+    {TEST, .rsa = 1, .m = 64,  .n = 128, .k = 5},
+    /* Beta=1 tests (accumulate into existing C) */
+    {TEST, .rsa = 1, .m = 65,  .n = 65,  .k = 0,  .beta = 1.f},
+    {TEST, .rsa = 1, .m = 65,  .n = 65,  .k = 1,  .beta = 1.f},
+    {TEST, .rsa = 1, .m = 65,  .n = 65,  .k = 33, .beta = 1.f},
+    {TEST, .rsa = 1, .m = 128, .n = 128, .k = 33, .beta = 1.f},
+};
+// clang-format on
+
+static skl_test_suite_t suite = {
+    .name = "skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f",
+    .num_tests = sizeof(tests) / sizeof(tests[0]),
+    .test_size = sizeof(gemm_f32rc_f32rc_f32rc_t),
+    .tests = tests,
+    .init = gemm_f32rc_f32rc_f32rc_init,
+    .warmup = gemm_f32rc_f32rc_f32rc_warmup,
+    .execute = execute,
+    .verify = gemm_f32rc_f32rc_f32rc_verify,
+    .report = gemm_f32rc_f32rc_f32rc_report,
+    .cleanup = gemm_f32rc_f32rc_f32rc_cleanup,
+};
+
+static int execute(skl_test_t *t) {
+  const gemm_f32rc_f32rc_f32rc_t *h = (gemm_f32rc_f32rc_f32rc_t *)t->harness;
+
+  SKL_TEST_REQUIRE(t, h->rsa == 1); // Note: column-major
+  SKL_TEST_REQUIRE(t, h->csb == 1);
+  SKL_TEST_REQUIRE(t, h->csc == 1);
+  SKL_TEST_REQUIRE(t, h->alpha == 1.f);
+  SKL_TEST_REQUIRE(t, h->beta == 0.f || h->beta == 1.f);
+
+  // Call the kernel with the appropriate parameters
+  // The kernel signature is: (m, n, k, a, csa, b, rsb, c, rsc, accum)
+  // where accum = (beta != 0)
+  skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f(h->m, h->n, h->k, h->a.data, h->csa,
+                                          h->b.data, h->rsb, h->c.data, h->rsc,
+                                          h->beta != 0.f);
+  return (t->status == SKL_TEST_PASS) ? 0 : 1;
+}
+
+int main(void) {
+  // Set default strides: A is column-major, B is row-major, C is row-major
+  for (size_t i = 0; i < suite.num_tests; i++) {
+    tests[i].csa = tests[i].csa ? tests[i].csa : tests[i].m;
+    tests[i].rsb = tests[i].rsb ? tests[i].rsb : tests[i].n;
+    tests[i].rsc = tests[i].rsc ? tests[i].rsc : tests[i].n;
+    // Make sure we still generate an error if a csc/csb/rsa is set accidentally
+    tests[i].csc = tests[i].csc ? tests[i].csc : 1;
+    tests[i].csb = tests[i].csb ? tests[i].csb : 1;
+    tests[i].rsa = tests[i].rsa ? tests[i].rsa : 1;
+  }
+
+  return skl_test_driver_run_suite(&suite);
+}

--- a/test/skl-test-driver.c
+++ b/test/skl-test-driver.c
@@ -1,0 +1,177 @@
+#include "skl-test-driver.h"
+#include <inttypes.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum { SKL_TEST_DRIVER_ALIGNMENT = 4096 };
+
+#if !defined(SKL_TEST_LOG_LEVEL)
+#define SKL_TEST_LOG_LEVEL SKL_TEST_LOG_INFO
+#endif
+
+#if defined(__riscv)
+#if __riscv_xlen == 32
+#define RISCV_READ_COUNTER_FUNC(COUNTER)                                       \
+  static inline uint64_t riscv_read_m##COUNTER(void) {                         \
+    uint32_t lo;                                                               \
+    uint32_t hi0, hi1;                                                         \
+    /* guard against overflow between reads of lo/hi counter halves */         \
+    do {                                                                       \
+      __asm__ volatile("rd" #COUNTER "h %0" : "=r"(hi0));                      \
+      __asm__ volatile("rd" #COUNTER " %0" : "=r"(lo));                        \
+      __asm__ volatile("rd" #COUNTER "h %0" : "=r"(hi1));                      \
+    } while (hi0 != hi1);                                                      \
+    return (uint64_t)lo + ((uint64_t)hi1 << 32);                               \
+  }
+#elif __riscv_xlen == 64
+#define RISCV_READ_COUNTER_FUNC(COUNTER)                                       \
+  static inline uint64_t riscv_read_m##COUNTER(void) {                         \
+    uint64_t res;                                                              \
+    __asm__ volatile("rd" #COUNTER " %0" : "=r"(res));                         \
+    return res;                                                                \
+  }
+#endif
+
+RISCV_READ_COUNTER_FUNC(cycle)   // riscv_read_mcycle()
+RISCV_READ_COUNTER_FUNC(instret) // riscv_read_minstret()
+
+static inline void riscv_fence(void) {
+  __asm__ volatile("fence" : : : "memory");
+}
+#else
+// Stub implementations for non-RISC-V platforms
+static inline uint64_t riscv_read_mcycle(void) { return 0; }
+static inline uint64_t riscv_read_minstret(void) { return 0; }
+static inline void riscv_fence(void) {}
+#endif
+
+void skl_test_driver_update_counters(skl_test_counters_t *counters) {
+  riscv_fence();
+  counters->cycles = riscv_read_mcycle() - counters->cycles;
+  counters->instret = riscv_read_minstret() - counters->instret;
+}
+
+void *skl_test_driver_alloc(size_t region, size_t size) {
+  (void)region;
+  return aligned_alloc(SKL_TEST_DRIVER_ALIGNMENT, size);
+}
+
+void skl_test_driver_free(size_t region, void *ptr) {
+  (void)region;
+  free(ptr);
+}
+
+static size_t fprintf_prefix(FILE *stream, skl_test_t *t) {
+  if (t == NULL) {
+    return 0;
+  }
+  size_t id =
+      ((char *)t->harness - (char *)t->suite->tests) / t->suite->test_size;
+  return fprintf(stream, "[%zd]: ", id);
+}
+
+void skl_test_driver_error(skl_test_t *t, const char *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  (void)fprintf_prefix(stderr, t);
+  (void)vfprintf(stderr, fmt, args);
+  va_end(args);
+}
+
+void skl_test_driver_log(skl_test_t *t, const char *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  (void)fprintf_prefix(stdout, t);
+  (void)vfprintf(stdout, fmt, args);
+  va_end(args);
+}
+
+static void log_separator(skl_test_t *t, char sep) {
+  enum { SEP_LEN = 10 };
+  char buf[SEP_LEN];
+  memset(buf, sep, sizeof(buf));
+  buf[sizeof(buf) - 1] = '\n';
+  SKL_TEST_LOG(t, SKL_TEST_LOG_INFO, "%s", buf);
+}
+
+int skl_test_driver_run_suite(skl_test_suite_t *suite) {
+  int failures = 0;
+
+  // Log test suite start (and avoid lint warning)
+  int log_level = SKL_TEST_LOG_LEVEL;
+  if (suite->num_tests > 0 && suite->name != NULL &&
+      log_level >= SKL_TEST_LOG_INFO) {
+    skl_test_driver_log(NULL, "Running test suite %s with %zd tests\n",
+                        suite->name, suite->num_tests);
+  }
+
+  // Main loop over all tests
+  for (size_t i = 0; i < suite->num_tests; ++i) {
+    skl_test_t t = {.suite = suite,
+                    .harness = (char *)suite->tests + i * suite->test_size,
+                    .log_level = log_level,
+                    .counters = {.cycles = 0, .instret = 0},
+                    .status = SKL_TEST_PASS};
+    log_separator(&t, '=');
+
+#define TRY(STEP)                                                              \
+  do {                                                                         \
+    if (suite->STEP != NULL) {                                                 \
+      SKL_TEST_REQUIRE(&t, suite->STEP(&t) == 0);                              \
+      if (t.status != SKL_TEST_PASS)                                           \
+        goto cleanup;                                                          \
+    }                                                                          \
+  } while (0)
+
+    TRY(init);
+
+    // Run the test, including optional cache warmup
+    TRY(warmup);
+    skl_test_driver_update_counters(&t.counters);
+    TRY(execute);
+    skl_test_driver_update_counters(&t.counters);
+
+    // Verify test results, if verification is enabled
+    TRY(verify);
+    SKL_TEST_LOG(&t, SKL_TEST_LOG_INFO, "Verification passed\n");
+
+  cleanup:
+    // Always run cleanup if provided
+    if (suite->cleanup != NULL) {
+      int cleanup_status = suite->cleanup(&t);
+      if (cleanup_status != 0) {
+        skl_test_driver_error(&t, "Cleanup function failed\n");
+        t.status = SKL_TEST_FAIL;
+      }
+    }
+
+    // Always run report if provided, even after failure
+    if (suite->report != NULL) {
+      int report_status = suite->report(&t);
+      if (report_status != 0) {
+        skl_test_driver_error(&t, "Report function failed\n");
+        t.status = SKL_TEST_FAIL;
+      }
+    }
+
+    // Check final status and update failure count
+    if (t.status != SKL_TEST_PASS) {
+      SKL_TEST_LOG(&t, SKL_TEST_LOG_ERROR, "Test failed\n");
+      failures++;
+    }
+    log_separator(&t, '=');
+    SKL_TEST_LOG(&t, SKL_TEST_LOG_INFO, "\n");
+  }
+
+  if (log_level >= SKL_TEST_LOG_INFO) {
+    skl_test_driver_log(NULL,
+                        "Test suite %s completed %zd tests with %d failures\n",
+                        suite->name, suite->num_tests, failures);
+  }
+
+  return failures;
+}

--- a/test/skl-test-driver.h
+++ b/test/skl-test-driver.h
@@ -1,0 +1,343 @@
+// Copyright 2026 SiFive, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file skl-test-driver.h
+ * @brief SKL test driver framework for benchmarking and verification
+ *
+ * This header defines the test driver framework used by SKL kernel tests.
+ * The framework provides a standardized interface for test harnesses to
+ * initialize, execute, verify, and report on kernel performance.
+ *
+ * The driver handles memory allocation, test data initialization, performance
+ * measurement (cycles and instructions), and result reporting. Test harnesses
+ * implement the required callback functions to integrate with the driver:
+ * - skl_test_init
+ * - skl_test_execute
+ * - skl_test_verify
+ * - skl_test_cleanup
+ * - skl_test_report
+ *
+ * A test suite is a collection of related tests that share a common harness.
+ * The harness defines a test configuration structure, and a suite is an array
+ * of test configurations.
+ *
+ * This interface is intended to allow consumers of SKL to adapt the test suite
+ * to their own environments by replacing the short driver program with one that
+ * uses the appropriate I/O, data generation, and measurement methods for their
+ * environment.
+ */
+
+#pragma once
+
+#include <float.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+//----- Test definitions -----
+
+// Forward declaration to resolve circular dependency
+typedef struct skl_test_t skl_test_t;
+
+/**
+ * @brief Test suite metadata.
+ *
+ * Describes a collection of related tests.
+ */
+typedef struct {
+  const char *name; /**< Name of the test suite */
+  size_t num_tests; /**< Number of tests in the suite */
+  size_t test_size; /**< Size of the test-specific data structure */
+  void *tests;      /**< Array of test-specific data structures */
+  int (*init)(
+      skl_test_t *t); /**< Optional initialization function, NULL to skip */
+  int (*warmup)(skl_test_t *t);  /**< Optional warmup function, NULL to skip */
+  int (*execute)(skl_test_t *t); /**< Required execution function */
+  int (*verify)(
+      skl_test_t *t); /**< Optional verification function, NULL to skip */
+  int (*report)(
+      skl_test_t *t); /**< Optional reporting function, NULL to skip */
+  int (*cleanup)(skl_test_t *t); /**< Optional cleanup function, NULL to skip */
+} skl_test_suite_t;
+
+/**
+ * @brief Performance counter values.
+ *
+ * Contains cycle and instruction counts measured during test execution.
+ */
+typedef struct {
+  uint64_t cycles;  /**< Number of CPU cycles elapsed */
+  uint64_t instret; /**< Number of instructions retired */
+} skl_test_counters_t;
+
+/**
+ * @brief Test status values.
+ */
+typedef enum {
+  SKL_TEST_PASS = 0, /**< Test passed */
+  SKL_TEST_FAIL = 1, /**< Test failed */
+} skl_test_status_t;
+
+/**
+ * @brief Test context structure.
+ *
+ * Contains all state for a single test execution, including driver
+ * configuration and harness-specific data. The driver initializes this
+ * structure and passes it to all harness callback functions.
+ */
+struct skl_test_t {
+  const skl_test_suite_t *suite; /**< Test suite (set by driver before init) */
+  void *harness; /**< Harness-specific data (set by harness in init) */
+  int log_level; /**< Logging verbosity level (set by driver before init) */
+  skl_test_counters_t counters; /**< Performance counters (updated by driver) */
+  skl_test_status_t status;     /**< Test pass/fail status */
+};
+
+//----- Functions provided by the driver -----
+
+/**
+ * @brief Run a test suite.
+ *
+ * @param suite - Test suite to run
+ * @return 0 on success, non-zero on error
+ */
+int skl_test_driver_run_suite(skl_test_suite_t *suite);
+
+/**
+ * @brief Allocate memory for a test buffer.
+ *
+ * @param region - Memory region to allocate from (defined by driver, must
+ * support 0)
+ * @param size - Size of memory to allocate in bytes
+ * @return Pointer to allocated memory
+ */
+void *skl_test_driver_alloc(size_t region, size_t size);
+
+/**
+ * @brief Free memory for a test buffer allocated with skl_test_driver_alloc.
+ *
+ * @param region - Memory region to free from (defined by driver, must support
+ * 0)
+ * @param ptr - Pointer to memory to free
+ */
+void skl_test_driver_free(size_t region, void *ptr);
+
+/**
+ * @brief Update performance counters.
+ *
+ * @param counters - Performance counter structure to update
+ *
+ * Reads the current values of the cycle and instruction counters and
+ * updates counters with the delta since the last update.
+ */
+void skl_test_driver_update_counters(skl_test_counters_t *counters);
+
+/**
+ * @brief Log an error message.
+ *
+ * @param t - Test context
+ * @param fmt - Printf-style format string
+ * @param ... - Format arguments
+ *
+ * Outputs an error message to stderr with test ID prefix.
+ * Supports printf-style formatting.
+ */
+void skl_test_driver_error(skl_test_t *t, const char *fmt, ...);
+
+/**
+ * @brief Log an informational message.
+ *
+ * @param t - Test context
+ * @param fmt - Printf-style format string
+ * @param ... - Format arguments
+ *
+ * Outputs a log message to stdout with test ID prefix.
+ * Supports printf-style formatting.
+ */
+void skl_test_driver_log(skl_test_t *t, const char *fmt, ...);
+
+//----- Utility macros for use in tests -----
+
+/**
+ * @brief Free a test buffer.
+ *
+ * @param T - Test context pointer
+ * @param BUF - Buffer to free
+ *
+ * Frees a buffer allocated with SKL_TEST_BUF_CREATE using the configured
+ * memory allocator. Logs the deallocation at log level SKL_TEST_LOG_DEBUG.
+ */
+#define SKL_TEST_BUF_FREE(T, BUF)                                              \
+  do {                                                                         \
+    skl_test_driver_free((BUF)->region, (BUF)->data);                          \
+    SKL_TEST_LOG((T), SKL_TEST_LOG_DEBUG, "freed %s at %p\n", #BUF,            \
+                 (BUF)->data);                                                 \
+  } while (0)
+
+// Helper macros for generating random values (used internally by
+// SKL_TEST_BUF_CREATE)
+
+#define SKL_TEST_BUF_RANDOM_FLOAT_(TYPE, MIN, MAX, LEN)                        \
+  ((TYPE)(TYPE)((MIN) + ((float)rand() / (float)RAND_MAX) * ((MAX) - (MIN))))
+
+#define SKL_TEST_BUF_RANDOM__Float16(TYPE, MIN, MAX, LEN)                      \
+  SKL_TEST_BUF_RANDOM_FLOAT_(TYPE, MIN, MAX, LEN)
+#define SKL_TEST_BUF_RANDOM_float(TYPE, MIN, MAX, LEN)                         \
+  SKL_TEST_BUF_RANDOM_FLOAT_(TYPE, MIN, MAX, LEN)
+#define SKL_TEST_BUF_RANDOM_double(TYPE, MIN, MAX, LEN)                        \
+  SKL_TEST_BUF_RANDOM_FLOAT_(TYPE, MIN, MAX, LEN)
+
+#define SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)                          \
+  ((TYPE)(rand() % ((MAX) - (MIN) + 1) + (MIN)))
+
+#define SKL_TEST_BUF_RANDOM_int8_t(TYPE, MIN, MAX, LEN)                        \
+  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
+#define SKL_TEST_BUF_RANDOM_uint8_t(TYPE, MIN, MAX, LEN)                       \
+  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
+#define SKL_TEST_BUF_RANDOM_int16_t(TYPE, MIN, MAX, LEN)                       \
+  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
+#define SKL_TEST_BUF_RANDOM_uint16_t(TYPE, MIN, MAX, LEN)                      \
+  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
+#define SKL_TEST_BUF_RANDOM_int32_t(TYPE, MIN, MAX, LEN)                       \
+  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
+#define SKL_TEST_BUF_RANDOM_uint32_t(TYPE, MIN, MAX, LEN)                      \
+  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
+#define SKL_TEST_BUF_RANDOM_int64_t(TYPE, MIN, MAX, LEN)                       \
+  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
+#define SKL_TEST_BUF_RANDOM_uint64_t(TYPE, MIN, MAX, LEN)                      \
+  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
+
+/**
+ * @brief Test buffer descriptor.
+ *
+ * Describes a buffer of test data with initialization parameters.
+ * Test harnesses use SKL_TEST_BUFFER() to define buffer members in their
+ * test configuration structures. These can then be allocated and initialized by
+ * the driver using SKL_TEST_BUF_CREATE.
+ */
+#define SKL_TEST_BUFFER(TYPE)                                                  \
+  struct {                                                                     \
+    TYPE *data;                                                                \
+    size_t len;                                                                \
+    skl_test_init_mode_t mode;                                                 \
+    TYPE min, max;                                                             \
+    const TYPE *static_data;                                                   \
+    size_t static_data_len;                                                    \
+    size_t region;                                                             \
+  }
+
+/**
+ * @brief Test data initialization modes.
+ *
+ * Specifies how test buffers should be initialized by SKL_TEST_BUF_CREATE.
+ */
+typedef enum {
+  SKL_TEST_RANDOM, /**< Initialize with random values in [min, max] */
+  SKL_TEST_STATIC, /**< Initialize from static_data array */
+  SKL_TEST_SEQ,    /**< Initialize with sequential values from min to max */
+} skl_test_init_mode_t;
+
+/**
+ * @brief Allocate and initialize a test buffer.
+ *
+ * @param T - Test context pointer
+ * @param TYPE - Element type (e.g., float, int32_t)
+ * @param BUF - SKL_TEST_BUFFER() to receive the allocated buffer
+ *
+ * Allocates a buffer and initializes it according to the parameters in BUF.
+ * The initialization mode determines how the buffer is filled:
+ * - SKL_TEST_RANDOM: Fill with random values in [min, max]
+ * - SKL_TEST_STATIC: Fill from static_data array (cycling if needed)
+ * - SKL_TEST_SEQ: Fill with sequential values from min to max
+ *
+ * Logs allocation at log level SKL_TEST_LOG_DEBUG.
+ */
+#define SKL_TEST_BUF_CREATE(T, TYPE, BUF)                                      \
+  do {                                                                         \
+    (BUF)->data = (TYPE *)skl_test_driver_alloc((BUF)->region,                 \
+                                                (BUF)->len * sizeof(TYPE));    \
+    SKL_TEST_LOG((T), SKL_TEST_LOG_DEBUG, "allocated %s of size %zd at %p \n", \
+                 #BUF, (BUF)->len, (BUF)->data);                               \
+    switch ((BUF)->mode) {                                                     \
+    case SKL_TEST_RANDOM:                                                      \
+      SKL_TEST_LOG((T), SKL_TEST_LOG_DEBUG, "random values in [%f, %f]\n",     \
+                   (double)(BUF)->min, (double)(BUF)->max);                    \
+      for (size_t i = 0; i < (BUF)->len; ++i) {                                \
+        (BUF)->data[i] = SKL_TEST_BUF_RANDOM_##TYPE(TYPE, (BUF)->min,          \
+                                                    (BUF)->max, (BUF)->len);   \
+      }                                                                        \
+      break;                                                                   \
+    case SKL_TEST_STATIC:                                                      \
+      SKL_TEST_LOG((T), SKL_TEST_LOG_DEBUG,                                    \
+                   "static data from %p (len = %zd)\n", (BUF)->static_data,    \
+                   (BUF)->static_data_len);                                    \
+      if ((BUF)->static_data) {                                                \
+        for (size_t i = 0; i < (BUF)->len; ++i) {                              \
+          (BUF)->data[i] = (BUF)->static_data[i % (BUF)->static_data_len];     \
+        }                                                                      \
+      } else {                                                                 \
+        SKL_TEST_LOG((T), SKL_TEST_LOG_DEBUG, "no static data\n");             \
+      }                                                                        \
+      break;                                                                   \
+    case SKL_TEST_SEQ: {                                                       \
+      TYPE step = ((BUF)->max - (BUF)->min) / (BUF)->len;                      \
+      SKL_TEST_LOG((T), SKL_TEST_LOG_DEBUG,                                    \
+                   "sequential values in [%f, %f] by %f\n",                    \
+                   (double)(BUF)->min, (double)(BUF)->max, (double)step);      \
+      for (size_t i = 0; i < (BUF)->len; ++i) {                                \
+        (BUF)->data[i] = (BUF)->min + step * i;                                \
+      }                                                                        \
+      break;                                                                   \
+    }                                                                          \
+    }                                                                          \
+  } while (0)
+
+//----- Logging macros -----
+
+/**
+ * @brief Logging verbosity levels.
+ */
+enum {
+  SKL_TEST_LOG_ERROR = 0, /**< Error messages only */
+  SKL_TEST_LOG_INFO,      /**< Error and info messages */
+  SKL_TEST_LOG_DEBUG,     /**< All messages */
+};
+
+/**
+ * @brief Conditionally log a message.
+ *
+ * @param T - Test context pointer
+ * @param LEVEL - Minimum log level required for this message
+ * @param ... - Printf-style format string and arguments
+ *
+ * Logs a message only if T->log_level >= LEVEL.
+ * Higher log levels provide more verbose output.
+ */
+#define SKL_TEST_LOG(T, LEVEL, ...)                                            \
+  if ((T)->log_level >= (LEVEL)) {                                             \
+    skl_test_driver_log((T), __VA_ARGS__);                                     \
+  }
+
+/**
+ * @brief Assert a condition and set error status.
+ *
+ * @param T - Test context pointer
+ * @param COND - Condition to check
+ *
+ * If COND is false, logs an error message with the test name, condition,
+ * file, and line number, then sets T->status to SKL_TEST_FAIL. Does not
+ * return early, allowing multiple requirements to be checked.
+ */
+#define SKL_TEST_REQUIRE(T, COND)                                              \
+  do {                                                                         \
+    if (!(COND)) {                                                             \
+      skl_test_driver_error((T), "%s: %s\n", (T)->suite->name, #COND);         \
+      skl_test_driver_error((T), "    %s:%d\n", __FILE__, __LINE__);           \
+      (T)->status = SKL_TEST_FAIL;                                             \
+    }                                                                          \
+  } while (0)


### PR DESCRIPTION
This converts the `gemm_f16rc_f16rc_f32rc` test harness into the new testing framework introduced in #56.