### PR TITLE
[Infra] Export compile commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 project(SKL)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(DEFAULT_CMAKE_BUILD_TYPE "Release")
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "No build type selected, default to ${DEFAULT_CMAKE_BUILD_TYPE}")


### PR DESCRIPTION
This sets `CMAKE_EXPORT_COMPILE_COMMANDS` to `ON` in order to assist in debugging and to allow tools like `clangd` to read the generated `compile_commands.json` file.