### PR TITLE
[Test] Let tests set their own function pointers

### DIFF
--- a/test/gemm/gemm_f32rc_f32rc_f32rc.c
+++ b/test/gemm/gemm_f32rc_f32rc_f32rc.c
@@ -41,7 +41,7 @@ int gemm_f32rc_f32rc_f32rc_init(skl_test_t *t) {
   SKL_TEST_BUF_CREATE(t, float, &h->a);
   SKL_TEST_BUF_CREATE(t, float, &h->b);
   SKL_TEST_BUF_CREATE(t, float, &h->c);
-  if (h->verify) {
+  if (t->steps->verify) {
     // Only allocate if lengths are non-zero to avoid malloc(0)
     h->ctx.a_wide = h->a.len > 0 ? malloc(h->a.len * sizeof(double)) : NULL;
     h->ctx.b_wide = h->b.len > 0 ? malloc(h->b.len * sizeof(double)) : NULL;
@@ -54,20 +54,9 @@ int gemm_f32rc_f32rc_f32rc_init(skl_test_t *t) {
   return 0;
 }
 
-int gemm_f32rc_f32rc_f32rc_warmup(skl_test_t *t) {
-  gemm_f32rc_f32rc_f32rc_t *h = (gemm_f32rc_f32rc_f32rc_t *)t->harness;
-  if (h->warmup) {
-    return t->suite->execute(t);
-  }
-  return 0;
-}
-
 int gemm_f32rc_f32rc_f32rc_verify(skl_test_t *t) {
   /* Compute the reference (scalar) matrix output. */
   gemm_f32rc_f32rc_f32rc_t *h = (gemm_f32rc_f32rc_f32rc_t *)t->harness;
-  if (!h->verify) {
-    return 0;
-  }
 
   //
   // Compute the error bound array for comparing test vs reference results.
@@ -143,7 +132,7 @@ int gemm_f32rc_f32rc_f32rc_report(skl_test_t *t) {
   INFO("CSA: %zd, RSB: %zd, RSC: %zd\n", h->csa, h->rsb, h->rsc);
   INFO("Alpha: %f, Beta: %f\n", h->alpha, h->beta);
   INFO("%s", "\n");
-  INFO("Warmup: %s\n", h->warmup ? "yes" : "no");
+  INFO("Warmup: %s\n", t->steps->warmup ? "yes" : "no");
   INFO("Cycles: %zd\n", t->counters.cycles);
   INFO("Instructions: %zd\n", t->counters.instret);
   INFO("MACs/Cycle: %f\n", mpc);
@@ -158,7 +147,7 @@ int gemm_f32rc_f32rc_f32rc_cleanup(skl_test_t *t) {
   SKL_TEST_BUF_FREE(t, &h->a);
   SKL_TEST_BUF_FREE(t, &h->b);
   SKL_TEST_BUF_FREE(t, &h->c);
-  if (h->verify) {
+  if (t->steps->verify) {
     free(h->ctx.a_wide);
     free(h->ctx.b_wide);
     free(h->ctx.ref_c);

--- a/test/gemm/gemm_f32rc_f32rc_f32rc.h
+++ b/test/gemm/gemm_f32rc_f32rc_f32rc.h
@@ -23,9 +23,8 @@
 #include <stdint.h>
 
 typedef struct {
-  // Test mode
-  bool warmup;
-  bool verify;
+  // Test function pointers for various steps
+  skl_test_steps_t steps;
 
   // Configurable parameters (arguments to GEMM function)
   size_t m, n, k;
@@ -47,7 +46,6 @@ typedef struct {
 } gemm_f32rc_f32rc_f32rc_t;
 
 int gemm_f32rc_f32rc_f32rc_init(skl_test_t *t);
-int gemm_f32rc_f32rc_f32rc_warmup(skl_test_t *t);
 int gemm_f32rc_f32rc_f32rc_verify(skl_test_t *t);
 int gemm_f32rc_f32rc_f32rc_report(skl_test_t *t);
 int gemm_f32rc_f32rc_f32rc_cleanup(skl_test_t *t);

--- a/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
+++ b/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
@@ -15,10 +15,29 @@
  *  - All matrices are row-major (csa == 1, csb == 1, csc == 1)
  */
 
-#define TEST GEMM_F32RC_F32RC_F32RC_DEFAULTS, .warmup = false, .verify = true
-#define BENCH GEMM_F32RC_F32RC_F32RC_DEFAULTS, .warmup = true, .verify = false
+#define TEST                                                                   \
+  GEMM_F32RC_F32RC_F32RC_DEFAULTS,                                             \
+      .steps = {                                                               \
+          .init = gemm_f32rc_f32rc_f32rc_init,                                 \
+          .warmup = NULL,                                                      \
+          .execute = execute,                                                  \
+          .verify = gemm_f32rc_f32rc_f32rc_verify,                             \
+          .report = NULL,                                                      \
+          .cleanup = gemm_f32rc_f32rc_f32rc_cleanup,                           \
+  }
+#define BENCH                                                                  \
+  GEMM_F32RC_F32RC_F32RC_DEFAULTS,                                             \
+      .steps = {                                                               \
+          .init = gemm_f32rc_f32rc_f32rc_init,                                 \
+          .warmup = execute,                                                   \
+          .execute = execute,                                                  \
+          .verify = NULL,                                                      \
+          .report = gemm_f32rc_f32rc_f32rc_report,                             \
+          .cleanup = gemm_f32rc_f32rc_f32rc_cleanup,                           \
+  }
 
 static int execute(skl_test_t *t);
+static int steps(skl_test_t *t);
 
 // clang-format off
 gemm_f32rc_f32rc_f32rc_t tests[] = {
@@ -53,18 +72,17 @@ gemm_f32rc_f32rc_f32rc_t tests[] = {
 };
 // clang-format on
 
-static skl_test_suite_t suite = {
-    .name = "skl_gemm_f32_f32_f32_zve32f_x390",
-    .num_tests = sizeof(tests) / sizeof(tests[0]),
-    .test_size = sizeof(gemm_f32rc_f32rc_f32rc_t),
-    .tests = tests,
-    .init = gemm_f32rc_f32rc_f32rc_init,
-    .warmup = gemm_f32rc_f32rc_f32rc_warmup,
-    .execute = execute,
-    .verify = gemm_f32rc_f32rc_f32rc_verify,
-    .report = gemm_f32rc_f32rc_f32rc_report,
-    .cleanup = gemm_f32rc_f32rc_f32rc_cleanup,
-};
+static skl_test_suite_t suite = {.name = "skl_gemm_f32_f32_f32_zve32f_x390",
+                                 .num_tests = sizeof(tests) / sizeof(tests[0]),
+                                 .test_size = sizeof(gemm_f32rc_f32rc_f32rc_t),
+                                 .tests = tests,
+                                 .steps = steps};
+
+static int steps(skl_test_t *t) {
+  const gemm_f32rc_f32rc_f32rc_t *h = (gemm_f32rc_f32rc_f32rc_t *)t->harness;
+  t->steps = &h->steps;
+  return 0; // Success
+}
 
 static int execute(skl_test_t *t) {
   const gemm_f32rc_f32rc_f32rc_t *h = (gemm_f32rc_f32rc_f32rc_t *)t->harness;

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
@@ -25,9 +25,28 @@
  * The kernel computes C = A * B (beta=0) or C += A * B (beta=1).
  */
 
-#define TEST GEMM_F32RC_F32RC_F32RC_DEFAULTS, .warmup = false, .verify = true
-#define BENCH GEMM_F32RC_F32RC_F32RC_DEFAULTS, .warmup = true, .verify = false
+#define TEST                                                                   \
+  GEMM_F32RC_F32RC_F32RC_DEFAULTS,                                             \
+      .steps = {                                                               \
+          .init = gemm_f32rc_f32rc_f32rc_init,                                 \
+          .warmup = NULL,                                                      \
+          .execute = execute,                                                  \
+          .verify = gemm_f32rc_f32rc_f32rc_verify,                             \
+          .report = NULL,                                                      \
+          .cleanup = gemm_f32rc_f32rc_f32rc_cleanup,                           \
+  }
+#define BENCH                                                                  \
+  GEMM_F32RC_F32RC_F32RC_DEFAULTS,                                             \
+      .steps = {                                                               \
+          .init = gemm_f32rc_f32rc_f32rc_init,                                 \
+          .warmup = execute,                                                   \
+          .execute = execute,                                                  \
+          .verify = NULL,                                                      \
+          .report = gemm_f32rc_f32rc_f32rc_report,                             \
+          .cleanup = gemm_f32rc_f32rc_f32rc_cleanup,                           \
+  }
 static int execute(skl_test_t *t);
+static int steps(skl_test_t *t);
 
 // clang-format off
 gemm_f32rc_f32rc_f32rc_t tests[] = {
@@ -68,18 +87,18 @@ gemm_f32rc_f32rc_f32rc_t tests[] = {
 };
 // clang-format on
 
-static skl_test_suite_t suite = {
-    .name = "skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f",
-    .num_tests = sizeof(tests) / sizeof(tests[0]),
-    .test_size = sizeof(gemm_f32rc_f32rc_f32rc_t),
-    .tests = tests,
-    .init = gemm_f32rc_f32rc_f32rc_init,
-    .warmup = gemm_f32rc_f32rc_f32rc_warmup,
-    .execute = execute,
-    .verify = gemm_f32rc_f32rc_f32rc_verify,
-    .report = gemm_f32rc_f32rc_f32rc_report,
-    .cleanup = gemm_f32rc_f32rc_f32rc_cleanup,
-};
+static skl_test_suite_t suite = {.name =
+                                     "skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f",
+                                 .num_tests = sizeof(tests) / sizeof(tests[0]),
+                                 .test_size = sizeof(gemm_f32rc_f32rc_f32rc_t),
+                                 .tests = tests,
+                                 .steps = steps};
+
+static int steps(skl_test_t *t) {
+  const gemm_f32rc_f32rc_f32rc_t *h = (gemm_f32rc_f32rc_f32rc_t *)t->harness;
+  t->steps = &h->steps;
+  return 0; // Success
+}
 
 static int execute(skl_test_t *t) {
   const gemm_f32rc_f32rc_f32rc_t *h = (gemm_f32rc_f32rc_f32rc_t *)t->harness;

--- a/test/skl-test-driver.c
+++ b/test/skl-test-driver.c
@@ -120,29 +120,32 @@ int skl_test_driver_run_suite(skl_test_suite_t *suite) {
 
 #define TRY(STEP)                                                              \
   do {                                                                         \
-    if (suite->STEP != NULL) {                                                 \
-      SKL_TEST_REQUIRE(&t, suite->STEP(&t) == 0);                              \
+    if (t.STEP != NULL) {                                                      \
+      SKL_TEST_REQUIRE(&t, t.STEP(&t) == 0);                                   \
       if (t.status != SKL_TEST_PASS)                                           \
         goto cleanup;                                                          \
     }                                                                          \
   } while (0)
 
-    TRY(init);
+    TRY(suite->steps);
+    TRY(steps->init);
 
     // Run the test, including optional cache warmup
-    TRY(warmup);
+    TRY(steps->warmup);
     skl_test_driver_update_counters(&t.counters);
-    TRY(execute);
+    TRY(steps->execute);
     skl_test_driver_update_counters(&t.counters);
 
     // Verify test results, if verification is enabled
-    TRY(verify);
-    SKL_TEST_LOG(&t, SKL_TEST_LOG_INFO, "Verification passed\n");
+    TRY(steps->verify);
+    if (t.steps->verify) {
+      SKL_TEST_LOG(&t, SKL_TEST_LOG_INFO, "Verification passed\n");
+    }
 
   cleanup:
     // Always run cleanup if provided
-    if (suite->cleanup != NULL) {
-      int cleanup_status = suite->cleanup(&t);
+    if (t.steps->cleanup != NULL) {
+      int cleanup_status = t.steps->cleanup(&t);
       if (cleanup_status != 0) {
         skl_test_driver_error(&t, "Cleanup function failed\n");
         t.status = SKL_TEST_FAIL;
@@ -150,8 +153,8 @@ int skl_test_driver_run_suite(skl_test_suite_t *suite) {
     }
 
     // Always run report if provided, even after failure
-    if (suite->report != NULL) {
-      int report_status = suite->report(&t);
+    if (t.steps->report != NULL) {
+      int report_status = t.steps->report(&t);
       if (report_status != 0) {
         skl_test_driver_error(&t, "Report function failed\n");
         t.status = SKL_TEST_FAIL;

--- a/test/skl-test-driver.h
+++ b/test/skl-test-driver.h
@@ -50,10 +50,17 @@ typedef struct skl_test_t skl_test_t;
  * Describes a collection of related tests.
  */
 typedef struct {
-  const char *name; /**< Name of the test suite */
-  size_t num_tests; /**< Number of tests in the suite */
-  size_t test_size; /**< Size of the test-specific data structure */
-  void *tests;      /**< Array of test-specific data structures */
+  const char *name;            /**< Name of the test suite */
+  size_t num_tests;            /**< Number of tests in the suite */
+  size_t test_size;            /**< Size of the test-specific data structure */
+  void *tests;                 /**< Array of test-specific data structures */
+  int (*steps)(skl_test_t *t); /**< Populates the steps field of t*/
+} skl_test_suite_t;
+
+/**
+ *  @brief Function pointers determining each step ran by the driver.
+ */
+typedef struct {
   int (*init)(
       skl_test_t *t); /**< Optional initialization function, NULL to skip */
   int (*warmup)(skl_test_t *t);  /**< Optional warmup function, NULL to skip */
@@ -63,7 +70,7 @@ typedef struct {
   int (*report)(
       skl_test_t *t); /**< Optional reporting function, NULL to skip */
   int (*cleanup)(skl_test_t *t); /**< Optional cleanup function, NULL to skip */
-} skl_test_suite_t;
+} skl_test_steps_t;
 
 /**
  * @brief Performance counter values.
@@ -92,6 +99,8 @@ typedef enum {
  */
 struct skl_test_t {
   const skl_test_suite_t *suite; /**< Test suite (set by driver before init) */
+  const skl_test_steps_t
+      *steps;    /**< Pointers to test functions (set by test) */
   void *harness; /**< Harness-specific data (set by harness in init) */
   int log_level; /**< Logging verbosity level (set by driver before init) */
   skl_test_counters_t counters; /**< Performance counters (updated by driver) */


### PR DESCRIPTION
This is a preview of what #56 would look like to allow each test to specify its own collection of steps ran by the test driver.

The various function pointers in `skl_test_suite_t` were moved into a new struct `skl_test_steps_t` that each test has a pointer to. Each test in the array specifies a `skl_test_steps_t` object that the driver acquires by means of a new `steps` function defined in the test file.

This is slightly more verbose, but it allows very fine control on what every single test is doing. It also enables setting functions to `NULL` on a per-test basis, which simplifies some of the harness logic.