### PR TITLE
[GEMM] Optimize large widening f16 x390 kernel

### DIFF
--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
@@ -10,6 +10,12 @@
 
 #include "skl-common.h"
 
+#if defined(__riscv_zihintntl)
+#define NTL_P1 "ntl.p1 \n\t"
+#else
+#define NTL_P1
+#endif
+
 /**
  * @brief RVV float16 vector-matrix multiply with float32 output for row-major
  * matrices, tuned for X390.
@@ -227,33 +233,33 @@ skl_gemm_1xm8x16_f16_f16_f32_zvfh_x390(size_t n, size_t k, float alpha,
 SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
     size_t m, size_t n, size_t k, float alpha, const _Float16 *a, size_t rsa,
     const _Float16 *b, size_t rsb, float beta, float *c, size_t rsc) {
-  size_t jj_vl = __riscv_vsetvlmax_e16m2();
+  size_t jj_vl;
   size_t ii;
   size_t jj;
   size_t kk;
-  size_t kk0;
   size_t ii0;
   size_t kk_peel;
-  _Float16 a0;
-  _Float16 a1;
-  _Float16 a2;
-  _Float16 a3;
-  _Float16 a4;
-  _Float16 a5;
+  _Float16 a00;
+  _Float16 a10;
+  _Float16 a20;
+  _Float16 a30;
+  _Float16 a40;
+  _Float16 a50;
+  _Float16 a01;
+  _Float16 a11;
+  _Float16 a21;
+  _Float16 a31;
+  _Float16 a41;
+  _Float16 a51;
   vfloat16m2_t b00;
+  vfloat16m2_t b10;
   vfloat32m4_t acc0;
   vfloat32m4_t acc1;
   vfloat32m4_t acc2;
   vfloat32m4_t acc3;
   vfloat32m4_t acc4;
   vfloat32m4_t acc5;
-  vfloat16m2_t b011;
-  vfloat32m4_t c00;
-  vfloat32m4_t c01;
-  vfloat32m4_t c02;
-  vfloat32m4_t c03;
-  vfloat32m4_t c04;
-  vfloat32m4_t c05;
+  _Float16 a0;
   vfloat16m2_t b0;
   vfloat32m4_t acc;
   vfloat32m4_t c0;
@@ -274,282 +280,495 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
     for (jj = 0; jj < n; jj = jj + jj_vl) {
       jj_vl = __riscv_vsetvl_e16m2(n - jj);
 
-      __asm__ volatile(
-          // clang-format off
-          "\n\t"
-          "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
-          "vle16.v %[b00], (%[b_addr]) \n\t"
-          "flh %[a0], 0(%[a_addr_0]) \n\t"
-          "flh %[a1], 0(%[a_addr_1]) \n\t"
-          "vfwmul.vf %[acc0], %[b00], %[a0] \n\t"
-          "vfwmul.vf %[acc1], %[b00], %[a1] \n\t"
-          "flh %[a2], 0(%[a_addr_2]) \n\t"
-          "flh %[a3], 0(%[a_addr_3]) \n\t"
-          "vfwmul.vf %[acc2], %[b00], %[a2] \n\t"
-          "vfwmul.vf %[acc3], %[b00], %[a3] \n\t"
-          "flh %[a4], 0(%[a_addr_4]) \n\t"
-          "flh %[a5], 0(%[a_addr_5]) \n\t"
-          "vfwmul.vf %[acc4], %[b00], %[a4] \n\t"
-          "vfwmul.vf %[acc5], %[b00], %[a5] \n\t"
-          : [a0] "=&f"(a0),
-            [a1] "=&f"(a1),
-            [a2] "=&f"(a2),
-            [a3] "=&f"(a3),
-            [a4] "=&f"(a4),
-            [a5] "=&f"(a5),
-            [b00] "=&vr"(b00),
-            [acc0] "=&vr"(acc0),
-            [acc1] "=&vr"(acc1),
-            [acc2] "=&vr"(acc2),
-            [acc3] "=&vr"(acc3),
-            [acc4] "=&vr"(acc4),
-            [acc5] "=vr"(acc5)
-          : [a_addr_0] "r"(a + (ii + 0) * rsa),
-            [a_addr_1] "r"(a + (ii + 1) * rsa),
-            [a_addr_2] "r"(a + (ii + 2) * rsa),
-            [a_addr_3] "r"(a + (ii + 3) * rsa),
-            [a_addr_4] "r"(a + (ii + 4) * rsa),
-            [a_addr_5] "r"(a + (ii + 5) * rsa),
-            [jj_vl_in] "r"(jj_vl),
-            [b_addr] "r"(b + jj)
-          : "vtype", "vl", "memory"
-          // clang-format on
-      );
-
-      for (kk = 1; (kk + 12) <= k; kk = kk + 12) {
+      {
+        const _Float16 *a_addr = a + ii * rsa;
         __asm__ volatile(
             // clang-format off
             "\n\t"
             "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+            "vle16.v %[b00], (%[b_addr]) \n\t"
 
-            "flh %[a0],  0(%[a_addr_0]) \n\t"
-            "flh %[a1],  0(%[a_addr_1]) \n\t"
-            "flh %[a2],  0(%[a_addr_2]) \n\t"
-            "flh %[a3],  0(%[a_addr_3]) \n\t"
-            "flh %[a4],  0(%[a_addr_4]) \n\t"
-            "flh %[a5],  0(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr_0]) \n\t"
-            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
-            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
-            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
-
-            "flh %[a0],  2(%[a_addr_0]) \n\t"
-            "flh %[a1],  2(%[a_addr_1]) \n\t"
-            "flh %[a2],  2(%[a_addr_2]) \n\t"
-            "flh %[a3],  2(%[a_addr_3]) \n\t"
-            "flh %[a4],  2(%[a_addr_4]) \n\t"
-            "flh %[a5],  2(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr_0]) \n\t"
-            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
-            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
-            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
-
-            "flh %[a0],  4(%[a_addr_0]) \n\t"
-            "flh %[a1],  4(%[a_addr_1]) \n\t"
-            "flh %[a2],  4(%[a_addr_2]) \n\t"
-            "flh %[a3],  4(%[a_addr_3]) \n\t"
-            "flh %[a4],  4(%[a_addr_4]) \n\t"
-            "flh %[a5],  4(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr_0]) \n\t"
-            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
-            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
-            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
-
-            "flh %[a0],  6(%[a_addr_0]) \n\t"
-            "flh %[a1],  6(%[a_addr_1]) \n\t"
-            "flh %[a2],  6(%[a_addr_2]) \n\t"
-            "flh %[a3],  6(%[a_addr_3]) \n\t"
-            "flh %[a4],  6(%[a_addr_4]) \n\t"
-            "flh %[a5],  6(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr_0]) \n\t"
-            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
-            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
-            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
-
-            "flh %[a0],  8(%[a_addr_0]) \n\t"
-            "flh %[a1],  8(%[a_addr_1]) \n\t"
-            "flh %[a2],  8(%[a_addr_2]) \n\t"
-            "flh %[a3],  8(%[a_addr_3]) \n\t"
-            "flh %[a4],  8(%[a_addr_4]) \n\t"
-            "flh %[a5],  8(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr_0]) \n\t"
-            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
-            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
-            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
-
-            "flh %[a0], 10(%[a_addr_0]) \n\t"
-            "flh %[a1], 10(%[a_addr_1]) \n\t"
-            "flh %[a2], 10(%[a_addr_2]) \n\t"
-            "flh %[a3], 10(%[a_addr_3]) \n\t"
-            "flh %[a4], 10(%[a_addr_4]) \n\t"
-            "flh %[a5], 10(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr_0]) \n\t"
-            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
-            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
-            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
-
-            "flh %[a0], 12(%[a_addr_0]) \n\t"
-            "flh %[a1], 12(%[a_addr_1]) \n\t"
-            "flh %[a2], 12(%[a_addr_2]) \n\t"
-            "flh %[a3], 12(%[a_addr_3]) \n\t"
-            "flh %[a4], 12(%[a_addr_4]) \n\t"
-            "flh %[a5], 12(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr_0]) \n\t"
-            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
-            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
-            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
-
-            "flh %[a0], 14(%[a_addr_0]) \n\t"
-            "flh %[a1], 14(%[a_addr_1]) \n\t"
-            "flh %[a2], 14(%[a_addr_2]) \n\t"
-            "flh %[a3], 14(%[a_addr_3]) \n\t"
-            "flh %[a4], 14(%[a_addr_4]) \n\t"
-            "flh %[a5], 14(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr_0]) \n\t"
-            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
-            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
-            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
-
-            "flh %[a0], 16(%[a_addr_0]) \n\t"
-            "flh %[a1], 16(%[a_addr_1]) \n\t"
-            "flh %[a2], 16(%[a_addr_2]) \n\t"
-            "flh %[a3], 16(%[a_addr_3]) \n\t"
-            "flh %[a4], 16(%[a_addr_4]) \n\t"
-            "flh %[a5], 16(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr_0]) \n\t"
-            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
-            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
-            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
-
-            "flh %[a0], 18(%[a_addr_0]) \n\t"
-            "flh %[a1], 18(%[a_addr_1]) \n\t"
-            "flh %[a2], 18(%[a_addr_2]) \n\t"
-            "flh %[a3], 18(%[a_addr_3]) \n\t"
-            "flh %[a4], 18(%[a_addr_4]) \n\t"
-            "flh %[a5], 18(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr_0]) \n\t"
-            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
-            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
-            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
-
-            "flh %[a0], 20(%[a_addr_0]) \n\t"
-            "flh %[a1], 20(%[a_addr_1]) \n\t"
-            "flh %[a2], 20(%[a_addr_2]) \n\t"
-            "flh %[a3], 20(%[a_addr_3]) \n\t"
-            "flh %[a4], 20(%[a_addr_4]) \n\t"
-            "flh %[a5], 20(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr_0]) \n\t"
-            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
-            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
-            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
-
-            "flh %[a0], 22(%[a_addr_0]) \n\t"
-            "flh %[a1], 22(%[a_addr_1]) \n\t"
-            "flh %[a2], 22(%[a_addr_2]) \n\t"
-            "flh %[a3], 22(%[a_addr_3]) \n\t"
-            "flh %[a4], 22(%[a_addr_4]) \n\t"
-            "flh %[a5], 22(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr_0]) \n\t"
-            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
-            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
-            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
-            : [a0] "=&f"(a0),
-              [a1] "=&f"(a1),
-              [a2] "=&f"(a2),
-              [a3] "=&f"(a3),
-              [a4] "=&f"(a4),
-              [a5] "=&f"(a5),
+            "flh %[a00], 0(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            "flh %[a10], 0(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            "vfwmul.vf %[acc0], %[b00], %[a00] \n\t"
+            "vfwmul.vf %[acc1], %[b00], %[a10] \n\t"
+            "flh %[a20], 0(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            "flh %[a30], 0(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            "vfwmul.vf %[acc2], %[b00], %[a20] \n\t"
+            "vfwmul.vf %[acc3], %[b00], %[a30] \n\t"
+            "flh %[a40], 0(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            "flh %[a50], 0(%[a_addr]) \n\t"
+            "vfwmul.vf %[acc4], %[b00], %[a40] \n\t"
+            "vfwmul.vf %[acc5], %[b00], %[a50] \n\t"
+            : [a00] "=&f"(a00),
+              [a10] "=&f"(a10),
+              [a20] "=&f"(a20),
+              [a30] "=&f"(a30),
+              [a40] "=&f"(a40),
+              [a50] "=&f"(a50),
+              [a_addr] "+&r"(a_addr),
               [b00] "=&vr"(b00),
+              [acc0] "=&vr"(acc0),
+              [acc1] "=&vr"(acc1),
+              [acc2] "=&vr"(acc2),
+              [acc3] "=&vr"(acc3),
+              [acc4] "=&vr"(acc4),
+              [acc5] "=vr"(acc5)
+            : [jj_vl_in] "r"(jj_vl),
+              [rsa2] "r" (rsa * sizeof(_Float16)),
+              [b_addr] "r"(b + jj)
+            : "vtype", "vl", "memory"
+            // clang-format on
+        );
+      }
+
+      if (12 + 2 < k) {
+        const size_t offset = 1;
+        const _Float16 *a_addr = a + ii * rsa + offset;
+        const _Float16 *b_addr = b + offset * rsb + jj;
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+
+            "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            NTL_P1
+            "flh %[a00], 0(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a01], 2(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            NTL_P1
+            "flh %[a10], 0(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a11], 2(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            NTL_P1
+            "flh %[a20], 0(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a21], 2(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            NTL_P1
+            "flh %[a30], 0(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a31], 2(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            NTL_P1
+            "flh %[a40], 0(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a41], 2(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            NTL_P1
+            "flh %[a50], 0(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a51], 2(%[a_addr]) \n\t"
+
+            "vle16.v %[b10], (%[b_addr]) \n\t"
+          : [a00] "=&f"(a00),
+            [a10] "=&f"(a10),
+            [a20] "=&f"(a20),
+            [a30] "=&f"(a30),
+            [a40] "=&f"(a40),
+            [a50] "=&f"(a50),
+            [a01] "=&f"(a01),
+            [a11] "=&f"(a11),
+            [a21] "=&f"(a21),
+            [a31] "=&f"(a31),
+            [a41] "=&f"(a41),
+            [a51] "=&f"(a51),
+            [a_addr] "+&r"(a_addr),
+            [b00] "=&vr"(b00),
+            [b10] "=vr"(b10),
+            [b_addr] "+&r"(b_addr)
+          : [jj_vl_in] "r"(jj_vl),
+            [rsa2] "r" (rsa * sizeof(_Float16)),
+            [rsb2] "r" (rsb * sizeof(_Float16))
+          : "vtype", "vl", "memory"
+            // clang-format on
+        );
+      }
+
+      for (kk = 1; (kk + 12 + 2) <= k; kk = kk + 12) {
+        const size_t offset = 2;
+        const _Float16 *b_addr = b + (kk + offset) * rsb + jj;
+        const _Float16 *a_addr_0 = a + (ii + 0) * rsa + kk + offset;
+        const _Float16 *a_addr_1;
+        const _Float16 *a_addr_2;
+        const _Float16 *a_addr_3;
+        const _Float16 *a_addr_4;
+        const _Float16 *a_addr_5;
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+            "add %[a_addr_1], %[a_addr_0], %[rsa2] \n\t"
+            "add %[a_addr_2], %[a_addr_1], %[rsa2] \n\t"
+            "add %[a_addr_3], %[a_addr_2], %[rsa2] \n\t"
+            "add %[a_addr_4], %[a_addr_3], %[rsa2] \n\t"
+            "add %[a_addr_5], %[a_addr_4], %[rsa2] \n\t"
+
+            "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+
+            "vfwmacc.vf %[acc0], %[a00], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a10], %[b00] \n\t"
+            NTL_P1
+            "flh %[a00],  0(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a10],  0(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a20], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a30], %[b00] \n\t"
+            NTL_P1
+            "flh %[a20],  0(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a30],  0(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a40], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a50], %[b00] \n\t"
+            NTL_P1
+            "flh %[a40],  0(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a50],  0(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc0], %[a01], %[b10] \n\t"
+            "vfwmacc.vf %[acc1], %[a11], %[b10] \n\t"
+            NTL_P1
+            "flh %[a01],  2(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a11],  2(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a21], %[b10] \n\t"
+            "vfwmacc.vf %[acc3], %[a31], %[b10] \n\t"
+            NTL_P1
+            "flh %[a21],  2(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a31],  2(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a41], %[b10] \n\t"
+            "vfwmacc.vf %[acc5], %[a51], %[b10] \n\t"
+            NTL_P1
+            "flh %[a41],  2(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a51],  2(%[a_addr_5]) \n\t"
+            "vle16.v %[b10], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc0], %[a00], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a10], %[b00] \n\t"
+            NTL_P1
+            "flh %[a00],  4(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a10],  4(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a20], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a30], %[b00] \n\t"
+            NTL_P1
+            "flh %[a20],  4(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a30],  4(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a40], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a50], %[b00] \n\t"
+            NTL_P1
+            "flh %[a40],  4(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a50],  4(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc0], %[a01], %[b10] \n\t"
+            "vfwmacc.vf %[acc1], %[a11], %[b10] \n\t"
+            NTL_P1
+            "flh %[a01],  6(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a11],  6(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a21], %[b10] \n\t"
+            "vfwmacc.vf %[acc3], %[a31], %[b10] \n\t"
+            NTL_P1
+            "flh %[a21],  6(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a31],  6(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a41], %[b10] \n\t"
+            "vfwmacc.vf %[acc5], %[a51], %[b10] \n\t"
+            NTL_P1
+            "flh %[a41],  6(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a51],  6(%[a_addr_5]) \n\t"
+            "vle16.v %[b10], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc0], %[a00], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a10], %[b00] \n\t"
+            NTL_P1
+            "flh %[a00],  8(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a10],  8(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a20], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a30], %[b00] \n\t"
+            NTL_P1
+            "flh %[a20],  8(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a30],  8(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a40], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a50], %[b00] \n\t"
+            NTL_P1
+            "flh %[a40],  8(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a50],  8(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc0], %[a01], %[b10] \n\t"
+            "vfwmacc.vf %[acc1], %[a11], %[b10] \n\t"
+            NTL_P1
+            "flh %[a01], 10(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a11], 10(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a21], %[b10] \n\t"
+            "vfwmacc.vf %[acc3], %[a31], %[b10] \n\t"
+            NTL_P1
+            "flh %[a21], 10(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a31], 10(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a41], %[b10] \n\t"
+            "vfwmacc.vf %[acc5], %[a51], %[b10] \n\t"
+            NTL_P1
+            "flh %[a41], 10(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a51], 10(%[a_addr_5]) \n\t"
+            "vle16.v %[b10], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc0], %[a00], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a10], %[b00] \n\t"
+            NTL_P1
+            "flh %[a00], 12(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a10], 12(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a20], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a30], %[b00] \n\t"
+            NTL_P1
+            "flh %[a20], 12(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a30], 12(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a40], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a50], %[b00] \n\t"
+            NTL_P1
+            "flh %[a40], 12(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a50], 12(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc0], %[a01], %[b10] \n\t"
+            "vfwmacc.vf %[acc1], %[a11], %[b10] \n\t"
+            NTL_P1
+            "flh %[a01], 14(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a11], 14(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a21], %[b10] \n\t"
+            "vfwmacc.vf %[acc3], %[a31], %[b10] \n\t"
+            NTL_P1
+            "flh %[a21], 14(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a31], 14(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a41], %[b10] \n\t"
+            "vfwmacc.vf %[acc5], %[a51], %[b10] \n\t"
+            NTL_P1
+            "flh %[a41], 14(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a51], 14(%[a_addr_5]) \n\t"
+            "vle16.v %[b10], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc0], %[a00], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a10], %[b00] \n\t"
+            NTL_P1
+            "flh %[a00], 16(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a10], 16(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a20], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a30], %[b00] \n\t"
+            NTL_P1
+            "flh %[a20], 16(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a30], 16(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a40], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a50], %[b00] \n\t"
+            NTL_P1
+            "flh %[a40], 16(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a50], 16(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc0], %[a01], %[b10] \n\t"
+            "vfwmacc.vf %[acc1], %[a11], %[b10] \n\t"
+            NTL_P1
+            "flh %[a01], 18(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a11], 18(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a21], %[b10] \n\t"
+            "vfwmacc.vf %[acc3], %[a31], %[b10] \n\t"
+            NTL_P1
+            "flh %[a21], 18(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a31], 18(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a41], %[b10] \n\t"
+            "vfwmacc.vf %[acc5], %[a51], %[b10] \n\t"
+            NTL_P1
+            "flh %[a41], 18(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a51], 18(%[a_addr_5]) \n\t"
+            "vle16.v %[b10], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc0], %[a00], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a10], %[b00] \n\t"
+            NTL_P1
+            "flh %[a00], 20(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a10], 20(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a20], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a30], %[b00] \n\t"
+            NTL_P1
+            "flh %[a20], 20(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a30], 20(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a40], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a50], %[b00] \n\t"
+            NTL_P1
+            "flh %[a40], 20(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a50], 20(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc0], %[a01], %[b10] \n\t"
+            "vfwmacc.vf %[acc1], %[a11], %[b10] \n\t"
+            NTL_P1
+            "flh %[a01], 22(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a11], 22(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a21], %[b10] \n\t"
+            "vfwmacc.vf %[acc3], %[a31], %[b10] \n\t"
+            NTL_P1
+            "flh %[a21], 22(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a31], 22(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a41], %[b10] \n\t"
+            "vfwmacc.vf %[acc5], %[a51], %[b10] \n\t"
+            NTL_P1
+            "flh %[a41], 22(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a51], 22(%[a_addr_5]) \n\t"
+            "vle16.v %[b10], (%[b_addr]) \n\t"
+            : [a00] "+&f"(a00),
+              [a10] "+&f"(a10),
+              [a20] "+&f"(a20),
+              [a30] "+&f"(a30),
+              [a40] "+&f"(a40),
+              [a50] "+&f"(a50),
+              [a01] "+&f"(a01),
+              [a11] "+&f"(a11),
+              [a21] "+&f"(a21),
+              [a31] "+&f"(a31),
+              [a41] "+&f"(a41),
+              [a51] "+&f"(a51),
+              [b00] "+&vr"(b00),
+              [b10] "+&vr"(b10),
               [acc0] "+&vr"(acc0),
               [acc1] "+&vr"(acc1),
               [acc2] "+&vr"(acc2),
               [acc3] "+&vr"(acc3),
               [acc4] "+&vr"(acc4),
-              [acc5] "+&vr"(acc5)
+              [acc5] "+&vr"(acc5),
+              [b_addr] "+&r"(b_addr),
+              [a_addr_1] "=r" (a_addr_1),
+              [a_addr_2] "=r" (a_addr_2),
+              [a_addr_3] "=r" (a_addr_3),
+              [a_addr_4] "=r" (a_addr_4),
+              [a_addr_5] "=r" (a_addr_5)
             : [jj_vl_in] "r"(jj_vl),
-              [a_addr_0] "r"(a + (ii + 0) * rsa + kk),
-              [a_addr_1] "r"(a + (ii + 1) * rsa + kk),
-              [a_addr_2] "r"(a + (ii + 2) * rsa + kk),
-              [a_addr_3] "r"(a + (ii + 3) * rsa + kk),
-              [a_addr_4] "r"(a + (ii + 4) * rsa + kk),
-              [a_addr_5] "r"(a + (ii + 5) * rsa + kk),
-              [b_addr_0] "r"(b + kk * rsb + jj),
+              [a_addr_0] "r" (a_addr_0),
+              [rsa2] "r" (rsa * sizeof(_Float16)),
               [rsb2] "r" (rsb * sizeof(_Float16))
             : "vtype", "vl", "memory"
             // clang-format on
         );
       }
-      for (kk0 = kk; (kk0 + 1) <= k; kk0 = kk0 + 1) {
+
+      if (12 + 2 < k) {
         __asm__ volatile(
             // clang-format off
             "\n\t"
             "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
-            "vle16.v %[b00], (%[b_addr_0]) \n\t"
-            "flh %[a0], 0(%[a_addr_0]) \n\t"
-            "flh %[a1], 0(%[a_addr_1]) \n\t"
-            "flh %[a2], 0(%[a_addr_2]) \n\t"
-            "flh %[a3], 0(%[a_addr_3]) \n\t"
-            "flh %[a4], 0(%[a_addr_4]) \n\t"
-            "flh %[a5], 0(%[a_addr_5]) \n\t"
-            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
-            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
-            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
-            : [a0] "=&f"(a0),
-              [a1] "=&f"(a1),
-              [a2] "=&f"(a2),
-              [a3] "=&f"(a3),
-              [a4] "=&f"(a4),
-              [a5] "=&f"(a5),
+
+            "vfwmacc.vf %[acc0], %[a00], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a10], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a20], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a30], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a40], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a50], %[b00] \n\t"
+
+            "vfwmacc.vf %[acc0], %[a01], %[b10] \n\t"
+            "vfwmacc.vf %[acc1], %[a11], %[b10] \n\t"
+            "vfwmacc.vf %[acc2], %[a21], %[b10] \n\t"
+            "vfwmacc.vf %[acc3], %[a31], %[b10] \n\t"
+            "vfwmacc.vf %[acc4], %[a41], %[b10] \n\t"
+            "vfwmacc.vf %[acc5], %[a51], %[b10] \n\t"
+            : [acc0] "+&vr" (acc0),
+              [acc1] "+&vr" (acc1),
+              [acc2] "+&vr" (acc2),
+              [acc3] "+&vr" (acc3),
+              [acc4] "+&vr" (acc4),
+              [acc5] "+&vr" (acc5)
+            : [jj_vl_in] "r"(jj_vl),
+              [b00] "vr" (b00),
+              [b10] "vr" (b10),
+              [a00] "f"(a00),
+              [a10] "f"(a10),
+              [a20] "f"(a20),
+              [a30] "f"(a30),
+              [a40] "f"(a40),
+              [a50] "f"(a50),
+              [a01] "f"(a01),
+              [a11] "f"(a11),
+              [a21] "f"(a21),
+              [a31] "f"(a31),
+              [a41] "f"(a41),
+              [a51] "f"(a51)
+            : "vtype", "vl", "memory"
+            // clang-format on
+        );
+        kk += 2;
+      }
+
+      for (; kk < k; kk++) {
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "flh %[a00], 0(%[a_addr_0]) \n\t"
+            "flh %[a10], 0(%[a_addr_1]) \n\t"
+            "flh %[a20], 0(%[a_addr_2]) \n\t"
+            "flh %[a30], 0(%[a_addr_3]) \n\t"
+            "flh %[a40], 0(%[a_addr_4]) \n\t"
+            "flh %[a50], 0(%[a_addr_5]) \n\t"
+            "vfwmacc.vf %[acc0], %[a00], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a10], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a20], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a30], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a40], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a50], %[b00] \n\t"
+            : [a00] "=&f"(a00),
+              [a10] "=&f"(a10),
+              [a20] "=&f"(a20),
+              [a30] "=&f"(a30),
+              [a40] "=&f"(a40),
+              [a50] "=&f"(a50),
               [b00] "=&vr"(b00),
               [acc0] "+&vr"(acc0),
               [acc1] "+&vr"(acc1),
@@ -558,53 +777,61 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
               [acc4] "+&vr"(acc4),
               [acc5] "+vr"(acc5)
             : [jj_vl_in] "r"(jj_vl),
-              [a_addr_0] "r"(a + (ii + 0) * rsa + kk0),
-              [a_addr_1] "r"(a + (ii + 1) * rsa + kk0),
-              [a_addr_2] "r"(a + (ii + 2) * rsa + kk0),
-              [a_addr_3] "r"(a + (ii + 3) * rsa + kk0),
-              [a_addr_4] "r"(a + (ii + 4) * rsa + kk0),
-              [a_addr_5] "r"(a + (ii + 5) * rsa + kk0),
-              [b_addr_0] "r"(b + kk0 * rsb + jj)
+              [a_addr_0] "r"(a + (ii + 0) * rsa + kk),
+              [a_addr_1] "r"(a + (ii + 1) * rsa + kk),
+              [a_addr_2] "r"(a + (ii + 2) * rsa + kk),
+              [a_addr_3] "r"(a + (ii + 3) * rsa + kk),
+              [a_addr_4] "r"(a + (ii + 4) * rsa + kk),
+              [a_addr_5] "r"(a + (ii + 5) * rsa + kk),
+              [b_addr] "r"(b + kk * rsb + jj)
             : "vtype", "vl", "memory"
             // clang-format on
         );
       }
+
+      float *c_addr = c + ii * rsc + jj;
       __asm__ volatile(
           // clang-format off
           "\n\t"
           "vsetvli zero, %[jj_vl_in], e32, m4, ta, ma \n\t"
-          "vle32.v %[c0], (%[c_addr_0]) \n\t"
+
+          "vle32.v %[c0], (%[c_addr]) \n\t"
           "vfmul.vf %[c0], %[c0], %[beta] \n\t"
           "vfmacc.vf %[c0], %[alpha], %[acc0] \n\t"
-          "vse32.v %[c0], (%[c_addr_0]) \n\t"
-          "vle32.v %[c0], (%[c_addr_1]) \n\t"
+          "vse32.v %[c0], (%[c_addr]) \n\t"
+          "add %[c_addr], %[c_addr], %[rsc4] \n\t"
+
+          "vle32.v %[c0], (%[c_addr]) \n\t"
           "vfmul.vf %[c0], %[c0], %[beta] \n\t"
           "vfmacc.vf %[c0], %[alpha], %[acc1] \n\t"
-          "vse32.v %[c0], (%[c_addr_1]) \n\t"
-          "vle32.v %[c0], (%[c_addr_2]) \n\t"
+          "vse32.v %[c0], (%[c_addr]) \n\t"
+          "add %[c_addr], %[c_addr], %[rsc4] \n\t"
+
+          "vle32.v %[c0], (%[c_addr]) \n\t"
           "vfmul.vf %[c0], %[c0], %[beta] \n\t"
           "vfmacc.vf %[c0], %[alpha], %[acc2] \n\t"
-          "vse32.v %[c0], (%[c_addr_2]) \n\t"
-          "vle32.v %[c0], (%[c_addr_3]) \n\t"
+          "vse32.v %[c0], (%[c_addr]) \n\t"
+          "add %[c_addr], %[c_addr], %[rsc4] \n\t"
+
+          "vle32.v %[c0], (%[c_addr]) \n\t"
           "vfmul.vf %[c0], %[c0], %[beta] \n\t"
           "vfmacc.vf %[c0], %[alpha], %[acc3] \n\t"
-          "vse32.v %[c0], (%[c_addr_3]) \n\t"
-          "vle32.v %[c0], (%[c_addr_4]) \n\t"
+          "vse32.v %[c0], (%[c_addr]) \n\t"
+          "add %[c_addr], %[c_addr], %[rsc4] \n\t"
+
+          "vle32.v %[c0], (%[c_addr]) \n\t"
           "vfmul.vf %[c0], %[c0], %[beta] \n\t"
           "vfmacc.vf %[c0], %[alpha], %[acc4] \n\t"
-          "vse32.v %[c0], (%[c_addr_4]) \n\t"
-          "vle32.v %[c0], (%[c_addr_5]) \n\t"
+          "vse32.v %[c0], (%[c_addr]) \n\t"
+          "add %[c_addr], %[c_addr], %[rsc4] \n\t"
+
+          "vle32.v %[c0], (%[c_addr]) \n\t"
           "vfmul.vf %[c0], %[c0], %[beta] \n\t"
           "vfmacc.vf %[c0], %[alpha], %[acc5] \n\t"
-          "vse32.v %[c0], (%[c_addr_5]) \n\t"
-          : [c0] "=&vr"(c0)
+          "vse32.v %[c0], (%[c_addr]) \n\t"
+          : [c0] "=&vr"(c0),
+            [c_addr] "+&r"(c_addr)
           : [jj_vl_in] "r"(jj_vl),
-            [c_addr_0] "r"(c + (ii + 0) * rsc + jj),
-            [c_addr_1] "r"(c + (ii + 1) * rsc + jj),
-            [c_addr_2] "r"(c + (ii + 2) * rsc + jj),
-            [c_addr_3] "r"(c + (ii + 3) * rsc + jj),
-            [c_addr_4] "r"(c + (ii + 4) * rsc + jj),
-            [c_addr_5] "r"(c + (ii + 5) * rsc + jj),
             [beta] "f"(beta),
             [alpha] "f"(alpha),
             [acc0] "vr"(acc0),
@@ -612,12 +839,14 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
             [acc2] "vr"(acc2),
             [acc3] "vr"(acc3),
             [acc4] "vr"(acc4),
-            [acc5] "vr"(acc5)
+            [acc5] "vr"(acc5),
+            [rsc4] "r"(rsc * sizeof(float))
           : "vtype", "vl", "memory"
           // clang-format on
       );
     }
   }
+
   for (ii0 = ii; (ii0 + 1) <= m; ii0 = ii0 + 1) {
     for (jj = 0; jj < n; jj = jj + jj_vl) {
       jj_vl = __riscv_vsetvl_e16m2(n - jj);
@@ -676,3 +905,5 @@ SKL_FUNC void skl_gemm_f16_f16_f32_zvfh_x390(size_t m, size_t n, size_t k,
   skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(m, n, k, alpha, a, rsa, b, rsb, beta, c,
                                         rsc);
 }
+
+#undef NTL_P1

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
@@ -763,11 +763,11 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4x12_f16_f16_f32_zvfh_x390(
               [acc4] "+&vr"(acc4),
               [acc5] "+&vr"(acc5),
               [b_addr] "+&r"(b_addr),
-              [a_addr_1] "=r" (a_addr_1),
-              [a_addr_2] "=r" (a_addr_2),
-              [a_addr_3] "=r" (a_addr_3),
-              [a_addr_4] "=r" (a_addr_4),
-              [a_addr_5] "=r" (a_addr_5)
+              [a_addr_1] "=&r" (a_addr_1),
+              [a_addr_2] "=&r" (a_addr_2),
+              [a_addr_3] "=&r" (a_addr_3),
+              [a_addr_4] "=&r" (a_addr_4),
+              [a_addr_5] "=&r" (a_addr_5)
             : [jj_vl_in] "r"(jj_vl),
               [a_addr_0] "r" (a_addr_0),
               [rsa2] "r" (rsa * sizeof(_Float16)),

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
@@ -465,6 +465,8 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4x12_f16_f16_f32_zvfh_x390(
         const _Float16 *a_addr_4;
         const _Float16 *a_addr_5;
         __asm__ volatile(
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Woverlength-strings"
             // clang-format off
             "\n\t"
             "add %[a_addr_1], %[a_addr_0], %[rsa2] \n\t"
@@ -725,6 +727,7 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4x12_f16_f16_f32_zvfh_x390(
             NTL_P1
             "flh %[a53], 22(%[a_addr_5]) \n\t"
             "vle16.v %[b30], (%[b_addr]) \n\t"
+#pragma clang diagnostic pop
             : [a00] "+&f"(a00),
               [a10] "+&f"(a10),
               [a20] "+&f"(a20),

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
@@ -225,12 +225,12 @@ skl_gemm_1xm8x16_f16_f16_f32_zvfh_x390(size_t n, size_t k, float alpha,
  *     c, rsc, 1
  * );
  * ```
- * Uses a 4 x LMUL=4 x 1 register tile. Vectorized across the N dimension.
+ * Uses a 6 x LMUL=4 x 12 register tile. Vectorized across the N dimension.
  *
  * @note
- * Works best when `m >= 4` and `n >= __riscv_vsetvlmax_e32m4()`.
+ * Works best when `m >= 6` and `n >= __riscv_vsetvlmax_e32m4()`.
  */
-SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
+SKL_FUNC_PRIVATE void skl_gemm_6xm4x12_f16_f16_f32_zvfh_x390(
     size_t m, size_t n, size_t k, float alpha, const _Float16 *a, size_t rsa,
     const _Float16 *b, size_t rsb, float beta, float *c, size_t rsc) {
   size_t jj_vl;
@@ -1006,8 +1006,8 @@ SKL_FUNC void skl_gemm_f16_f16_f32_zvfh_x390(size_t m, size_t n, size_t k,
     skl_gemm_1xm8x16_f16_f16_f32_zvfh_x390(n, k, alpha, a, b, rsb, beta, c);
     return;
   }
-  skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(m, n, k, alpha, a, rsa, b, rsb, beta, c,
-                                        rsc);
+  skl_gemm_6xm4x12_f16_f16_f32_zvfh_x390(m, n, k, alpha, a, rsa, b, rsb, beta,
+                                         c, rsc);
 }
 
 #undef NTL_P1

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
@@ -227,93 +227,395 @@ skl_gemm_1xm8x16_f16_f16_f32_zvfh_x390(size_t n, size_t k, float alpha,
 SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
     size_t m, size_t n, size_t k, float alpha, const _Float16 *a, size_t rsa,
     const _Float16 *b, size_t rsb, float beta, float *c, size_t rsc) {
-  size_t jj_vl;
+  size_t jj_vl = __riscv_vsetvlmax_e16m2();
   size_t ii;
   size_t jj;
-  size_t kk_peel;
   size_t kk;
+  size_t kk0;
   size_t ii0;
-  _Float16 a00;
-  _Float16 a01;
-  _Float16 a02;
-  _Float16 a03;
-  vfloat16m2_t b0;
+  size_t kk_peel;
+  _Float16 a0;
+  _Float16 a1;
+  _Float16 a2;
+  _Float16 a3;
+  _Float16 a4;
+  _Float16 a5;
+  vfloat16m2_t b00;
   vfloat32m4_t acc0;
   vfloat32m4_t acc1;
   vfloat32m4_t acc2;
   vfloat32m4_t acc3;
+  vfloat32m4_t acc4;
+  vfloat32m4_t acc5;
+  vfloat16m2_t b011;
   vfloat32m4_t c00;
   vfloat32m4_t c01;
   vfloat32m4_t c02;
   vfloat32m4_t c03;
-  _Float16 a0;
+  vfloat32m4_t c04;
+  vfloat32m4_t c05;
+  vfloat16m2_t b0;
   vfloat32m4_t acc;
   vfloat32m4_t c0;
+
   if (k == 0) {
     for (ii = 0; (ii + 1) <= m; ii = ii + 1) {
       for (jj = 0; jj < n; jj = jj + jj_vl) {
         jj_vl = __riscv_vsetvl_e32m4(n - jj);
-        c0 = __riscv_vle32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)),
-                                   jj_vl);
+        c0 = __riscv_vle32_v_f32m4(c + ii * rsc + jj, jj_vl);
         c0 = __riscv_vfmul_vf_f32m4(c0, beta, jj_vl);
-        __riscv_vse32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)), c0,
-                              jj_vl);
+        __riscv_vse32_v_f32m4(c + ii * rsc + jj, c0, jj_vl);
       }
     }
     return;
   }
