### PR TITLE
[Packing] Name Scheme & Documentation for Pack/Unpack Kernel Family

### DIFF
--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -169,49 +169,7 @@ Packing and unpacking must be performed by the user, and is not automatically ap
 - If one input is available offline, or reused across multiple GEMMs, it should not be packed multiple times
 - Some applications may provide data in the necessary format already, and should not be forced to repack it
 
-Each packed GEMM kernel (or family) supplies a corresponding pack and, if relevant, unpack function optimized for its layout's shape.
-These functions specialize the general form:
-```c
-void skl_pack_<a/b/c>_<datatype>_<isa>(
-  size_t m,           // Num. rows in input matrix
-  size_t n,           // Num. columns in input matrix
-  const <type>* src,  // Input matrix
-  size_t rs,          // Row stride of input matrix
-  size_t cs,          // Column stride of input matrix
-  size_t m0,          // Num. rows in a block of the input matrix
-  size_t n0,          // Num. columns in a block of the input matrix
-  <type>* dst,        // Output packed matrix [m1 x n1]
-  size_t rs0,         // Row stride within a block of the output matrix
-  size_t cs0,         // Column stride within a block of the output matrix
-  size_t rs1,         // Row stride between blocks of the output matrix
-  size_t cs1          // Column stride between blocks of the output matrix
-) {
-  size_t m1 = (m + m0 - 1) / m0; // Num. row blocks in the input matrix
-  size_t n1 = (n + n0 - 1) / n0; // Num. column blocks in the input matrix
-  for (size_t ii1 = 0; ii1 < m1; ++ii1) {
-    for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      const <type>* src_block = src + ii1 * m0 * rs + jj1 * n0 * cs;
-      <type>* dst_block = dst + ii1 * rs1 + jj1 * cs1;
-      for (size_t ii0 = 0; ii0 < m0; ++ii0) {
-        for (size_t jj0 = 0; jj0 < n0; ++jj0) {
-          if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
-            dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0 * cs];
-          } else {
-            // Pad with zeros
-            dst_block[ii0 * rs0 + jj0 * cs0] = 0;
-          }
-        }
-      }
-    }
-  }
-}
-```
-Unpacking functions work analogously.
-
-Since the layouts of the three matrices may be different, the packing function's name must indicate which matrix it is packing (A, B, or C).
-
-As in the case of GEMM kernels, most packing kernels will fully specialize or constrain most of the parameters, and they are thus omitted from the API.
-Usually, `m0`, `n0`, `rs0`, `cs0`, `rs1`, and `cs1` are all fixed by the target's layout.
+For more details, see the [SKL Matrix Packing Kernels](../pack/README.md) document.
 
 ## Application to Specific ISAs and Frameworks
 

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -71,7 +71,7 @@ It is assumed by default that the ordering of elements within a block is fixed t
 If instead the layout within a block is column-major, the inner-block-rder term is `c`, and if it may be either, `rc` is used.
 Similarly, the ordering of blocks relative to each other is assumed to be block-row-major, but if it is either block-column-major or configurable, a block-order term of `bc` or `brc` is added to the end of the layout term.
 
-When one of the dimensions is `1`, there is no difference in memory ordering between row- and column-major; however, the order is still said to be "column-major" when the second dimension is `1`, as this corresponds to the canonical layout of a column vector, and better indicates the transposition implied by the layout.
+When one of the dimensions is `1`, there is technically no difference in memory ordering between row- and column-major; however, the order is still said to be "column-major" when the second dimension is `1`, as this corresponds to the canonical layout of a column vector, and better communicates the transposition implied by the layout.
 
 Use of `1` for either block dimension effectively creates a block with one side of arbitrary size, referred to as a _panel_.
 
