### PR TITLE
[GEMM] Optimize widening f16 GEMV x390 kernel

### DIFF
--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
@@ -17,181 +17,225 @@
 #endif
 
 /**
- * @brief RVV float16 vector-matrix multiply with float32 output for row-major
+ * @brief RVV float16 matrix-matrix multiply with float32 output for row-major
  * matrices, tuned for X390.
  *
+ * @param m - Number of rows in matrices A and C.
  * @param n - Number of columns in matrices B and C.
  * @param k - Number of columns in A and rows in B (inner dimension).
  * @param alpha - Scalar multiplier for A*B product.
- * @param a - Pointer to vector A.
+ * @param a - Pointer to matrix A.
+ * @param rsa - Row stride of matrix A in elements.
  * @param b - Pointer to matrix B.
  * @param rsb - Row stride of matrix B in elements.
  * @param beta - Scalar multiplier for matrix C.
  * @param c - Pointer to matrix C.
+ * @param rsc - Row stride of matrix C in elements.
  *
- * Computes `C = alpha * A * B + beta * C` for FP16 unit-stride vector A and
- * row-major matrix B and FP32 unit-stride output vector C.
+ * Computes `C = alpha * A * B + beta * C` for FP16 row-major matrices A and
+ * B and FP32 row-major matrix C.
+ *
  * Functionally equivalent to calling:
  * ```
  * skl_gemm_f16rc_f16rc_f32rc_ref(
- *     1, n, k,
+ *     m, n, k,
  *     alpha,
- *     a, 1, 1,
+ *     a, rsa, 1,
  *     b, rsb, 1,
  *     beta,
- *     c, 1, 1
+ *     c, rsc, 1
  * );
  * ```
  *
  * Uses a 1 x LMUL=8 x 16 register tile. Vectorized across the N dimension.
  *
  * @note
- * Works best when `n >= __riscv_vsetvlmax_e32m8()`.
+ * Works best when `m = 1` and `n >= __riscv_vsetvlmax_e32m8()`.
  */