-  for (ii = 0; (ii + 4) <= m; ii = ii + 4) {
+
+  for (ii = 0; (ii + 6) <= m; ii = ii + 6) {
     for (jj = 0; jj < n; jj = jj + jj_vl) {
       jj_vl = __riscv_vsetvl_e16m2(n - jj);
-      for (kk_peel = 0; ((kk_peel + 1) <= k) && (kk_peel < (0 + (1 * 1)));
-           kk_peel = kk_peel + 1) {
-        a00 = a[((ii + 0) * rsa) + ((kk_peel + 0) * 1)];
-        a01 = a[((ii + 1) * rsa) + ((kk_peel + 0) * 1)];
-        a02 = a[((ii + 2) * rsa) + ((kk_peel + 0) * 1)];
-        a03 = a[((ii + 3) * rsa) + ((kk_peel + 0) * 1)];
-        b0 = __riscv_vle16_v_f16m2(b + (((kk_peel + 0) * rsb) + ((jj + 0) * 1)),
-                                   jj_vl);
-        acc0 = __riscv_vfwmul_vf_f32m4(b0, a00, jj_vl);
-        acc1 = __riscv_vfwmul_vf_f32m4(b0, a01, jj_vl);
-        acc2 = __riscv_vfwmul_vf_f32m4(b0, a02, jj_vl);
-        acc3 = __riscv_vfwmul_vf_f32m4(b0, a03, jj_vl);
+
+      __asm__ volatile(
+          // clang-format off
+          "\n\t"
+          "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+          "vle16.v %[b00], (%[b_addr]) \n\t"
+          "flh %[a0], 0(%[a_addr_0]) \n\t"
+          "flh %[a1], 0(%[a_addr_1]) \n\t"
+          "vfwmul.vf %[acc0], %[b00], %[a0] \n\t"
+          "vfwmul.vf %[acc1], %[b00], %[a1] \n\t"
+          "flh %[a2], 0(%[a_addr_2]) \n\t"
+          "flh %[a3], 0(%[a_addr_3]) \n\t"
+          "vfwmul.vf %[acc2], %[b00], %[a2] \n\t"
+          "vfwmul.vf %[acc3], %[b00], %[a3] \n\t"
+          "flh %[a4], 0(%[a_addr_4]) \n\t"
+          "flh %[a5], 0(%[a_addr_5]) \n\t"
+          "vfwmul.vf %[acc4], %[b00], %[a4] \n\t"
+          "vfwmul.vf %[acc5], %[b00], %[a5] \n\t"
+          : [a0] "=&f"(a0),
+            [a1] "=&f"(a1),
+            [a2] "=&f"(a2),
+            [a3] "=&f"(a3),
+            [a4] "=&f"(a4),
+            [a5] "=&f"(a5),
+            [b00] "=&vr"(b00),
+            [acc0] "=&vr"(acc0),
+            [acc1] "=&vr"(acc1),
+            [acc2] "=&vr"(acc2),
+            [acc3] "=&vr"(acc3),
+            [acc4] "=&vr"(acc4),
+            [acc5] "=vr"(acc5)
+          : [a_addr_0] "r"(a + (ii + 0) * rsa),
+            [a_addr_1] "r"(a + (ii + 1) * rsa),
+            [a_addr_2] "r"(a + (ii + 2) * rsa),
+            [a_addr_3] "r"(a + (ii + 3) * rsa),
+            [a_addr_4] "r"(a + (ii + 4) * rsa),
+            [a_addr_5] "r"(a + (ii + 5) * rsa),
+            [jj_vl_in] "r"(jj_vl),
+            [b_addr] "r"(b + jj)
+          : "vtype", "vl", "memory"
+          // clang-format on
+      );
+
+      for (kk = 1; (kk + 12) <= k; kk = kk + 12) {
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+
+            "flh %[a0],  0(%[a_addr_0]) \n\t"
+            "flh %[a1],  0(%[a_addr_1]) \n\t"
+            "flh %[a2],  0(%[a_addr_2]) \n\t"
+            "flh %[a3],  0(%[a_addr_3]) \n\t"
+            "flh %[a4],  0(%[a_addr_4]) \n\t"
+            "flh %[a5],  0(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr_0]) \n\t"
+            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
+
+            "flh %[a0],  2(%[a_addr_0]) \n\t"
+            "flh %[a1],  2(%[a_addr_1]) \n\t"
+            "flh %[a2],  2(%[a_addr_2]) \n\t"
+            "flh %[a3],  2(%[a_addr_3]) \n\t"
+            "flh %[a4],  2(%[a_addr_4]) \n\t"
+            "flh %[a5],  2(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr_0]) \n\t"
+            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
+
+            "flh %[a0],  4(%[a_addr_0]) \n\t"
+            "flh %[a1],  4(%[a_addr_1]) \n\t"
+            "flh %[a2],  4(%[a_addr_2]) \n\t"
+            "flh %[a3],  4(%[a_addr_3]) \n\t"
+            "flh %[a4],  4(%[a_addr_4]) \n\t"
+            "flh %[a5],  4(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr_0]) \n\t"
+            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
+
+            "flh %[a0],  6(%[a_addr_0]) \n\t"
+            "flh %[a1],  6(%[a_addr_1]) \n\t"
+            "flh %[a2],  6(%[a_addr_2]) \n\t"
+            "flh %[a3],  6(%[a_addr_3]) \n\t"
+            "flh %[a4],  6(%[a_addr_4]) \n\t"
+            "flh %[a5],  6(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr_0]) \n\t"
+            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
+
+            "flh %[a0],  8(%[a_addr_0]) \n\t"
+            "flh %[a1],  8(%[a_addr_1]) \n\t"
+            "flh %[a2],  8(%[a_addr_2]) \n\t"
+            "flh %[a3],  8(%[a_addr_3]) \n\t"
+            "flh %[a4],  8(%[a_addr_4]) \n\t"
+            "flh %[a5],  8(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr_0]) \n\t"
+            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
+
+            "flh %[a0], 10(%[a_addr_0]) \n\t"
+            "flh %[a1], 10(%[a_addr_1]) \n\t"
+            "flh %[a2], 10(%[a_addr_2]) \n\t"
+            "flh %[a3], 10(%[a_addr_3]) \n\t"
+            "flh %[a4], 10(%[a_addr_4]) \n\t"
+            "flh %[a5], 10(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr_0]) \n\t"
+            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
+
+            "flh %[a0], 12(%[a_addr_0]) \n\t"
+            "flh %[a1], 12(%[a_addr_1]) \n\t"
+            "flh %[a2], 12(%[a_addr_2]) \n\t"
+            "flh %[a3], 12(%[a_addr_3]) \n\t"
+            "flh %[a4], 12(%[a_addr_4]) \n\t"
+            "flh %[a5], 12(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr_0]) \n\t"
+            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
+
+            "flh %[a0], 14(%[a_addr_0]) \n\t"
+            "flh %[a1], 14(%[a_addr_1]) \n\t"
+            "flh %[a2], 14(%[a_addr_2]) \n\t"
+            "flh %[a3], 14(%[a_addr_3]) \n\t"
+            "flh %[a4], 14(%[a_addr_4]) \n\t"
+            "flh %[a5], 14(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr_0]) \n\t"
+            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
+
+            "flh %[a0], 16(%[a_addr_0]) \n\t"
+            "flh %[a1], 16(%[a_addr_1]) \n\t"
+            "flh %[a2], 16(%[a_addr_2]) \n\t"
+            "flh %[a3], 16(%[a_addr_3]) \n\t"
+            "flh %[a4], 16(%[a_addr_4]) \n\t"
+            "flh %[a5], 16(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr_0]) \n\t"
+            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
+
+            "flh %[a0], 18(%[a_addr_0]) \n\t"
+            "flh %[a1], 18(%[a_addr_1]) \n\t"
+            "flh %[a2], 18(%[a_addr_2]) \n\t"
+            "flh %[a3], 18(%[a_addr_3]) \n\t"
+            "flh %[a4], 18(%[a_addr_4]) \n\t"
+            "flh %[a5], 18(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr_0]) \n\t"
+            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
+
+            "flh %[a0], 20(%[a_addr_0]) \n\t"
+            "flh %[a1], 20(%[a_addr_1]) \n\t"
+            "flh %[a2], 20(%[a_addr_2]) \n\t"
+            "flh %[a3], 20(%[a_addr_3]) \n\t"
+            "flh %[a4], 20(%[a_addr_4]) \n\t"
+            "flh %[a5], 20(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr_0]) \n\t"
+            "add %[b_addr_0], %[b_addr_0], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
+
+            "flh %[a0], 22(%[a_addr_0]) \n\t"
+            "flh %[a1], 22(%[a_addr_1]) \n\t"
+            "flh %[a2], 22(%[a_addr_2]) \n\t"
+            "flh %[a3], 22(%[a_addr_3]) \n\t"
+            "flh %[a4], 22(%[a_addr_4]) \n\t"
+            "flh %[a5], 22(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr_0]) \n\t"
+            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
+            : [a0] "=&f"(a0),
+              [a1] "=&f"(a1),
+              [a2] "=&f"(a2),
+              [a3] "=&f"(a3),
+              [a4] "=&f"(a4),
+              [a5] "=&f"(a5),
+              [b00] "=&vr"(b00),
+              [acc0] "+&vr"(acc0),
+              [acc1] "+&vr"(acc1),
+              [acc2] "+&vr"(acc2),
+              [acc3] "+&vr"(acc3),
+              [acc4] "+&vr"(acc4),
+              [acc5] "+&vr"(acc5)
+            : [jj_vl_in] "r"(jj_vl),
+              [a_addr_0] "r"(a + (ii + 0) * rsa + kk),
+              [a_addr_1] "r"(a + (ii + 1) * rsa + kk),
+              [a_addr_2] "r"(a + (ii + 2) * rsa + kk),
+              [a_addr_3] "r"(a + (ii + 3) * rsa + kk),
+              [a_addr_4] "r"(a + (ii + 4) * rsa + kk),
+              [a_addr_5] "r"(a + (ii + 5) * rsa + kk),
+              [b_addr_0] "r"(b + kk * rsb + jj),
+              [rsb2] "r" (rsb * sizeof(_Float16))
+            : "vtype", "vl", "memory"
+            // clang-format on
+        );
       }
-      for (kk = kk_peel; (kk + 1) <= k; kk = kk + 1) {
-        a00 = a[((ii + 0) * rsa) + ((kk + 0) * 1)];
-        a01 = a[((ii + 1) * rsa) + ((kk + 0) * 1)];
-        a02 = a[((ii + 2) * rsa) + ((kk + 0) * 1)];
-        a03 = a[((ii + 3) * rsa) + ((kk + 0) * 1)];
-        b0 = __riscv_vle16_v_f16m2(b + (((kk + 0) * rsb) + ((jj + 0) * 1)),
-                                   jj_vl);
-        acc0 = __riscv_vfwmacc_vf_f32m4(acc0, a00, b0, jj_vl);
-        acc1 = __riscv_vfwmacc_vf_f32m4(acc1, a01, b0, jj_vl);
-        acc2 = __riscv_vfwmacc_vf_f32m4(acc2, a02, b0, jj_vl);
-        acc3 = __riscv_vfwmacc_vf_f32m4(acc3, a03, b0, jj_vl);
+      for (kk0 = kk; (kk0 + 1) <= k; kk0 = kk0 + 1) {
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+            "vle16.v %[b00], (%[b_addr_0]) \n\t"
+            "flh %[a0], 0(%[a_addr_0]) \n\t"
+            "flh %[a1], 0(%[a_addr_1]) \n\t"
+            "flh %[a2], 0(%[a_addr_2]) \n\t"
+            "flh %[a3], 0(%[a_addr_3]) \n\t"
+            "flh %[a4], 0(%[a_addr_4]) \n\t"
+            "flh %[a5], 0(%[a_addr_5]) \n\t"
+            "vfwmacc.vf %[acc0], %[a0], %[b00] \n\t"
+            "vfwmacc.vf %[acc1], %[a1], %[b00] \n\t"
+            "vfwmacc.vf %[acc2], %[a2], %[b00] \n\t"
+            "vfwmacc.vf %[acc3], %[a3], %[b00] \n\t"
+            "vfwmacc.vf %[acc4], %[a4], %[b00] \n\t"
+            "vfwmacc.vf %[acc5], %[a5], %[b00] \n\t"
+            : [a0] "=&f"(a0),
+              [a1] "=&f"(a1),
+              [a2] "=&f"(a2),
+              [a3] "=&f"(a3),
+              [a4] "=&f"(a4),
+              [a5] "=&f"(a5),
+              [b00] "=&vr"(b00),
+              [acc0] "+&vr"(acc0),
+              [acc1] "+&vr"(acc1),
+              [acc2] "+&vr"(acc2),
+              [acc3] "+&vr"(acc3),
+              [acc4] "+&vr"(acc4),
+              [acc5] "+vr"(acc5)
+            : [jj_vl_in] "r"(jj_vl),
+              [a_addr_0] "r"(a + (ii + 0) * rsa + kk0),
+              [a_addr_1] "r"(a + (ii + 1) * rsa + kk0),
+              [a_addr_2] "r"(a + (ii + 2) * rsa + kk0),
+              [a_addr_3] "r"(a + (ii + 3) * rsa + kk0),
+              [a_addr_4] "r"(a + (ii + 4) * rsa + kk0),
+              [a_addr_5] "r"(a + (ii + 5) * rsa + kk0),
+              [b_addr_0] "r"(b + kk0 * rsb + jj)
+            : "vtype", "vl", "memory"
+            // clang-format on
+        );
       }
-      c00 =
-          __riscv_vle32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)), jj_vl);
-      c01 =
-          __riscv_vle32_v_f32m4(c + (((ii + 1) * rsc) + ((jj + 0) * 1)), jj_vl);
-      c02 =
-          __riscv_vle32_v_f32m4(c + (((ii + 2) * rsc) + ((jj + 0) * 1)), jj_vl);
-      c03 =
-          __riscv_vle32_v_f32m4(c + (((ii + 3) * rsc) + ((jj + 0) * 1)), jj_vl);
-      c00 = __riscv_vfmul_vf_f32m4(c00, beta, jj_vl);
-      c00 = __riscv_vfmacc_vf_f32m4(c00, alpha, acc0, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii + 0) * rsc) + ((jj + 0) * 1)), c00,
-                            jj_vl);
-      c01 = __riscv_vfmul_vf_f32m4(c01, beta, jj_vl);
-      c01 = __riscv_vfmacc_vf_f32m4(c01, alpha, acc1, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii + 1) * rsc) + ((jj + 0) * 1)), c01,
-                            jj_vl);
-      c02 = __riscv_vfmul_vf_f32m4(c02, beta, jj_vl);
-      c02 = __riscv_vfmacc_vf_f32m4(c02, alpha, acc2, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii + 2) * rsc) + ((jj + 0) * 1)), c02,
-                            jj_vl);
-      c03 = __riscv_vfmul_vf_f32m4(c03, beta, jj_vl);
-      c03 = __riscv_vfmacc_vf_f32m4(c03, alpha, acc3, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii + 3) * rsc) + ((jj + 0) * 1)), c03,
-                            jj_vl);
+      __asm__ volatile(
+          // clang-format off
+          "\n\t"
+          "vsetvli zero, %[jj_vl_in], e32, m4, ta, ma \n\t"
+          "vle32.v %[c0], (%[c_addr_0]) \n\t"
+          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
+          "vfmacc.vf %[c0], %[alpha], %[acc0] \n\t"
+          "vse32.v %[c0], (%[c_addr_0]) \n\t"
+          "vle32.v %[c0], (%[c_addr_1]) \n\t"
+          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
+          "vfmacc.vf %[c0], %[alpha], %[acc1] \n\t"
+          "vse32.v %[c0], (%[c_addr_1]) \n\t"
+          "vle32.v %[c0], (%[c_addr_2]) \n\t"
+          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
+          "vfmacc.vf %[c0], %[alpha], %[acc2] \n\t"
+          "vse32.v %[c0], (%[c_addr_2]) \n\t"
+          "vle32.v %[c0], (%[c_addr_3]) \n\t"
+          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
+          "vfmacc.vf %[c0], %[alpha], %[acc3] \n\t"
+          "vse32.v %[c0], (%[c_addr_3]) \n\t"
+          "vle32.v %[c0], (%[c_addr_4]) \n\t"
+          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
+          "vfmacc.vf %[c0], %[alpha], %[acc4] \n\t"
+          "vse32.v %[c0], (%[c_addr_4]) \n\t"
+          "vle32.v %[c0], (%[c_addr_5]) \n\t"
+          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
+          "vfmacc.vf %[c0], %[alpha], %[acc5] \n\t"
+          "vse32.v %[c0], (%[c_addr_5]) \n\t"
+          : [c0] "=&vr"(c0)
+          : [jj_vl_in] "r"(jj_vl),
+            [c_addr_0] "r"(c + (ii + 0) * rsc + jj),
+            [c_addr_1] "r"(c + (ii + 1) * rsc + jj),
+            [c_addr_2] "r"(c + (ii + 2) * rsc + jj),
+            [c_addr_3] "r"(c + (ii + 3) * rsc + jj),
+            [c_addr_4] "r"(c + (ii + 4) * rsc + jj),
+            [c_addr_5] "r"(c + (ii + 5) * rsc + jj),
+            [beta] "f"(beta),
+            [alpha] "f"(alpha),
+            [acc0] "vr"(acc0),
+            [acc1] "vr"(acc1),
+            [acc2] "vr"(acc2),
+            [acc3] "vr"(acc3),
+            [acc4] "vr"(acc4),
+            [acc5] "vr"(acc5)
+          : "vtype", "vl", "memory"
+          // clang-format on
+      );
     }
   }
   for (ii0 = ii; (ii0 + 1) <= m; ii0 = ii0 + 1) {
@@ -321,23 +623,43 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
       jj_vl = __riscv_vsetvl_e16m2(n - jj);
       for (kk_peel = 0; ((kk_peel + 1) <= k) && (kk_peel < (0 + (1 * 1)));
            kk_peel = kk_peel + 1) {
-        a0 = a[((ii0 + 0) * rsa) + ((kk_peel + 0) * 1)];
-        b0 = __riscv_vle16_v_f16m2(b + (((kk_peel + 0) * rsb) + ((jj + 0) * 1)),
-                                   jj_vl);
-        acc = __riscv_vfwmul_vf_f32m4(b0, a0, jj_vl);
+        __asm__ volatile(
+            "\n\t"
+            "flh %[a0], 0(%[a_addr_83]) \n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+            "vle16.v %[b0], (%[b_addr_13]) \n\t"
+            "vfwmul.vf %[acc], %[b0], %[a0] \n\t"
+            : [a0] "=&f"(a0), [b0] "=&vr"(b0), [acc] "=vr"(acc)
+            : [a_addr_83] "r"(a + (((ii0 + 0) * rsa) + ((kk_peel + 0) * 1))),
+              [jj_vl_in] "r"(jj_vl),
+              [b_addr_13] "r"(b + (((kk_peel + 0) * rsb) + ((jj + 0) * 1)))
+            : "vtype", "vl", "memory");
       }
       for (kk = kk_peel; (kk + 1) <= k; kk = kk + 1) {
-        a0 = a[((ii0 + 0) * rsa) + ((kk + 0) * 1)];
-        b0 = __riscv_vle16_v_f16m2(b + (((kk + 0) * rsb) + ((jj + 0) * 1)),
-                                   jj_vl);
-        acc = __riscv_vfwmacc_vf_f32m4(acc, a0, b0, jj_vl);
+        __asm__ volatile(
+            "\n\t"
+            "flh %[a0], 0(%[a_addr_84]) \n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+            "vle16.v %[b0], (%[b_addr_14]) \n\t"
+            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
+            : [a0] "=&f"(a0), [b0] "=&vr"(b0), [acc] "+vr"(acc)
+            : [a_addr_84] "r"(a + (((ii0 + 0) * rsa) + ((kk + 0) * 1))),
+              [jj_vl_in] "r"(jj_vl),
+              [b_addr_14] "r"(b + (((kk + 0) * rsb) + ((jj + 0) * 1)))
+            : "vtype", "vl", "memory");
       }
-      c0 = __riscv_vle32_v_f32m4(c + (((ii0 + 0) * rsc) + ((jj + 0) * 1)),
-                                 jj_vl);
-      c0 = __riscv_vfmul_vf_f32m4(c0, beta, jj_vl);
-      c0 = __riscv_vfmacc_vf_f32m4(c0, alpha, acc, jj_vl);
-      __riscv_vse32_v_f32m4(c + (((ii0 + 0) * rsc) + ((jj + 0) * 1)), c0,
-                            jj_vl);
+      __asm__ volatile(
+          "\n\t"
+          "vsetvli zero, %[jj_vl_in], e32, m4, ta, ma \n\t"
+          "vle32.v %[c0], (%[c_addr_5]) \n\t"
+          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
+          "vfmacc.vf %[c0], %[alpha], %[acc] \n\t"
+          "vse32.v %[c0], (%[c_addr_5]) \n\t"
+          : [c0] "=&vr"(c0)
+          : [jj_vl_in] "r"(jj_vl),
+            [c_addr_5] "r"(c + (((ii0 + 0) * rsc) + ((jj + 0) * 1))),
+            [beta] "f"(beta), [alpha] "f"(alpha), [acc] "vr"(acc)
+          : "vtype", "vl", "memory");
     }
   }
 }

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
@@ -251,8 +251,22 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
   _Float16 a31;
   _Float16 a41;
   _Float16 a51;