@@ -103,10 +103,10 @@ Memory layout: [0,4,8,12, 1,5,9,13, 2,6,10,14, 3,7,11,15, 16,20,24,28, 17,21,25,
                └─Block(0,0)┘ └─Block(0,1)┘ └─Block(0,2)┘ └─Block(0,3)┘ └─Block(1,0)─┘ └─Block(1,1)─┘
 
 Strides: rs0=1 (row stride within block), cs0=4 (column stride within block)
-         rs1=4 (row stride between blocks), cs1=16 (column stride between blocks)
+         rs1=16 (row stride between blocks), cs1=4 (column stride between blocks)
 ```
 
-### Example: 1x4 Block Layout (Block-Column-Major with Outer Transposition)
+### Example: 1x4bc Block Layout (Block-Column-Major with Outer Transposition)
 ```
 Original row-major matrix (4x8):        Packed layout [m0=1, n0=4, m1=4, n1=2]:
 
@@ -157,7 +157,7 @@ Memory layout: [0,4,1,5, 2,6,3,7, 8,12,9,13, 10,14,11,15]
                └Block(0,0)┘ └Block(0,1)┘ └─Block(1,0)─┘ └─Block(1,1)─┘
 
 Strides: rs0=1 (row stride within block), cs0=2 (column stride within block)
-         rs1=4 (row stride between blocks), cs1=4 (column stride between blocks)
+         rs1=8 (row stride between blocks), cs1=4 (column stride between blocks)
 ```
 Note: This layout does not occur in any of the current SKL GEMM kernels.
 It is for illustrative purposes only.

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -99,8 +99,9 @@ Original row-major matrix (8x4):        Packed layout [m0=4, n0=1, m1=2, n1=4]:
                                         │ 28  │     │ 29  │     │ 30  │     │ 31  │
                                         └─────┘     └─────┘     └─────┘     └─────┘
 
-Memory layout: [0,4,8,12, 1,5,9,13, 2,6,10,14, 3,7,11,15, 16,20,24,28, 17,21,25,29, ...]
-               └─Block(0,0)┘ └─Block(0,1)┘ └─Block(0,2)┘ └─Block(0,3)┘ └─Block(1,0)─┘ └─Block(1,1)─┘
+Memory layout:
+[ 0, 4, 8,12,  1, 5, 9,13,  2, 6,10,14,  3, 7,11,15, 16,20,24,28, 17,21,25,29, ...]
+ └Block(0,0)┘ └Block(0,1)┘ └Block(0,2)┘ └Block(0,3)┘ └Block(1,0)┘ └Block(1,1)┘
 
 Strides: rs0=1 (row stride within block), cs0=4 (column stride within block)
          rs1=16 (row stride between blocks), cs1=4 (column stride between blocks)
@@ -130,8 +131,9 @@ Original row-major matrix (4x8):        Packed layout [m0=1, n0=4, m1=4, n1=2]:
                                         │24 25 26 27│ │28 29 30 31│
                                         └───────────┘ └───────────┘
 
-Memory layout: [0,1,2,3, 8,9,10,11, 16,17,18,19, 24,25,26,27, 4,5,6,7, 12,13,14,15, ...]
-               └Block(0,0)┘ └Block(1,0)─┘ └─Block(2,0)─┘ └─Block(3,0)─┘ └Block(0,1)┘ └─Block(1,1)─┘
+Memory layout:
+[ 0, 1, 2, 3,  8, 9,10,11, 16,17,18,19, 24,25,26,27,  4, 5, 6, 7, 12,13,14,15, ...]
+ └Block(0,0)┘ └Block(1,0)┘ └Block(2,0)┘ └Block(3,0)┘ └Block(0,1)┘ └Block(1,1)┘
 
 Strides: rs0=4 (row stride within block), cs0=1 (column stride within block)
          rs1=4 (row stride between blocks), cs1=16 (column stride between blocks)
@@ -153,8 +155,9 @@ Original row-major matrix (4x4):        Packed layout [m0=2, n0=2, m1=2, n1=2]:
                                         │ 9 13  │   │11 15  │
                                         └───────┘   └───────┘
 
-Memory layout: [0,4,1,5, 2,6,3,7, 8,12,9,13, 10,14,11,15]
-               └Block(0,0)┘ └Block(0,1)┘ └─Block(1,0)─┘ └─Block(1,1)─┘
+Memory layout:
+[ 0, 4, 1, 5,  2, 6, 3, 7,  8,12, 9,13, 10,14,11,15 ]
+ └Block(0,0)┘ └Block(0,1)┘ └Block(1,0)┘ └Block(1,1)┘
 
 Strides: rs0=1 (row stride within block), cs0=2 (column stride within block)
          rs1=8 (row stride between blocks), cs1=4 (column stride between blocks)

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -14,7 +14,7 @@ See the [list of packing kernels](#list-of-packing-kernels) for details.
 
 These functions specialize the general form:
 ```c
-void skl_pack_<m0xn0>_<datatype>_<isa>(
+void skl_pack_rcbrc_<datatype>_<isa>(
   size_t m,           // Num. rows in input matrix
   size_t n,           // Num. columns in input matrix
   const <type>* src,  // Input matrix
@@ -52,32 +52,30 @@ Unpacking functions work analogously.
 
 
 As in the case of GEMM kernels, most packing kernels will fully specialize or constrain most of the parameters, and they are thus omitted from the API.
-Usually, `m0`, `n0`, `rs0`, and `cs0` are all fixed by the target's layout, and indicated in the kernel's name.
+Usually, `m0`, `n0`, `rs0`, and `cs0` are all fixed by the target's layout, and indicated in the kernel's name as part of the _layout term_ (`_rcbrc_` in the generic case shown above).
 
 ### Naming Convention for Packing Kernels
 
 The name of the packing kernel indicates the block size and ISA extension required by the kernel, and whether it is required or optional.
-The general form is `skl_pack_<m0>x<n0>_<datatype>_<isa>`, where `<m0>` and `<n0>` are the block dimensions, `<datatype>` is the datatype of the matrix, and `<isa>` is the ISA extension required by the kernel.
+The general form is `skl_pack_<layout>_<datatype>_<isa>`.
 
 > **Note**: As in other kernel families, the ISA suffix indicates the minimum requirement to execute the packing kernel itself (normally `zve32x`), but its primary intended use may be for a particular matrix extension. This is indicated in the documentation for each kernel (packing and GEMM).
 >
 > The `skl_pack_tex1_e8_xsfmm` function is an exception, as it uses the matrix engine to accelerate transposition within blocks.
 
-If it is ever ambiguous whether the layout of elements within a block is row- or column-major, the layout term of the name will end in `c` in the case of column-major.
-However, this is omitted when one of the dimensions is 1, as the two layouts are the same.
-The ordering of blocks relative to each other is never reflected in the name, as this is always set by configurable block strides (there should be no performance advantage to fixing these at compile time).
+#### Layout Term
 
-The choice of block dimensions and block ordering determines the overall data layout and can achieve different effects:
+The layout term may further be decomposed as `<m0>x<n0>[<inner-block-order>][<block-order>]`, where `m0` and `n0` are the block dimensions (rows and columns per block, respectively).
 
-- A `4x1` block implies transposition when the input matrix is row-major, since elements from different rows are grouped together within each block. The blocks themselves can be stored in either block-row- or block-column-major order. Block-column-major ordering is equivalent to full matrix transposition, with the `4` dimension only affecting padding.
+It is assumed by default that the ordering of elements within a block is fixed to be row-major.
+If instead the layout within a block is column-major, the inner-block-rder term is `c`, and if it may be either, `rc` is used.
+Similarly, the ordering of blocks relative to each other is assumed to be row-major, but if it is either column-major or configurable, a block-order term of `bc` or `brc` is added to the end of the layout term.
 
-- A `1x4` block does not transpose row-major elements, but can arrange data into _panels_ of `m0 x 4` shape by using block-column-major layout (`rs1=4`, `cs1=4*m0*m1`). With block-row-major layout, this has no effect aside from padding.
+When one of the dimensions is 1, neither `c` nor `rc` is added, as the two layouts are the same.
+If the second dimension (`n0`) is 1 and `m0` is not, a _transposition_ is implied relative to the original input, which is assumed to be row-major.
+(Use of `1` is equivalent to a "block dimension" of arbitrary size, as the block size is effectively ignored in that dimension.)
 
-- A `2x2` (or larger square) block keeps elements in their original layout within blocks, but blocks can be stored in either block-row- or block-column-major order.
-
-- A `2x2c` (or larger square) block transposes row-major elements within blocks.
-
-The examples below illustrate these different layouts.
+The examples below illustrate these different layouts, and relation to the layout term.
 
 ## Packing Layout Examples
 
@@ -161,6 +159,8 @@ Memory layout: [0,4,1,5, 2,6,3,7, 8,12,9,13, 10,14,11,15]
 Strides: rs0=1 (row stride within block), cs0=2 (column stride within block)
          rs1=4 (row stride between blocks), cs1=4 (column stride between blocks)
 ```
+Note: This layout does not occur in any of the current SKL GEMM kernels.
+It is for illustrative purposes only.
 
 
 
@@ -170,7 +170,7 @@ Strides: rs0=1 (row stride within block), cs0=2 (column stride within block)
 All of these kernels are required for correct operation of the corresponding GEMM kernels.
 
 #### Xsfvqdotq
-- `skl_pack_4x1_e8_zve32x`: Pack the B matrix into column-major panels to use `sf.vqdot.vx` without reduction summation.
+- `skl_pack_4x1_e8_zve32x`: Pack the B matrix into 4x1 panels (4x1 block-row-major example above) to use `sf.vqdot.vx` without reduction summation.
 
 #### Xsfvqmaccqoq
 These kernels are required for use of the `sf.vqmacc.4x8x4` instruction.

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -61,7 +61,7 @@ The general form is `skl_pack_<layout>_<datatype>_<isa>`.
 
 > **Note**: As in other kernel families, the ISA suffix indicates the minimum requirement to execute the packing kernel itself (normally `zve32x`), but its primary intended use may be for a particular matrix extension. This is indicated in the documentation for each kernel (packing and GEMM).
 >
-> The `skl_pack_tex1_e8_xsfmm` function is an exception, as it uses the matrix engine to accelerate transposition within blocks.
+> The `skl_pack_tex1c_e8_xsfmm` function is an exception, as it uses the matrix engine to accelerate transposition within blocks.
 
 #### Layout Term
 
@@ -69,17 +69,17 @@ The layout term may further be decomposed as `<m0>x<n0>[<inner-block-order>][<bl
 
 It is assumed by default that the ordering of elements within a block is fixed to be row-major.
 If instead the layout within a block is column-major, the inner-block-rder term is `c`, and if it may be either, `rc` is used.
-Similarly, the ordering of blocks relative to each other is assumed to be row-major, but if it is either column-major or configurable, a block-order term of `bc` or `brc` is added to the end of the layout term.
+Similarly, the ordering of blocks relative to each other is assumed to be block-row-major, but if it is either block-column-major or configurable, a block-order term of `bc` or `brc` is added to the end of the layout term.
 
-When one of the dimensions is 1, neither `c` nor `rc` is added, as the two layouts are the same.
-If the second dimension (`n0`) is 1 and `m0` is not, a _transposition_ is implied relative to the original input, which is assumed to be row-major.
-(Use of `1` is equivalent to a "block dimension" of arbitrary size, as the block size is effectively ignored in that dimension.)
+When one of the dimensions is `1`, there is no difference in memory ordering between row- and column-major; however, the order is still said to be "column-major" when the second dimension is `1`, as this corresponds to the canonical layout of a column vector, and better indicates the transposition implied by the layout.
+
+Use of `1` for either block dimension effectively creates a block with one side of arbitrary size, referred to as a _panel_.
 
 The examples below illustrate these different layouts, and relation to the layout term.
 
 ## Packing Layout Examples
 
-### Example: 4x1 Block Layout (Block-Row-Major with Inner Transposition)
+### Example: 4x1c Block Layout (Block-Row-Major with Inner Transposition)
 ```
 Original row-major matrix (8x4):        Packed layout [m0=4, n0=1, m1=2, n1=4]:
 
@@ -170,7 +170,7 @@ It is for illustrative purposes only.
 All of these kernels are required for correct operation of the corresponding GEMM kernels.
 
 #### Xsfvqdotq
-- `skl_pack_4x1_e8_zve32x`: Pack the B matrix into 4x1 panels (4x1 block-row-major example above) to use `sf.vqdot.vx` without reduction summation.
+- `skl_pack_4x1c_e8_zve32x`: Pack the B matrix into 4x1 panels (4x1 block-row-major example above) to use `sf.vqdot.vx` without reduction summation.
 
 #### Xsfvqmaccqoq
 These kernels are required for use of the `sf.vqmacc.4x8x4` instruction.
@@ -183,7 +183,7 @@ Because the of the small block size, significant specialization is required to a
 ### Optional Packing Kernels
 None of these are strictly required for correct operation of the corresponding GEMM kernels, but they may be useful for performance or compatibility reasons.
 (For Xsfmm, it is never required to pack any matrix; only [transposition](../transpose/README.md) is required if that A matrix is in row-major format, or B is in column-major format.)
-- `skl_pack_tex1_e8_xsfmm`: Transpose (TE x K) panels using the matrix engine. Used on a row-major A matrix or column-major B matrix.
+- `skl_pack_tex1c_e8_xsfmm`: Transpose (TE x K) panels using the matrix engine. Used on a row-major A matrix or column-major B matrix.
 
 ### Packing Kernels That Do Not Exist
 These names refer to kernels that users might expect to exist, but do not, because they can be implemented with an appropriate block size in the generic RVV packing kernel at reasonable performance.

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -68,7 +68,7 @@ The general form is `skl_pack_<layout>_<datatype>_<isa>`.
 The layout term may further be decomposed as `<m0>x<n0>[<inner-block-order>][<block-order>]`, where `m0` and `n0` are the block dimensions (rows and columns per block, respectively).
 
 It is assumed by default that the ordering of elements within a block is fixed to be row-major.
-If instead the layout within a block is column-major, the inner-block-rder term is `c`, and if it may be either, `rc` is used.
+If instead the layout within a block is column-major, the inner-block-order term is `c`, and if it may be either, `rc` is used.
 Similarly, the ordering of blocks relative to each other is assumed to be block-row-major, but if it is either block-column-major or configurable, a block-order term of `bc` or `brc` is added to the end of the layout term.
 
 When one of the dimensions is `1`, there is technically no difference in memory ordering between row- and column-major; however, the order is still said to be "column-major" when the second dimension is `1`, as this corresponds to the canonical layout of a column vector, and better communicates the transposition implied by the layout.
@@ -182,7 +182,7 @@ Because the of the small block size, significant specialization is required to a
 
 ### Optional Packing Kernels
 None of these are strictly required for correct operation of the corresponding GEMM kernels, but they may be useful for performance or compatibility reasons.
-(For Xsfmm, it is never required to pack any matrix; only [transposition](../transpose/README.md) is required if that A matrix is in row-major format, or B is in column-major format.)
+(For Xsfmm, it is never required to pack any matrix; only [transposition](../transpose/README.md) is required if the A matrix is in row-major format, or B is in column-major format.)
 - `skl_pack_tex1c_e8_xsfmm`: Transpose (TE x K) panels using the matrix engine. Used on a row-major A matrix or column-major B matrix.
 
 ### Packing Kernels That Do Not Exist

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -1,0 +1,204 @@
+# SKL Matrix Packing Kernels
+
+This family of kernels implements the pack and unpack operations for matrices used in the [packed GEMM kernels](../gemm/packed-gemm.md).
+It includes a set of packing and, when relevant, unpacking functions for each GEMM-related ISA extension.
+
+These routines reorder the elements of a 2D, row-major matrix of size `m` x `n` into a blocked layout where blocks of size `m0` x `n0` are stored contiguously, and padded with zeros if necessary, for a total of `m1` x `n1` blocks, where `m1 = ceil(m/m0)` and `n1 = ceil(n/n0)`.
+Depending on the requirements of the target ISA or application, the elements within each block may also be transposed, and the blocks themselves may be stored in row- or column-major order.
+
+Not all extensions require packing for all matrices, but kernels for such cases may nevertheless be provided, as some applications may require similar layouts across all matrices, or seek locality benefits from arranging data in the shape of the underlying multiplication operation, or one of its dimensions.
+The documentation for each kernel indicates whether it is required or optional.
+See the [list of packing kernels](#list-of-packing-kernels) for details.
+
+## General API for Packing & Unpacking Kernels
+
+These functions specialize the general form:
+```c
+void skl_pack_<m0xn0>_<datatype>_<isa>(
+  size_t m,           // Num. rows in input matrix
+  size_t n,           // Num. columns in input matrix
+  const <type>* src,  // Input matrix
+  size_t rs,          // Row stride of input matrix
+  size_t cs,          // Column stride of input matrix
+  size_t m0,          // Num. rows in a block of the input matrix
+  size_t n0,          // Num. columns in a block of the input matrix
+  <type>* dst,        // Output packed matrix [m1 x n1]
+  size_t rs0,         // Row stride within a block of the output matrix
+  size_t cs0,         // Column stride within a block of the output matrix
+  size_t rs1,         // Row stride between blocks of the output matrix
+  size_t cs1          // Column stride between blocks of the output matrix
+) {
+  size_t m1 = (m + m0 - 1) / m0; // Num. row blocks in the input matrix
+  size_t n1 = (n + n0 - 1) / n0; // Num. column blocks in the input matrix
+  for (size_t ii1 = 0; ii1 < m1; ++ii1) {
+    for (size_t jj1 = 0; jj1 < n1; ++jj1) {
+      const <type>* src_block = src + ii1 * m0 * rs + jj1 * n0 * cs;
+      <type>* dst_block = dst + ii1 * rs1 + jj1 * cs1;
+      for (size_t ii0 = 0; ii0 < m0; ++ii0) {
+        for (size_t jj0 = 0; jj0 < n0; ++jj0) {
+          if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
+            dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0 * cs];
+          } else {
+            // Pad with zeros
+            dst_block[ii0 * rs0 + jj0 * cs0] = 0;
+          }
+        }
+      }
+    }
+  }
+}
+```
+Unpacking functions work analogously.
+
+
+As in the case of GEMM kernels, most packing kernels will fully specialize or constrain most of the parameters, and they are thus omitted from the API.
+Usually, `m0`, `n0`, `rs0`, and `cs0` are all fixed by the target's layout, and indicated in the kernel's name.
+
+### Naming Convention for Packing Kernels
+
+The name of the packing kernel indicates the block size and ISA extension required by the kernel, and whether it is required or optional.
+The general form is `skl_pack_<m0>x<n0>_<datatype>_<isa>`, where `<m0>` and `<n0>` are the block dimensions, `<datatype>` is the datatype of the matrix, and `<isa>` is the ISA extension required by the kernel.
+
+> **Note**: As in other kernel families, the ISA suffix indicates the minimum requirement to execute the packing kernel itself (normally `zve32x`), but its primary intended use may be for a particular matrix extension. This is indicated in the documentation for each kernel (packing and GEMM).
+>
+> The `skl_pack_tex1_e8_xsfmm` function is an exception, as it uses the matrix engine to accelerate transposition within blocks.
+
+If it is ever ambiguous whether the layout of elements within a block is row- or column-major, the layout term of the name will end in `c` in the case of column-major.
+However, this is omitted when one of the dimensions is 1, as the two layouts are the same.
+The ordering of blocks relative to each other is never reflected in the name, as this is always set by configurable block strides (there should be no performance advantage to fixing these at compile time).
+
+The choice of block dimensions and block ordering determines the overall data layout and can achieve different effects:
+
+- A `4x1` block implies transposition when the input matrix is row-major, since elements from different rows are grouped together within each block. The blocks themselves can be stored in either block-row- or block-column-major order. Block-column-major ordering is equivalent to full matrix transposition, with the `4` dimension only affecting padding.
+
+- A `1x4` block does not transpose row-major elements, but can arrange data into _panels_ of `m0 x 4` shape by using block-column-major layout (`rs1=4`, `cs1=4*m0*m1`). With block-row-major layout, this has no effect aside from padding.
+
+- A `2x2` (or larger square) block keeps elements in their original layout within blocks, but blocks can be stored in either block-row- or block-column-major order.
+
+- A `2x2c` (or larger square) block transposes row-major elements within blocks.
+
+The examples below illustrate these different layouts.
+
+## Packing Layout Examples
+
+### Example: 4x1 Block Layout (Block-Row-Major with Inner Transposition)
+```
+Original row-major matrix (8x4):        Packed layout [m0=4, n0=1, m1=2, n1=4]:
+
+ 0  1  2  3                             Block(0,0)  Block(0,1)  Block(0,2)  Block(0,3)
+ 4  5  6  7                             ┌─────┐     ┌─────┐     ┌─────┐     ┌─────┐
+ 8  9 10 11                             │  0  │     │  1  │     │  2  │     │  3  │
+12 13 14 15                             │  4  │     │  5  │     │  6  │     │  7  │
+16 17 18 19                             │  8  │     │  9  │     │ 10  │     │ 11  │
+20 21 22 23                             │ 12  │     │ 13  │     │ 14  │     │ 15  │
+24 25 26 27                             └─────┘     └─────┘     └─────┘     └─────┘
+28 29 30 31
+                                        Block(1,0)  Block(1,1)  Block(1,2)  Block(1,3)
+                                        ┌─────┐     ┌─────┐     ┌─────┐     ┌─────┐
+                                        │ 16  │     │ 17  │     │ 18  │     │ 19  │
+                                        │ 20  │     │ 21  │     │ 22  │     │ 23  │
+                                        │ 24  │     │ 25  │     │ 26  │     │ 27  │
+                                        │ 28  │     │ 29  │     │ 30  │     │ 31  │
+                                        └─────┘     └─────┘     └─────┘     └─────┘
+
+Memory layout: [0,4,8,12, 1,5,9,13, 2,6,10,14, 3,7,11,15, 16,20,24,28, 17,21,25,29, ...]
+               └─Block(0,0)┘ └─Block(0,1)┘ └─Block(0,2)┘ └─Block(0,3)┘ └─Block(1,0)─┘ └─Block(1,1)─┘
+
+Strides: rs0=1 (row stride within block), cs0=4 (column stride within block)
+         rs1=4 (row stride between blocks), cs1=16 (column stride between blocks)
+```
+
+### Example: 1x4 Block Layout (Block-Column-Major with Outer Transposition)
+```
+Original row-major matrix (4x8):        Packed layout [m0=1, n0=4, m1=4, n1=2]:
+
+ 0  1  2  3  4  5  6  7                 Block(0,0)    Block(0,1)
+ 8  9 10 11 12 13 14 15                 ┌───────────┐ ┌───────────┐
+16 17 18 19 20 21 22 23                 │ 0  1  2  3│ │ 4  5  6  7│
+24 25 26 27 28 29 30 31                 └───────────┘ └───────────┘
+
+                                        Block(1,0)    Block(1,1)
+                                        ┌───────────┐ ┌───────────┐
+                                        │ 8  9 10 11│ │12 13 14 15│
+                                        └───────────┘ └───────────┘
+
+                                        Block(2,0)    Block(2,1)
+                                        ┌───────────┐ ┌───────────┐
+                                        │16 17 18 19│ │20 21 22 23│
+                                        └───────────┘ └───────────┘
+
+                                        Block(3,0)    Block(3,1)
+                                        ┌───────────┐ ┌───────────┐
+                                        │24 25 26 27│ │28 29 30 31│
+                                        └───────────┘ └───────────┘
+
+Memory layout: [0,1,2,3, 8,9,10,11, 16,17,18,19, 24,25,26,27, 4,5,6,7, 12,13,14,15, ...]
+               └Block(0,0)┘ └Block(1,0)─┘ └─Block(2,0)─┘ └─Block(3,0)─┘ └Block(0,1)┘ └─Block(1,1)─┘
+
+Strides: rs0=4 (row stride within block), cs0=1 (column stride within block)
+         rs1=4 (row stride between blocks), cs1=16 (column stride between blocks)
+```
+
+### Example: 2x2c Block Layout (Block-Row-Major with Column-Major Within Blocks)
+```
+Original row-major matrix (4x4):        Packed layout [m0=2, n0=2, m1=2, n1=2]:
+
+ 0  1  2  3                             Block(0,0)  Block(0,1)
+ 4  5  6  7                             ┌───────┐   ┌───────┐
+ 8  9 10 11                             │ 0  4  │   │ 2  6  │
+12 13 14 15                             │ 1  5  │   │ 3  7  │
+                                        └───────┘   └───────┘
+
+                                        Block(1,0)  Block(1,1)
+                                        ┌───────┐   ┌───────┐
+                                        │ 8 12  │   │10 14  │
+                                        │ 9 13  │   │11 15  │
+                                        └───────┘   └───────┘
+
+Memory layout: [0,4,1,5, 2,6,3,7, 8,12,9,13, 10,14,11,15]
+               └Block(0,0)┘ └Block(0,1)┘ └─Block(1,0)─┘ └─Block(1,1)─┘
+
+Strides: rs0=1 (row stride within block), cs0=2 (column stride within block)
+         rs1=4 (row stride between blocks), cs1=4 (column stride between blocks)
+```
+
+
+
+## List of Packing Kernels
+
+### Required Packing Kernels
+All of these kernels are required for correct operation of the corresponding GEMM kernels.
+
+#### Xsfvqdotq
+- `skl_pack_4x1_e8_zve32x`: Pack the B matrix into column-major panels to use `sf.vqdot.vx` without reduction summation.
+
+#### Xsfvqmaccqoq
+These kernels are required for use of the `sf.vqmacc.4x8x4` instruction.
+Because the of the small block size, significant specialization is required to achieve reasonable performance.
+- `skl_pack_4x4_e32_zve32x`: Used for the C matrix.
+- `skl_unpack_4x4_e32_zve32x`: Inverse of `skl_pack_4x4_e32_zve32x`.
+- `skl_pack_4x8_e8_zve32x`: Used for the A matrix.
+- `skl_pack_8x4_e8_zve32x`: Used for the B matrix.
+
+### Optional Packing Kernels
+None of these are strictly required for correct operation of the corresponding GEMM kernels, but they may be useful for performance or compatibility reasons.
+(For Xsfmm, it is never required to pack any matrix; only [transposition](../transpose/README.md) is required if that A matrix is in row-major format, or B is in column-major format.)
+- `skl_pack_tex1_e8_xsfmm`: Transpose (TE x K) panels using the matrix engine. Used on a row-major A matrix or column-major B matrix.
+
+### Packing Kernels That Do Not Exist
+These names refer to kernels that users might expect to exist, but do not, because they can be implemented with an appropriate block size in the generic RVV packing kernel at reasonable performance.
+In general, so long as the block size is large enough in at least one dimension (as is the case in paneling), a generic packing kernel with a large enough vector length can achieve reasonable performance.
+
+- ~~`skl_pack_1xte_e8_zve32x`~~: Pack (K x TE) panels. Used on a column-major A matrix or row-major B matrix.
+- ~~`skl_pack_texte_e32_zve32x`~~: Pack (TE x TE) blocks without transposition. Used on a C matrix.
+- ~~`skl_pack_1xvlm8_e8_zve32x`~~: Pack (1 x VLMAX*8) column panels.
+
+In addition to being unnecessary for correct execution, these can all be implemented by supplying the machine-dependent dimension (TE or VLMAX) to the generic packing kernel.
+
+## Generic RVV Packing Kernel [**Future Work**]
+
+The fully-general packing function described [above](#general-api-for-packing--unpacking-kernels) can be vectorized with RVV, and will perform reasonably well in many cases.
+Specifically, if the input is row-major, the innermost loop can be vectorized, and if `cs0` is 1, unit-stride loads and stores can be used.
+So long as the block width `n0 * SEW` is at least as large as the machine data path width, no specialized optimizations should be required.
+**This implementation is not yet provided by SKL.**
+


### PR DESCRIPTION
Inspired by questions raised in @myeh01 's work (https://github.com/sifive/skl/pull/59), this moves the "pack & unpack" kernel description out of the [packed GEMM doc](https://github.com/sifive/skl/blob/main/src/gemm/packed-gemm.md) into a separate README in `skl/src/pack`, which it also creates.

## Changes
It makes the following proposals:

1. A standard naming scheme: `skl_pack_<m0xn0>_` for `m0` x `n0` blocks.
2. Drop `_a_` / `_b_` / `_c_` matrix references in names.
3. Blocks are presumed to have row-major order internally, but this only shows up so far in Xsfvqmaccqoq (4x4 and 4x8).
4. Explicit differentiation between _mandatory_ (needed by ISA) and _optional_ (helps framework integration) packing.
5. List of optional packing kernels that will be provided (due to anticipated demand) and those that won't (because they can be handled without specific optimization).
6. A proposal -- yet unimplemented -- of a "generic RVV packing" kernel that should handle all "easy" cases (block sizes are large enough that you can vectorize without dimension-specific hacks).

## Review and Feedback
Please share your opinions of all the proposals outlined above (not feeling so sure about many of them!), and when we agree on the overall design, then help review the document itself.

## Status & Plans
Keeping this as a draft for now, as the changes it proposes are not reflected in the actual kernel source code.
I will wait for consensus on the plan before we start making changes to the code.