### PR TITLE
[CI] Update checkout to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
Due to deprecation of Node.js 20 actions, this PR updates the CI script to use `checkout@v6`. Thanks to @hdelassus for bringing up this issue.