-SKL_FUNC_PRIVATE void
-skl_gemm_1xm8x16_f16_f16_f32_zvfh_x390(size_t n, size_t k, float alpha,
-                                       const _Float16 *a, const _Float16 *b,
-                                       size_t rsb, float beta, float *c) {
+SKL_FUNC_PRIVATE void skl_gemm_1xm8x16_f16_f16_f32_zvfh_x390(
+    size_t m, size_t n, size_t k, float alpha, const _Float16 *a, size_t rsa,
+    const _Float16 *b, size_t rsb, float beta, float *c, size_t rsc) {
   size_t jj_vl;
+  size_t ii;
   size_t jj;
-  size_t kk_peel;
   size_t kk;
-  size_t kk0;
-  float _alpha;
-  float _beta;
   _Float16 a0;
+  _Float16 a1;
   vfloat16m4_t b0;
+  vfloat16m4_t b1;
   vfloat32m8_t acc;
-  _Float16 a00;
-  _Float16 a01;
-  _Float16 a02;
-  _Float16 a03;
-  _Float16 a04;
-  _Float16 a05;
-  _Float16 a06;
-  _Float16 a07;
-  _Float16 a08;
-  _Float16 a09;
-  _Float16 a010;
-  _Float16 a011;
-  _Float16 a012;
-  _Float16 a013;
-  _Float16 a014;
-  _Float16 a015;
-  vfloat16m4_t b00;
-  vfloat16m4_t b01;
-  vfloat16m4_t b02;
-  vfloat16m4_t b03;
-  vfloat16m4_t b04;
-  vfloat16m4_t b05;
-  vfloat16m4_t b06;
-  vfloat16m4_t b07;
-  vfloat16m4_t b08;
-  vfloat16m4_t b09;
-  vfloat16m4_t b010;
-  vfloat16m4_t b011;
-  vfloat16m4_t b012;
-  vfloat16m4_t b013;
-  vfloat16m4_t b014;
-  vfloat16m4_t b015;
   vfloat32m8_t c0;
-  _alpha = alpha;
-  _beta = beta;
+
   if (k == 0) {
-    for (jj = 0; jj < n; jj = jj + jj_vl) {
-      jj_vl = __riscv_vsetvl_e32m8(n - jj);
-      c0 = __riscv_vle32_v_f32m8(c + ((jj + 0) * 1), jj_vl);
-      c0 = __riscv_vfmul_vf_f32m8(c0, _beta, jj_vl);
-      __riscv_vse32_v_f32m8(c + ((jj + 0) * 1), c0, jj_vl);
+    for (ii = 0; (ii + 1) <= m; ii = ii + 1) {
+      for (jj = 0; jj < n; jj = jj + jj_vl) {
+        jj_vl = __riscv_vsetvl_e32m1(n - jj);
+        c0 = __riscv_vle32_v_f32m8(c + ii * rsc + jj, jj_vl);
+        c0 = __riscv_vfmul_vf_f32m8(c0, beta, jj_vl);
+        __riscv_vse32_v_f32m8(c + ii * rsc + jj, c0, jj_vl);
+      }
     }
     return;
   }
-  for (jj = 0; jj < n; jj = jj + jj_vl) {
-    jj_vl = __riscv_vsetvl_e16m4(n - jj);
-    for (kk_peel = 0; ((kk_peel + 1) <= k) && (kk_peel < (0 + (1 * 1)));
-         kk_peel = kk_peel + 1) {
-      a0 = a[(kk_peel + 0) * 1];
-      b0 = __riscv_vle16_v_f16m4(b + (((kk_peel + 0) * rsb) + ((jj + 0) * 1)),
-                                 jj_vl);
-      acc = __riscv_vfwmul_vf_f32m8(b0, a0, jj_vl);
+
+  for (ii = 0; (ii + 1) <= m; ii = ii + 1) {
+    for (jj = 0; jj < n; jj = jj + jj_vl) {
+      jj_vl = __riscv_vsetvl_e16m4(n - jj);
+      __asm__ volatile(
+          // clang-format off
+          "\n\t"
+          "vsetvli zero, %[jj_vl_in], e16, m4, ta, ma \n\t"
+
+          "flh %[a0], 0(%[a_addr]) \n\t"
+          "vle16.v %[b0], (%[b_addr]) \n\t"
+          "vfwmul.vf %[acc], %[b0], %[a0] \n\t"
+          : [a0] "=&f"(a0),
+            [b0] "=&vr"(b0),
+            [acc] "=vr"(acc)
+          : [jj_vl_in] "r"(jj_vl),
+            [a_addr] "r"(a + ii * rsa),
+            [b_addr] "r"(b + jj)
+          : "vtype", "vl", "memory"
+          // clang-format on
+      );
+
+      for (kk = 1; (kk + 16) <= k; kk = kk + 16) {
+        const _Float16 *b_addr = b + kk * rsb + jj;
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m4, ta, ma \n\t"
+
+            "flh %[a0],  0(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
+
+            "flh %[a1],  2(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
+
+            "flh %[a0],  4(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
+
+            "flh %[a1],  6(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
+
+            "flh %[a0],  8(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
+
+            "flh %[a1], 10(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
+
+            "flh %[a0], 12(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
+
+            "flh %[a1], 14(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
+
+            "flh %[a0], 16(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
+
+            "flh %[a1], 18(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
+
+            "flh %[a0], 20(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
+
+            "flh %[a1], 22(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
+
+            "flh %[a0], 24(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
+
+            "flh %[a1], 26(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
+
+            "flh %[a0], 28(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
+
+            "flh %[a1], 30(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
+            : [a0] "=&f"(a0),
+              [a1] "=&f"(a1),
+              [b0] "=&vr"(b0),
+              [b1] "=&vr"(b1),
+              [acc] "+&vr"(acc),
+              [b_addr] "+&r"(b_addr)
+            : [jj_vl_in] "r"(jj_vl),
+              [a_addr] "r"(a + ii  * rsa + kk),
+              [rsb2] "r" (rsb * sizeof(_Float16))
+            : "vtype", "vl", "memory"
+            // clang-format on
+        );
+      }
+
+      for (; (kk + 1) <= k; kk = kk + 1) {
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m4, ta, ma \n\t"
+
+            "flh %[a0], 0(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
+            : [a0] "=&f"(a0),
+              [b0] "=&vr"(b0),
+              [acc] "+vr"(acc)
+            : [jj_vl_in] "r"(jj_vl),
+              [a_addr] "r"(a + ii  * rsa + kk),
+              [b_addr] "r"(b + kk  * rsb + jj)
+            : "vtype", "vl", "memory"
+            // clang-format on
+        );
+      }
+      __asm__ volatile(
+          // clang-format off
+          "\n\t"
+          "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+
+          "vle32.v %[c0], (%[c_addr]) \n\t"
+          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
+          "vfmacc.vf %[c0], %[alpha], %[acc] \n\t"
+          "vse32.v %[c0], (%[c_addr]) \n\t"
+          : [c0] "=&vr"(c0)
+          : [jj_vl_in] "r"(jj_vl),
+            [c_addr] "r"(c + ii * rsc + jj),
+            [beta] "f"(beta),
+            [alpha] "f"(alpha),
+            [acc] "vr"(acc)
+          : "vtype", "vl", "memory"
+          // clang-format on
+      );
     }
-    for (kk = kk_peel; (kk + 16) <= k; kk = kk + 16) {
-      a00 = a[(kk + 0) * 1];
-      a01 = a[(kk + 1) * 1];
-      a02 = a[(kk + 2) * 1];
-      a03 = a[(kk + 3) * 1];
-      a04 = a[(kk + 4) * 1];
-      a05 = a[(kk + 5) * 1];
-      a06 = a[(kk + 6) * 1];
-      a07 = a[(kk + 7) * 1];
-      a08 = a[(kk + 8) * 1];
-      a09 = a[(kk + 9) * 1];
-      a010 = a[(kk + 10) * 1];
-      a011 = a[(kk + 11) * 1];
-      a012 = a[(kk + 12) * 1];
-      a013 = a[(kk + 13) * 1];
-      a014 = a[(kk + 14) * 1];
-      a015 = a[(kk + 15) * 1];
-      skl_instruction_schedule_barrier();
-      b00 =
-          __riscv_vle16_v_f16m4(b + (((kk + 0) * rsb) + ((jj + 0) * 1)), jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a00, b00, jj_vl);
-      b01 =
-          __riscv_vle16_v_f16m4(b + (((kk + 1) * rsb) + ((jj + 0) * 1)), jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a01, b01, jj_vl);
-      b02 =
-          __riscv_vle16_v_f16m4(b + (((kk + 2) * rsb) + ((jj + 0) * 1)), jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a02, b02, jj_vl);
-      b03 =
-          __riscv_vle16_v_f16m4(b + (((kk + 3) * rsb) + ((jj + 0) * 1)), jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a03, b03, jj_vl);
-      b04 =
-          __riscv_vle16_v_f16m4(b + (((kk + 4) * rsb) + ((jj + 0) * 1)), jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a04, b04, jj_vl);
-      b05 =
-          __riscv_vle16_v_f16m4(b + (((kk + 5) * rsb) + ((jj + 0) * 1)), jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a05, b05, jj_vl);
-      b06 =
-          __riscv_vle16_v_f16m4(b + (((kk + 6) * rsb) + ((jj + 0) * 1)), jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a06, b06, jj_vl);
-      b07 =
-          __riscv_vle16_v_f16m4(b + (((kk + 7) * rsb) + ((jj + 0) * 1)), jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a07, b07, jj_vl);
-      b08 =
-          __riscv_vle16_v_f16m4(b + (((kk + 8) * rsb) + ((jj + 0) * 1)), jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a08, b08, jj_vl);
-      b09 =
-          __riscv_vle16_v_f16m4(b + (((kk + 9) * rsb) + ((jj + 0) * 1)), jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a09, b09, jj_vl);
-      b010 = __riscv_vle16_v_f16m4(b + (((kk + 10) * rsb) + ((jj + 0) * 1)),
-                                   jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a010, b010, jj_vl);
-      b011 = __riscv_vle16_v_f16m4(b + (((kk + 11) * rsb) + ((jj + 0) * 1)),
-                                   jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a011, b011, jj_vl);
-      b012 = __riscv_vle16_v_f16m4(b + (((kk + 12) * rsb) + ((jj + 0) * 1)),
-                                   jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a012, b012, jj_vl);
-      b013 = __riscv_vle16_v_f16m4(b + (((kk + 13) * rsb) + ((jj + 0) * 1)),
-                                   jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a013, b013, jj_vl);
-      b014 = __riscv_vle16_v_f16m4(b + (((kk + 14) * rsb) + ((jj + 0) * 1)),
-                                   jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a014, b014, jj_vl);
-      b015 = __riscv_vle16_v_f16m4(b + (((kk + 15) * rsb) + ((jj + 0) * 1)),
-                                   jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a015, b015, jj_vl);
-    }
-    for (kk0 = kk; (kk0 + 1) <= k; kk0 = kk0 + 1) {
-      a0 = a[(kk0 + 0) * 1];
-      b0 = __riscv_vle16_v_f16m4(b + (((kk0 + 0) * rsb) + ((jj + 0) * 1)),
-                                 jj_vl);
-      acc = __riscv_vfwmacc_vf_f32m8(acc, a0, b0, jj_vl);
-    }
-    c0 = __riscv_vle32_v_f32m8(c + ((jj + 0) * 1), jj_vl);
-    c0 = __riscv_vfmul_vf_f32m8(c0, _beta, jj_vl);
-    c0 = __riscv_vfmacc_vf_f32m8(c0, _alpha, acc, jj_vl);
-    __riscv_vse32_v_f32m8(c + ((jj + 0) * 1), c0, jj_vl);
   }
 }
 
@@ -1006,7 +1050,8 @@ SKL_FUNC void skl_gemm_f16_f16_f32_zvfh_x390(size_t m, size_t n, size_t k,
                                              size_t rsb, float beta, float *c,
                                              size_t rsc) {
   if (m == 1) {
-    skl_gemm_1xm8x16_f16_f16_f32_zvfh_x390(n, k, alpha, a, b, rsb, beta, c);
+    skl_gemm_1xm8x16_f16_f16_f32_zvfh_x390(m, n, k, alpha, a, rsc, b, rsb, beta,
+                                           c, rsc);
     return;
   }
   skl_gemm_6xm4x12_f16_f16_f32_zvfh_x390(m, n, k, alpha, a, rsa, b, rsb, beta,

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
@@ -47,12 +47,12 @@
  * );
  * ```
  *
- * Uses a 1 x LMUL=8 x 16 register tile. Vectorized across the N dimension.
+ * Uses a 1 x LMUL=8 x 18 register tile. Vectorized across the N dimension.
  *
  * @note
  * Works best when `m = 1` and `n >= __riscv_vsetvlmax_e32m8()`.
  */
-SKL_FUNC_PRIVATE void skl_gemm_1xm8x16_f16_f16_f32_zvfh_x390(
+SKL_FUNC_PRIVATE void skl_gemm_1xm8x18_f16_f16_f32_zvfh_x390(
     size_t m, size_t n, size_t k, float alpha, const _Float16 *a, size_t rsa,
     const _Float16 *b, size_t rsb, float beta, float *c, size_t rsc) {
   size_t jj_vl;
@@ -61,8 +61,16 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm8x16_f16_f16_f32_zvfh_x390(
   size_t kk;
   _Float16 a0;
   _Float16 a1;
+  _Float16 a2;
+  _Float16 a3;
+  _Float16 a4;
+  _Float16 a5;
   vfloat16m4_t b0;
   vfloat16m4_t b1;
+  vfloat16m4_t b2;
+  vfloat16m4_t b3;
+  vfloat16m4_t b4;
+  vfloat16m4_t b5;
   vfloat32m8_t acc;
   vfloat32m8_t c0;
 
@@ -81,6 +89,10 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm8x16_f16_f16_f32_zvfh_x390(
   for (ii = 0; (ii + 1) <= m; ii = ii + 1) {
     for (jj = 0; jj < n; jj = jj + jj_vl) {
       jj_vl = __riscv_vsetvl_e16m4(n - jj);
+
+      const size_t kk_unroll_degree = 18;
+      const size_t preload_distance = 6;
+
       __asm__ volatile(
           // clang-format off
           "\n\t"
@@ -99,7 +111,10 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm8x16_f16_f16_f32_zvfh_x390(
           // clang-format on
       );
 
-      for (kk = 1; (kk + 16) <= k; kk = kk + 16) {
+      kk = 1;
+
+      if (kk_unroll_degree + preload_distance < k) {
+        // Load initial values for kk loop below.
         const _Float16 *b_addr = b + kk * rsb + jj;
         __asm__ volatile(
             // clang-format off
@@ -109,93 +124,212 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm8x16_f16_f16_f32_zvfh_x390(
             "flh %[a0],  0(%[a_addr]) \n\t"
             "vle16.v %[b0], (%[b_addr]) \n\t"
             "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
 
             "flh %[a1],  2(%[a_addr]) \n\t"
             "vle16.v %[b1], (%[b_addr]) \n\t"
             "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
 
-            "flh %[a0],  4(%[a_addr]) \n\t"
-            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "flh %[a2],  4(%[a_addr]) \n\t"
+            "vle16.v %[b2], (%[b_addr]) \n\t"
             "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
 
-            "flh %[a1],  6(%[a_addr]) \n\t"
-            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "flh %[a3],  6(%[a_addr]) \n\t"
+            "vle16.v %[b3], (%[b_addr]) \n\t"
             "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
 
-            "flh %[a0],  8(%[a_addr]) \n\t"
-            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "flh %[a4],  8(%[a_addr]) \n\t"
+            "vle16.v %[b4], (%[b_addr]) \n\t"
             "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
 
-            "flh %[a1], 10(%[a_addr]) \n\t"
-            "vle16.v %[b1], (%[b_addr]) \n\t"
-            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
-
-            "flh %[a0], 12(%[a_addr]) \n\t"
-            "vle16.v %[b0], (%[b_addr]) \n\t"
-            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
-
-            "flh %[a1], 14(%[a_addr]) \n\t"
-            "vle16.v %[b1], (%[b_addr]) \n\t"
-            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
-
-            "flh %[a0], 16(%[a_addr]) \n\t"
-            "vle16.v %[b0], (%[b_addr]) \n\t"
-            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
-
-            "flh %[a1], 18(%[a_addr]) \n\t"
-            "vle16.v %[b1], (%[b_addr]) \n\t"
-            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
-
-            "flh %[a0], 20(%[a_addr]) \n\t"
-            "vle16.v %[b0], (%[b_addr]) \n\t"
-            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
-
-            "flh %[a1], 22(%[a_addr]) \n\t"
-            "vle16.v %[b1], (%[b_addr]) \n\t"
-            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
-
-            "flh %[a0], 24(%[a_addr]) \n\t"
-            "vle16.v %[b0], (%[b_addr]) \n\t"
-            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
-
-            "flh %[a1], 26(%[a_addr]) \n\t"
-            "vle16.v %[b1], (%[b_addr]) \n\t"
-            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
-
-            "flh %[a0], 28(%[a_addr]) \n\t"
-            "vle16.v %[b0], (%[b_addr]) \n\t"
-            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
-            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
-
-            "flh %[a1], 30(%[a_addr]) \n\t"
-            "vle16.v %[b1], (%[b_addr]) \n\t"
-            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
-            : [a0] "=&f"(a0),
-              [a1] "=&f"(a1),
-              [b0] "=&vr"(b0),
-              [b1] "=&vr"(b1),
-              [acc] "+&vr"(acc),
-              [b_addr] "+&r"(b_addr)
-            : [jj_vl_in] "r"(jj_vl),
-              [a_addr] "r"(a + ii  * rsa + kk),
+            "flh %[a5], 10(%[a_addr]) \n\t"
+            "vle16.v %[b5], (%[b_addr]) \n\t"
+            : [a0] "=&f" (a0),
+              [a1] "=&f" (a1),
+              [a2] "=&f" (a2),
+              [a3] "=&f" (a3),
+              [a4] "=&f" (a4),
+              [a5] "=&f" (a5),
+              [b0] "=&vr" (b0),
+              [b1] "=&vr" (b1),
+              [b2] "=&vr" (b2),
+              [b3] "=&vr" (b3),
+              [b4] "=&vr" (b4),
+              [b5] "=&vr" (b5),
+              [b_addr] "+&r" (b_addr)
+            : [jj_vl_in] "r" (jj_vl),
+              [a_addr] "r" (a + ii * rsa + kk),
               [rsb2] "r" (rsb * sizeof(_Float16))
             : "vtype", "vl", "memory"
             // clang-format on
         );
+      }
+
+      for (; (kk + kk_unroll_degree + preload_distance) <= k;
+           kk += kk_unroll_degree) {
+        const size_t offset = preload_distance;
+        const _Float16 *b_addr = b + (kk + offset) * rsb + jj;
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m4, ta, ma \n\t"
+
+            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
+            NTL_P1
+            "flh %[a0],  0(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
+            NTL_P1
+            "flh %[a1],  2(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a2], %[b2] \n\t"
+            NTL_P1
+            "flh %[a2],  4(%[a_addr]) \n\t"
+            "vle16.v %[b2], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a3], %[b3] \n\t"
+            NTL_P1
+            "flh %[a3],  6(%[a_addr]) \n\t"
+            "vle16.v %[b3], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a4], %[b4] \n\t"
+            NTL_P1
+            "flh %[a4],  8(%[a_addr]) \n\t"
+            "vle16.v %[b4], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a5], %[b5] \n\t"
+            NTL_P1
+            "flh %[a5], 10(%[a_addr]) \n\t"
+            "vle16.v %[b5], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
+            NTL_P1
+            "flh %[a0], 12(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
+            NTL_P1
+            "flh %[a1], 14(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a2], %[b2] \n\t"
+            NTL_P1
+            "flh %[a2], 16(%[a_addr]) \n\t"
+            "vle16.v %[b2], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a3], %[b3] \n\t"
+            NTL_P1
+            "flh %[a3], 18(%[a_addr]) \n\t"
+            "vle16.v %[b3], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a4], %[b4] \n\t"
+            NTL_P1
+            "flh %[a4], 20(%[a_addr]) \n\t"
+            "vle16.v %[b4], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a5], %[b5] \n\t"
+            NTL_P1
+            "flh %[a5], 22(%[a_addr]) \n\t"
+            "vle16.v %[b5], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
+            NTL_P1
+            "flh %[a0], 24(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
+            NTL_P1
+            "flh %[a1], 26(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a2], %[b2] \n\t"
+            NTL_P1
+            "flh %[a2], 28(%[a_addr]) \n\t"
+            "vle16.v %[b2], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a3], %[b3] \n\t"
+            NTL_P1
+            "flh %[a3], 30(%[a_addr]) \n\t"
+            "vle16.v %[b3], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a4], %[b4] \n\t"
+            NTL_P1
+            "flh %[a4], 32(%[a_addr]) \n\t"
+            "vle16.v %[b4], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmacc.vf %[acc], %[a5], %[b5] \n\t"
+            NTL_P1
+            "flh %[a5], 34(%[a_addr]) \n\t"
+            "vle16.v %[b5], (%[b_addr]) \n\t"
+            : [a0] "+&f"(a0),
+              [a1] "+&f"(a1),
+              [a2] "+&f"(a2),
+              [a3] "+&f"(a3),
+              [a4] "+&f"(a4),
+              [a5] "+&f"(a5),
+              [b0] "+&vr"(b0),
+              [b1] "+&vr"(b1),
+              [b2] "+&vr"(b2),
+              [b3] "+&vr"(b3),
+              [b4] "+&vr"(b4),
+              [b5] "+&vr"(b5),
+              [acc] "+&vr"(acc),
+              [b_addr] "+&r"(b_addr)
+            : [jj_vl_in] "r"(jj_vl),
+              [a_addr] "r"(a + ii  * rsa + kk + offset),
+              [rsb2] "r" (rsb * sizeof(_Float16))
+            : "vtype", "vl", "memory"
+            // clang-format on
+        );
+      }
+
+      if (kk_unroll_degree + preload_distance < k) {
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m4, ta, ma \n\t"
+            "vfwmacc.vf %[acc], %[a0], %[b0] \n\t"
+            "vfwmacc.vf %[acc], %[a1], %[b1] \n\t"
+            "vfwmacc.vf %[acc], %[a2], %[b2] \n\t"
+            "vfwmacc.vf %[acc], %[a3], %[b3] \n\t"
+            "vfwmacc.vf %[acc], %[a4], %[b4] \n\t"
+            "vfwmacc.vf %[acc], %[a5], %[b5] \n\t"
+            : [acc] "+&vr"(acc)
+            : [jj_vl_in] "r" (jj_vl),
+              [a0] "f"(a0),
+              [a1] "f"(a1),
+              [a2] "f"(a2),
+              [a3] "f"(a3),
+              [a4] "f"(a4),
+              [a5] "f"(a5),
+              [b0] "vr"(b0),
+              [b1] "vr"(b1),
+              [b2] "vr"(b2),
+              [b3] "vr"(b3),
+              [b4] "vr"(b4),
+              [b5] "vr"(b5)
+            : "vtype", "vl"
+            // clang-format on
+        );
+        kk += preload_distance;
       }
 
       for (; (kk + 1) <= k; kk = kk + 1) {
@@ -1050,7 +1184,7 @@ SKL_FUNC void skl_gemm_f16_f16_f32_zvfh_x390(size_t m, size_t n, size_t k,
                                              size_t rsb, float beta, float *c,
                                              size_t rsc) {
   if (m == 1) {
-    skl_gemm_1xm8x16_f16_f16_f32_zvfh_x390(m, n, k, alpha, a, rsc, b, rsb, beta,
+    skl_gemm_1xm8x18_f16_f16_f32_zvfh_x390(m, n, k, alpha, a, rsc, b, rsb, beta,
                                            c, rsc);
     return;
   }

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
@@ -154,7 +154,7 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm8x18_f16_f16_f32_zvfh_x390(
               [b2] "=&vr" (b2),
               [b3] "=&vr" (b3),
               [b4] "=&vr" (b4),
-              [b5] "=&vr" (b5),
+              [b5] "=vr" (b5),
               [b_addr] "+&r" (b_addr)
             : [jj_vl_in] "r" (jj_vl),
               [a_addr] "r" (a + ii * rsa + kk),

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
@@ -77,7 +77,7 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm8x18_f16_f16_f32_zvfh_x390(
   if (k == 0) {
     for (ii = 0; (ii + 1) <= m; ii = ii + 1) {
       for (jj = 0; jj < n; jj = jj + jj_vl) {
-        jj_vl = __riscv_vsetvl_e32m1(n - jj);
+        jj_vl = __riscv_vsetvl_e32m8(n - jj);
         c0 = __riscv_vle32_v_f32m8(c + ii * rsc + jj, jj_vl);
         c0 = __riscv_vfmul_vf_f32m8(c0, beta, jj_vl);
         __riscv_vse32_v_f32m8(c + ii * rsc + jj, c0, jj_vl);


### PR DESCRIPTION
This optimizes the widening f16 GEMV x390 kernel:
- use inline assembly for a fixed instruction schedule.
- use `ntl.p1` hints to make scalar loads non-blocking.
- preload A and B values in advance.
- changed tile size to 1xm8x18.
- add `m`, `rsa`, `rsc` parameters so that the kernel can compute arbitrary GEMM problems (but optimization is still limited to `m == 1`).

With these changes I saw a performance improvement of up to 20% in certain problem sizes.