+  _Float16 a02;
+  _Float16 a12;
+  _Float16 a22;
+  _Float16 a32;
+  _Float16 a42;
+  _Float16 a52;
+  _Float16 a03;
+  _Float16 a13;
+  _Float16 a23;
+  _Float16 a33;
+  _Float16 a43;
+  _Float16 a53;
   vfloat16m2_t b00;
   vfloat16m2_t b10;
+  vfloat16m2_t b20;
+  vfloat16m2_t b30;
   vfloat32m4_t acc0;
   vfloat32m4_t acc1;
   vfloat32m4_t acc2;
@@ -263,6 +277,7 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
   vfloat16m2_t b0;
   vfloat32m4_t acc;
   vfloat32m4_t c0;
+  vfloat32m4_t c1;
 
   if (k == 0) {
     for (ii = 0; (ii + 1) <= m; ii = ii + 1) {
@@ -327,7 +342,10 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
         );
       }
 
-      if (12 + 2 < k) {
+      const size_t kk_unroll_degree = 12;
+      const size_t preload_distance = 4;
+
+      if (kk_unroll_degree + preload_distance < k) {
         const size_t offset = 1;
         const _Float16 *a_addr = a + ii * rsa + offset;
         const _Float16 *b_addr = b + offset * rsb + jj;
@@ -336,40 +354,68 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
             "\n\t"
 
             "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+
             "vle16.v %[b00], (%[b_addr]) \n\t"
             "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-
             NTL_P1
             "flh %[a00], 0(%[a_addr]) \n\t"
             NTL_P1
             "flh %[a01], 2(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a02], 4(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a03], 6(%[a_addr]) \n\t"
             "add %[a_addr], %[a_addr], %[rsa2] \n\t"
             NTL_P1
             "flh %[a10], 0(%[a_addr]) \n\t"
             NTL_P1
             "flh %[a11], 2(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a12], 4(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a13], 6(%[a_addr]) \n\t"
             "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            "vle16.v %[b10], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
             NTL_P1
             "flh %[a20], 0(%[a_addr]) \n\t"
             NTL_P1
             "flh %[a21], 2(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a22], 4(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a23], 6(%[a_addr]) \n\t"
             "add %[a_addr], %[a_addr], %[rsa2] \n\t"
             NTL_P1
             "flh %[a30], 0(%[a_addr]) \n\t"
             NTL_P1
             "flh %[a31], 2(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a32], 4(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a33], 6(%[a_addr]) \n\t"
             "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            "vle16.v %[b20], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
             NTL_P1
             "flh %[a40], 0(%[a_addr]) \n\t"
             NTL_P1
             "flh %[a41], 2(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a42], 4(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a43], 6(%[a_addr]) \n\t"
             "add %[a_addr], %[a_addr], %[rsa2] \n\t"
             NTL_P1
             "flh %[a50], 0(%[a_addr]) \n\t"
             NTL_P1
             "flh %[a51], 2(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a52], 4(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a53], 6(%[a_addr]) \n\t"
+            "vle16.v %[b30], (%[b_addr]) \n\t"
 
-            "vle16.v %[b10], (%[b_addr]) \n\t"
           : [a00] "=&f"(a00),
             [a10] "=&f"(a10),
             [a20] "=&f"(a20),
@@ -382,9 +428,23 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
             [a31] "=&f"(a31),
             [a41] "=&f"(a41),
             [a51] "=&f"(a51),
+            [a02] "=&f"(a02),
+            [a12] "=&f"(a12),
+            [a22] "=&f"(a22),
+            [a32] "=&f"(a32),
+            [a42] "=&f"(a42),
+            [a52] "=&f"(a52),
+            [a03] "=&f"(a03),
+            [a13] "=&f"(a13),
+            [a23] "=&f"(a23),
+            [a33] "=&f"(a33),
+            [a43] "=&f"(a43),
+            [a53] "=&f"(a53),
             [a_addr] "+&r"(a_addr),
             [b00] "=&vr"(b00),
-            [b10] "=vr"(b10),
+            [b10] "=&vr"(b10),
+            [b20] "=&vr"(b20),
+            [b30] "=vr"(b30),
             [b_addr] "+&r"(b_addr)
           : [jj_vl_in] "r"(jj_vl),
             [rsa2] "r" (rsa * sizeof(_Float16)),
@@ -394,8 +454,9 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
         );
       }
 
