### PR TITLE
[CVT] Fix cvt_zvfofp4min bug when considering `rvv_vl_half_avl`

### DIFF
--- a/src/cvt/cvt_zvfofp4min.c
+++ b/src/cvt/cvt_zvfofp4min.c
@@ -24,11 +24,13 @@ SKL_FUNC void skl_cvt_f4e2m1_f8e4m3_zvfofp4min(
         "vsetvli %[vl_pairs], %[pairs_remain], e8, m4, ta, ma\n\t"
         "vle8.v v28, (%[src])\n\t"
         "add %[src], %[src], %[vl_pairs]\n\t"
-        "vsetvli %[vl], %[n_remain], e8, m8, ta, ma\n\t"
+        "slli    %[vl_n], %[vl_pairs], 1\n\t"
+        "minu     %[vl_n], %[vl_n], %[n_remain]\n\t"
+        "vsetvli %[vl_n], %[vl_n], e8, m8, ta, ma\n\t"
         "vfext.vf2 v16, v28\n\t"
         "vse8.v v16, (%[dst])\n\t"
-        "add %[dst], %[dst], %[vl]\n\t"
-        : [vl] "=&r"(vl_n), [vl_pairs] "=&r"(vl_pairs), [src] "+&r"(pSrc),
+        "add %[dst], %[dst], %[vl_n]\n\t"
+        : [vl_n] "=&r"(vl_n), [vl_pairs] "=&r"(vl_pairs), [src] "+&r"(pSrc),
           [dst] "+r"(pDst)
         : [n_remain] "r"(n_remain), [pairs_remain] "r"(pairs_remain)
         : "v28", "v29", "v30", "v31", "v16", "v17", "v18", "v19", "v20", "v21",


### PR DESCRIPTION
The original implementation assumes vl policy: `vl = vlmax` when `vlmax < avl < 2*vlmax`.

However, with the `rvv_vl_half_avl` policy where `vl = ceil(avl/2)`, `vl_n` is not guaranteed to be even except for the last iteration.

**Example:**
Given `vlmax = 1024` (vlmax_pair = 512) and `avl = 1025` (avl_pair = 513):

- **Policy 1** (`vl = vlmax`): 
  - Iteration 1: `vl_pairs = 512`, `vl_n = 1024` (even) ✅
  - Iteration 2: `vl_pairs = 1`, `vl_n = 1` (odd) ✅

- **Policy 2** (`vl = ceil(avl/2)`):
  - Iteration 1: `vl_pairs = 257`, `vl_n = 513` (odd) ❌
  - Causes incorrect unpacking since paired elements are required