-      for (kk = 1; (kk + 12 + 2) <= k; kk = kk + 12) {
-        const size_t offset = 2;
+      for (kk = 1; (kk + kk_unroll_degree + preload_distance) <= k;
+           kk += kk_unroll_degree) {
+        const size_t offset = preload_distance;
         const _Float16 *b_addr = b + (kk + offset) * rsb + jj;
         const _Float16 *a_addr_0 = a + (ii + 0) * rsa + kk + offset;
         const _Float16 *a_addr_1;
@@ -456,46 +517,46 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
             "vle16.v %[b10], (%[b_addr]) \n\t"
             "add %[b_addr], %[b_addr], %[rsb2] \n\t"
 
-            "vfwmacc.vf %[acc0], %[a00], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a10], %[b00] \n\t"
+            "vfwmacc.vf %[acc0], %[a02], %[b20] \n\t"
+            "vfwmacc.vf %[acc1], %[a12], %[b20] \n\t"
             NTL_P1
-            "flh %[a00],  4(%[a_addr_0]) \n\t"
+            "flh %[a02],  4(%[a_addr_0]) \n\t"
             NTL_P1
-            "flh %[a10],  4(%[a_addr_1]) \n\t"
-            "vfwmacc.vf %[acc2], %[a20], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a30], %[b00] \n\t"
+            "flh %[a12],  4(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a22], %[b20] \n\t"
+            "vfwmacc.vf %[acc3], %[a32], %[b20] \n\t"
             NTL_P1
-            "flh %[a20],  4(%[a_addr_2]) \n\t"
+            "flh %[a22],  4(%[a_addr_2]) \n\t"
             NTL_P1
-            "flh %[a30],  4(%[a_addr_3]) \n\t"
-            "vfwmacc.vf %[acc4], %[a40], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a50], %[b00] \n\t"
+            "flh %[a32],  4(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a42], %[b20] \n\t"
+            "vfwmacc.vf %[acc5], %[a52], %[b20] \n\t"
             NTL_P1
-            "flh %[a40],  4(%[a_addr_4]) \n\t"
+            "flh %[a42],  4(%[a_addr_4]) \n\t"
             NTL_P1
-            "flh %[a50],  4(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "flh %[a52],  4(%[a_addr_5]) \n\t"
+            "vle16.v %[b20], (%[b_addr]) \n\t"
             "add %[b_addr], %[b_addr], %[rsb2] \n\t"
 
-            "vfwmacc.vf %[acc0], %[a01], %[b10] \n\t"
-            "vfwmacc.vf %[acc1], %[a11], %[b10] \n\t"
+            "vfwmacc.vf %[acc0], %[a03], %[b30] \n\t"
+            "vfwmacc.vf %[acc1], %[a13], %[b30] \n\t"
             NTL_P1
-            "flh %[a01],  6(%[a_addr_0]) \n\t"
+            "flh %[a03],  6(%[a_addr_0]) \n\t"
             NTL_P1
-            "flh %[a11],  6(%[a_addr_1]) \n\t"
-            "vfwmacc.vf %[acc2], %[a21], %[b10] \n\t"
-            "vfwmacc.vf %[acc3], %[a31], %[b10] \n\t"
+            "flh %[a13],  6(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a23], %[b30] \n\t"
+            "vfwmacc.vf %[acc3], %[a33], %[b30] \n\t"
             NTL_P1
-            "flh %[a21],  6(%[a_addr_2]) \n\t"
+            "flh %[a23],  6(%[a_addr_2]) \n\t"
             NTL_P1
-            "flh %[a31],  6(%[a_addr_3]) \n\t"
-            "vfwmacc.vf %[acc4], %[a41], %[b10] \n\t"
-            "vfwmacc.vf %[acc5], %[a51], %[b10] \n\t"
+            "flh %[a33],  6(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a43], %[b30] \n\t"
+            "vfwmacc.vf %[acc5], %[a53], %[b30] \n\t"
             NTL_P1
-            "flh %[a41],  6(%[a_addr_4]) \n\t"
+            "flh %[a43],  6(%[a_addr_4]) \n\t"
             NTL_P1
-            "flh %[a51],  6(%[a_addr_5]) \n\t"
-            "vle16.v %[b10], (%[b_addr]) \n\t"
+            "flh %[a53],  6(%[a_addr_5]) \n\t"
+            "vle16.v %[b30], (%[b_addr]) \n\t"
             "add %[b_addr], %[b_addr], %[rsb2] \n\t"
 
             "vfwmacc.vf %[acc0], %[a00], %[b00] \n\t"
@@ -540,46 +601,46 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
             "vle16.v %[b10], (%[b_addr]) \n\t"
             "add %[b_addr], %[b_addr], %[rsb2] \n\t"
 
-            "vfwmacc.vf %[acc0], %[a00], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a10], %[b00] \n\t"
+            "vfwmacc.vf %[acc0], %[a02], %[b20] \n\t"
+            "vfwmacc.vf %[acc1], %[a12], %[b20] \n\t"
             NTL_P1
-            "flh %[a00], 12(%[a_addr_0]) \n\t"
+            "flh %[a02], 12(%[a_addr_0]) \n\t"
             NTL_P1
-            "flh %[a10], 12(%[a_addr_1]) \n\t"
-            "vfwmacc.vf %[acc2], %[a20], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a30], %[b00] \n\t"
+            "flh %[a12], 12(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a22], %[b20] \n\t"
+            "vfwmacc.vf %[acc3], %[a32], %[b20] \n\t"
             NTL_P1
-            "flh %[a20], 12(%[a_addr_2]) \n\t"
+            "flh %[a22], 12(%[a_addr_2]) \n\t"
             NTL_P1
-            "flh %[a30], 12(%[a_addr_3]) \n\t"
-            "vfwmacc.vf %[acc4], %[a40], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a50], %[b00] \n\t"
+            "flh %[a32], 12(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a42], %[b20] \n\t"
+            "vfwmacc.vf %[acc5], %[a52], %[b20] \n\t"
             NTL_P1
-            "flh %[a40], 12(%[a_addr_4]) \n\t"
+            "flh %[a42], 12(%[a_addr_4]) \n\t"
             NTL_P1
-            "flh %[a50], 12(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "flh %[a52], 12(%[a_addr_5]) \n\t"
+            "vle16.v %[b20], (%[b_addr]) \n\t"
             "add %[b_addr], %[b_addr], %[rsb2] \n\t"
 
-            "vfwmacc.vf %[acc0], %[a01], %[b10] \n\t"
-            "vfwmacc.vf %[acc1], %[a11], %[b10] \n\t"
+            "vfwmacc.vf %[acc0], %[a03], %[b30] \n\t"
+            "vfwmacc.vf %[acc1], %[a13], %[b30] \n\t"
             NTL_P1
-            "flh %[a01], 14(%[a_addr_0]) \n\t"
+            "flh %[a03], 14(%[a_addr_0]) \n\t"
             NTL_P1
-            "flh %[a11], 14(%[a_addr_1]) \n\t"
-            "vfwmacc.vf %[acc2], %[a21], %[b10] \n\t"
-            "vfwmacc.vf %[acc3], %[a31], %[b10] \n\t"
+            "flh %[a13], 14(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a23], %[b30] \n\t"
+            "vfwmacc.vf %[acc3], %[a33], %[b30] \n\t"
             NTL_P1
-            "flh %[a21], 14(%[a_addr_2]) \n\t"
+            "flh %[a23], 14(%[a_addr_2]) \n\t"
             NTL_P1
-            "flh %[a31], 14(%[a_addr_3]) \n\t"
-            "vfwmacc.vf %[acc4], %[a41], %[b10] \n\t"
-            "vfwmacc.vf %[acc5], %[a51], %[b10] \n\t"
+            "flh %[a33], 14(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a43], %[b30] \n\t"
+            "vfwmacc.vf %[acc5], %[a53], %[b30] \n\t"
             NTL_P1
-            "flh %[a41], 14(%[a_addr_4]) \n\t"
+            "flh %[a43], 14(%[a_addr_4]) \n\t"
             NTL_P1
-            "flh %[a51], 14(%[a_addr_5]) \n\t"
-            "vle16.v %[b10], (%[b_addr]) \n\t"
+            "flh %[a53], 14(%[a_addr_5]) \n\t"
+            "vle16.v %[b30], (%[b_addr]) \n\t"
             "add %[b_addr], %[b_addr], %[rsb2] \n\t"
 
             "vfwmacc.vf %[acc0], %[a00], %[b00] \n\t"
@@ -624,46 +685,46 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
             "vle16.v %[b10], (%[b_addr]) \n\t"
             "add %[b_addr], %[b_addr], %[rsb2] \n\t"
 
-            "vfwmacc.vf %[acc0], %[a00], %[b00] \n\t"
-            "vfwmacc.vf %[acc1], %[a10], %[b00] \n\t"
+            "vfwmacc.vf %[acc0], %[a02], %[b20] \n\t"
+            "vfwmacc.vf %[acc1], %[a12], %[b20] \n\t"
             NTL_P1
-            "flh %[a00], 20(%[a_addr_0]) \n\t"
+            "flh %[a02], 20(%[a_addr_0]) \n\t"
             NTL_P1
-            "flh %[a10], 20(%[a_addr_1]) \n\t"
-            "vfwmacc.vf %[acc2], %[a20], %[b00] \n\t"
-            "vfwmacc.vf %[acc3], %[a30], %[b00] \n\t"
+            "flh %[a12], 20(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a22], %[b20] \n\t"
+            "vfwmacc.vf %[acc3], %[a32], %[b20] \n\t"
             NTL_P1
-            "flh %[a20], 20(%[a_addr_2]) \n\t"
+            "flh %[a22], 20(%[a_addr_2]) \n\t"
             NTL_P1
-            "flh %[a30], 20(%[a_addr_3]) \n\t"
-            "vfwmacc.vf %[acc4], %[a40], %[b00] \n\t"
-            "vfwmacc.vf %[acc5], %[a50], %[b00] \n\t"
+            "flh %[a32], 20(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a42], %[b20] \n\t"
+            "vfwmacc.vf %[acc5], %[a52], %[b20] \n\t"
             NTL_P1
-            "flh %[a40], 20(%[a_addr_4]) \n\t"
+            "flh %[a42], 20(%[a_addr_4]) \n\t"
             NTL_P1
-            "flh %[a50], 20(%[a_addr_5]) \n\t"
-            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "flh %[a52], 20(%[a_addr_5]) \n\t"
+            "vle16.v %[b20], (%[b_addr]) \n\t"
             "add %[b_addr], %[b_addr], %[rsb2] \n\t"
 
-            "vfwmacc.vf %[acc0], %[a01], %[b10] \n\t"
-            "vfwmacc.vf %[acc1], %[a11], %[b10] \n\t"
+            "vfwmacc.vf %[acc0], %[a03], %[b30] \n\t"
+            "vfwmacc.vf %[acc1], %[a13], %[b30] \n\t"
             NTL_P1
-            "flh %[a01], 22(%[a_addr_0]) \n\t"
+            "flh %[a03], 22(%[a_addr_0]) \n\t"
             NTL_P1
-            "flh %[a11], 22(%[a_addr_1]) \n\t"
-            "vfwmacc.vf %[acc2], %[a21], %[b10] \n\t"
-            "vfwmacc.vf %[acc3], %[a31], %[b10] \n\t"
+            "flh %[a13], 22(%[a_addr_1]) \n\t"
+            "vfwmacc.vf %[acc2], %[a23], %[b30] \n\t"
+            "vfwmacc.vf %[acc3], %[a33], %[b30] \n\t"
             NTL_P1
-            "flh %[a21], 22(%[a_addr_2]) \n\t"
+            "flh %[a23], 22(%[a_addr_2]) \n\t"
             NTL_P1
-            "flh %[a31], 22(%[a_addr_3]) \n\t"
-            "vfwmacc.vf %[acc4], %[a41], %[b10] \n\t"
-            "vfwmacc.vf %[acc5], %[a51], %[b10] \n\t"
+            "flh %[a33], 22(%[a_addr_3]) \n\t"
+            "vfwmacc.vf %[acc4], %[a43], %[b30] \n\t"
+            "vfwmacc.vf %[acc5], %[a53], %[b30] \n\t"
             NTL_P1
-            "flh %[a41], 22(%[a_addr_4]) \n\t"
+            "flh %[a43], 22(%[a_addr_4]) \n\t"
             NTL_P1
-            "flh %[a51], 22(%[a_addr_5]) \n\t"
-            "vle16.v %[b10], (%[b_addr]) \n\t"
+            "flh %[a53], 22(%[a_addr_5]) \n\t"
+            "vle16.v %[b30], (%[b_addr]) \n\t"
             : [a00] "+&f"(a00),
               [a10] "+&f"(a10),
               [a20] "+&f"(a20),
@@ -676,8 +737,22 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
               [a31] "+&f"(a31),
               [a41] "+&f"(a41),
               [a51] "+&f"(a51),
+              [a02] "+&f"(a02),
+              [a12] "+&f"(a12),
+              [a22] "+&f"(a22),
+              [a32] "+&f"(a32),
+              [a42] "+&f"(a42),
+              [a52] "+&f"(a52),
+              [a03] "+&f"(a03),
+              [a13] "+&f"(a13),
+              [a23] "+&f"(a23),
+              [a33] "+&f"(a33),
+              [a43] "+&f"(a43),
+              [a53] "+&f"(a53),
               [b00] "+&vr"(b00),
               [b10] "+&vr"(b10),
+              [b20] "+&vr"(b20),
+              [b30] "+&vr"(b30),
               [acc0] "+&vr"(acc0),
               [acc1] "+&vr"(acc1),
               [acc2] "+&vr"(acc2),
@@ -699,7 +774,7 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
         );
       }
 
-      if (12 + 2 < k) {
+      if (kk_unroll_degree + preload_distance < k) {
         __asm__ volatile(
             // clang-format off
             "\n\t"
@@ -718,6 +793,20 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
             "vfwmacc.vf %[acc3], %[a31], %[b10] \n\t"
             "vfwmacc.vf %[acc4], %[a41], %[b10] \n\t"
             "vfwmacc.vf %[acc5], %[a51], %[b10] \n\t"
+
+            "vfwmacc.vf %[acc0], %[a02], %[b20] \n\t"
+            "vfwmacc.vf %[acc1], %[a12], %[b20] \n\t"
+            "vfwmacc.vf %[acc2], %[a22], %[b20] \n\t"
+            "vfwmacc.vf %[acc3], %[a32], %[b20] \n\t"
+            "vfwmacc.vf %[acc4], %[a42], %[b20] \n\t"
+            "vfwmacc.vf %[acc5], %[a52], %[b20] \n\t"
+
+            "vfwmacc.vf %[acc0], %[a03], %[b30] \n\t"
+            "vfwmacc.vf %[acc1], %[a13], %[b30] \n\t"
+            "vfwmacc.vf %[acc2], %[a23], %[b30] \n\t"
+            "vfwmacc.vf %[acc3], %[a33], %[b30] \n\t"
+            "vfwmacc.vf %[acc4], %[a43], %[b30] \n\t"
+            "vfwmacc.vf %[acc5], %[a53], %[b30] \n\t"
             : [acc0] "+&vr" (acc0),
               [acc1] "+&vr" (acc1),
               [acc2] "+&vr" (acc2),
@@ -727,6 +816,8 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
             : [jj_vl_in] "r"(jj_vl),
               [b00] "vr" (b00),
               [b10] "vr" (b10),
+              [b20] "vr" (b20),
+              [b30] "vr" (b30),
               [a00] "f"(a00),
               [a10] "f"(a10),
               [a20] "f"(a20),
@@ -738,11 +829,23 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
               [a21] "f"(a21),
               [a31] "f"(a31),
               [a41] "f"(a41),
-              [a51] "f"(a51)
+              [a51] "f"(a51),
+              [a02] "f"(a02),
+              [a12] "f"(a12),
+              [a22] "f"(a22),
+              [a32] "f"(a32),
+              [a42] "f"(a42),
+              [a52] "f"(a52),
+              [a03] "f"(a03),
+              [a13] "f"(a13),
+              [a23] "f"(a23),
+              [a33] "f"(a33),
+              [a43] "f"(a43),
+              [a53] "f"(a53)
             : "vtype", "vl", "memory"
             // clang-format on
         );
-        kk += 2;
+        kk += preload_distance;
       }
 
       for (; kk < k; kk++) {
@@ -801,10 +904,10 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
           "vse32.v %[c0], (%[c_addr]) \n\t"
           "add %[c_addr], %[c_addr], %[rsc4] \n\t"
 
-          "vle32.v %[c0], (%[c_addr]) \n\t"
-          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
-          "vfmacc.vf %[c0], %[alpha], %[acc1] \n\t"
-          "vse32.v %[c0], (%[c_addr]) \n\t"
+          "vle32.v %[c1], (%[c_addr]) \n\t"
+          "vfmul.vf %[c1], %[c1], %[beta] \n\t"
+          "vfmacc.vf %[c1], %[alpha], %[acc1] \n\t"
+          "vse32.v %[c1], (%[c_addr]) \n\t"
           "add %[c_addr], %[c_addr], %[rsc4] \n\t"
 
           "vle32.v %[c0], (%[c_addr]) \n\t"
@@ -813,10 +916,10 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
           "vse32.v %[c0], (%[c_addr]) \n\t"
           "add %[c_addr], %[c_addr], %[rsc4] \n\t"
 
-          "vle32.v %[c0], (%[c_addr]) \n\t"
-          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
-          "vfmacc.vf %[c0], %[alpha], %[acc3] \n\t"
-          "vse32.v %[c0], (%[c_addr]) \n\t"
+          "vle32.v %[c1], (%[c_addr]) \n\t"
+          "vfmul.vf %[c1], %[c1], %[beta] \n\t"
+          "vfmacc.vf %[c1], %[alpha], %[acc3] \n\t"
+          "vse32.v %[c1], (%[c_addr]) \n\t"
           "add %[c_addr], %[c_addr], %[rsc4] \n\t"
 
           "vle32.v %[c0], (%[c_addr]) \n\t"
@@ -825,11 +928,12 @@ SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390(
           "vse32.v %[c0], (%[c_addr]) \n\t"
           "add %[c_addr], %[c_addr], %[rsc4] \n\t"
 
-          "vle32.v %[c0], (%[c_addr]) \n\t"
-          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
-          "vfmacc.vf %[c0], %[alpha], %[acc5] \n\t"
-          "vse32.v %[c0], (%[c_addr]) \n\t"
+          "vle32.v %[c1], (%[c_addr]) \n\t"
+          "vfmul.vf %[c1], %[c1], %[beta] \n\t"
+          "vfmacc.vf %[c1], %[alpha], %[acc5] \n\t"
+          "vse32.v %[c1], (%[c_addr]) \n\t"
           : [c0] "=&vr"(c0),
+            [c1] "=&vr"(c1),
             [c_addr] "+&r"(c_addr)
           : [jj_vl_in] "r"(jj_vl),
             [beta] "f"(beta),


### PR DESCRIPTION
This effectively rewrites the `skl_gemm_4xm4x1_f16_f16_f32_zvfh_x390` kernel to provide better performance. The new version uses inline assembly with a 6xm4x12 tile size (so the `vfwmacc.vf`s are still done at LMUL=2) and preloads the A and B matrix values a few iterations in advance by making the scalar loads non-blocking with the ntl.p1 instruction.

My benchmarking showed a substantial performance boost, with the new version giving up to 80% improvement over the original kernel in certain cases.

Note that the `__asm__` statement for the main loop used an extremely long assembler template string, for which I had to locally suppress the following compiler warning:
```
error: string literal of length 6475 exceeds maximum length 4095 that ISO C99 compilers are required to support [-Werror,-Woverlength-strings]
```