### PR TITLE
[Logistic] Adds Xsfvfexp32e kernels.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ add_skl_src(src/gemm/xsfvqdotq/pack_b_xsfvqdotq.c "zve32x")
 
 add_skl_src(src/logistic/logistic_f16_xsfvfexp16e.c "xsfvfexp16e")
 add_skl_src(src/logistic/logistic_f16_zvfh.c "zvfh")
+add_skl_src(src/logistic/logistic_f32_xsfvfexp32e.c "xsfvfexp32e")
 add_skl_src(src/logistic/logistic_f32_xsfvfexpa.c "xsfvfexpa")
 add_skl_src(src/logistic/logistic_f32_zve32f.c "zve32f")
 

--- a/include/skl.h
+++ b/include/skl.h
@@ -110,6 +110,7 @@
 
 #if defined(__riscv_xsfvfexp32e)
 #include "../src/exp/exp_f32_xsfvfexp32e.h"
+#include "../src/logistic/logistic_f32_xsfvfexp32e.h"
 #endif
 
 #if defined(__riscv_xsfvfexpa) && defined(__riscv_zvfbfmin)

--- a/src/logistic/logistic_f32_xsfvfexp32e.c
+++ b/src/logistic/logistic_f32_xsfvfexp32e.c
@@ -25,7 +25,7 @@ SKL_FUNC void skl_logistic_5u_f32_xsfvfexp32e(float *out, const float *in,
       "\t   vle32.v     v8,  (%[in])     \n"
       "\t   vfsgnj.vf   v8,  v8, %[b]    \n"
       "\t   vfmax.vf    v8,  v8, %[b]    \n"
-      /* 1. Split x = a + e */
+      /* 1. Split x = a - e */
       "\t   vfmul.vf   v16,  v8, %[S]    \n"
       "\t   vfsub.vv   v24, v16, v8      \n"
       /* 2. Compute o = exp(a) and p = exp(e) */

--- a/src/logistic/logistic_f32_xsfvfexp32e.c
+++ b/src/logistic/logistic_f32_xsfvfexp32e.c
@@ -47,9 +47,9 @@ SKL_FUNC void skl_logistic_5u_f32_xsfvfexp32e(float *out, const float *in,
       "\t   vfmul.vv   %[y], %[y], %[z]       \n"
       "\t   vse32.v    %[y], (%[out])"
       : [vl] "=&r"(vl),
-	[w] "=vr"(w), [x] "=vd"(x), [y] "=vd"(y), [z] "=vd"(z)
+        [w] "=vr"(w), [x] "=vd"(x), [y] "=vd"(y), [z] "=vd"(z)
       : [n] "r"(n), [in] "r"(in), [out] "r"(out),
-	[b] "f"(b), [S] "f"(S), [one] "f"(1.0f)
+        [b] "f"(b), [S] "f"(S), [one] "f"(1.0f)
       : "vtype", "vl", "memory");
   // clang-format on
 }

--- a/src/logistic/logistic_f32_xsfvfexp32e.c
+++ b/src/logistic/logistic_f32_xsfvfexp32e.c
@@ -31,7 +31,7 @@ SKL_FUNC void skl_logistic_5u_f32_xsfvfexp32e(float *out, const float *in,
       /* 2. Compute o = exp(a) and p = exp(e) */
       "\t   sf.vfexp.v v16, v16          \n"
       "\t   sf.vfexp.v v24, v24          \n"
-      "\t   vmsgt.vi    v0,  v8, 0       \n"
+      "\t   vmslt.vi    v0,  v8, 0       \n"
       "\t   vfadd.vv    v8, v16, v24     \n"
       /* 3. Assemble numerator: n = x>0 ? p : o */
       "\t   vmerge.vvm v16, v16, v24, v0 \n"

--- a/src/logistic/logistic_f32_xsfvfexp32e.c
+++ b/src/logistic/logistic_f32_xsfvfexp32e.c
@@ -1,0 +1,53 @@
+// Copyright 2026 SiFive, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#if !defined(__riscv_xsfvfexpa)
+#error This file requires the Xsfvfexpa extension
+#endif
+
+#include "skl-common.h"
+#include <riscv_vector.h>
+#include <sifive_vector.h>
+#include <stddef.h>
+
+// NOLINTNEXTLINE(readability-non-const-parameter)
+SKL_FUNC void skl_logistic_5u_f32_xsfvfexp32e(float *out, const float *in,
+                                              size_t N) {
+  size_t vl;
+  const float b = -0x1.9fe370p+6f; /* Input lower bound */
+  const float S = +0x1.35512ep-1f; /* Input split ratio */
+
+  // clang-format off
+  for (; N; in += vl, out += vl, N -= vl)
+    __asm__ volatile(
+      "     vsetvli  %[vl], %[N], e32, m8, ta, ma \n"
+      /* 0. Load and clamp */
+      "\t   vle32.v     v8,  (%[in])     \n"
+      "\t   vfsgnj.vf   v8,  v8, %[b]    \n"
+      "\t   vfmax.vf    v8,  v8, %[b]    \n"
+      /* 1. Split x = a + e */
+      "\t   vfmul.vf   v16,  v8, %[S]    \n"
+      "\t   vfsub.vv   v24, v16, v8      \n"
+      /* 2. Compute o = exp(a) and p = exp(e) */
+      "\t   sf.vfexp.v v16, v16          \n"
+      "\t   sf.vfexp.v v24, v24          \n"
+      "\t   vmsgt.vi    v0,  v8, 0       \n"
+      "\t   vfadd.vv    v8, v16, v24     \n"
+      /* 3. Assemble numerator: n = x>0 ? p : o */
+      "\t   vmerge.vvm v16, v16, v24, v0 \n"
+      "\t   vfmv.v.f    v0, %[one]       \n"
+      /* 4. Approximate 1 / (o + p) */
+      "\t   vfrec7.v   v24, v8 \n"
+      "\t   vfnmsac.vv  v0, v8, v24      \n"
+      "\t   vfmadd.vv  v24, v0, v24      \n"
+      "\t   vfmul.vv    v0, v0, v0       \n"
+      "\t   vfmadd.vv  v24, v0, v24      \n"
+      /* 5. Finally, n * r ~ n / d */
+      "\t   vfmul.vv   v16, v16, v24     \n"
+      "\t   vse32.v    v16, (%[out])"
+      : [vl] "=r"(vl)
+      : [N] "r"(N), [in] "r"(in), [out] "r"(out), [S] "f"(S),
+        [b] "f"(b), [one] "f"(1.0f)
+      : "vtype", "vl", "memory");
+  // clang-format on
+}

--- a/src/logistic/logistic_f32_xsfvfexp32e.c
+++ b/src/logistic/logistic_f32_xsfvfexp32e.c
@@ -16,7 +16,7 @@ SKL_FUNC void skl_logistic_5u_f32_xsfvfexp32e(float *out, const float *in,
   size_t vl;
   const float b = -0x1.9fe370p+6f; /* Input lower bound */
   const float S = +0x1.35512ep-1f; /* Input split ratio */
-  vfloat32m8_t w, x, y, z;
+  vfloat32m8_t w, x, y, z;	   /* NOLINT(*-isolate-declaration) */
 
   // clang-format off
   for (; n; in += vl, out += vl, n -= vl)

--- a/src/logistic/logistic_f32_xsfvfexp32e.c
+++ b/src/logistic/logistic_f32_xsfvfexp32e.c
@@ -1,8 +1,8 @@
 // Copyright 2026 SiFive, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#if !defined(__riscv_xsfvfexpa)
-#error This file requires the Xsfvfexpa extension
+#if !defined(__riscv_xsfvfexp32e)
+#error This file requires the Xsfvfexp32e extension
 #endif
 
 #include "skl-common.h"
@@ -12,15 +12,15 @@
 
 // NOLINTNEXTLINE(readability-non-const-parameter)
 SKL_FUNC void skl_logistic_5u_f32_xsfvfexp32e(float *out, const float *in,
-                                              size_t N) {
+                                              size_t n) {
   size_t vl;
   const float b = -0x1.9fe370p+6f; /* Input lower bound */
   const float S = +0x1.35512ep-1f; /* Input split ratio */
 
   // clang-format off
-  for (; N; in += vl, out += vl, N -= vl)
+  for (; n; in += vl, out += vl, n -= vl)
     __asm__ volatile(
-      "     vsetvli  %[vl], %[N], e32, m8, ta, ma \n"
+      "     vsetvli  %[vl], %[n], e32, m8, ta, ma \n"
       /* 0. Load and clamp */
       "\t   vle32.v     v8,  (%[in])     \n"
       "\t   vfsgnj.vf   v8,  v8, %[b]    \n"
@@ -45,8 +45,8 @@ SKL_FUNC void skl_logistic_5u_f32_xsfvfexp32e(float *out, const float *in,
       /* 5. Finally, n * r ~ n / d */
       "\t   vfmul.vv   v16, v16, v24     \n"
       "\t   vse32.v    v16, (%[out])"
-      : [vl] "=r"(vl)
-      : [N] "r"(N), [in] "r"(in), [out] "r"(out), [S] "f"(S),
+      : [vl] "=&r"(vl)
+      : [n] "r"(n), [in] "r"(in), [out] "r"(out), [S] "f"(S),
         [b] "f"(b), [one] "f"(1.0f)
       : "vtype", "vl", "memory");
   // clang-format on

--- a/src/logistic/logistic_f32_xsfvfexp32e.c
+++ b/src/logistic/logistic_f32_xsfvfexp32e.c
@@ -36,7 +36,7 @@ SKL_FUNC void skl_logistic_5u_f32_xsfvfexp32e(float *out, const float *in,
       /* 3. Assemble numerator: n = x>0 ? p : o */
       "\t   vmerge.vvm v16, v16, v24, v0 \n"
       "\t   vfmv.v.f    v0, %[one]       \n"
-      /* 4. Approximate 1 / (o + p) */
+      /* 4. Approximate r = 1 / (d = o + p) */
       "\t   vfrec7.v   v24, v8 \n"
       "\t   vfnmsac.vv  v0, v8, v24      \n"
       "\t   vfmadd.vv  v24, v0, v24      \n"

--- a/src/logistic/logistic_f32_xsfvfexp32e.c
+++ b/src/logistic/logistic_f32_xsfvfexp32e.c
@@ -16,38 +16,40 @@ SKL_FUNC void skl_logistic_5u_f32_xsfvfexp32e(float *out, const float *in,
   size_t vl;
   const float b = -0x1.9fe370p+6f; /* Input lower bound */
   const float S = +0x1.35512ep-1f; /* Input split ratio */
+  vfloat32m8_t w, x, y, z;
 
   // clang-format off
   for (; n; in += vl, out += vl, n -= vl)
     __asm__ volatile(
       "     vsetvli  %[vl], %[n], e32, m8, ta, ma \n"
       /* 0. Load and clamp */
-      "\t   vle32.v     v8,  (%[in])     \n"
-      "\t   vfsgnj.vf   v8,  v8, %[b]    \n"
-      "\t   vfmax.vf    v8,  v8, %[b]    \n"
+      "\t   vle32.v    %[x], (%[in])          \n"
+      "\t   vfsgnj.vf  %[x], %[x], %[b]       \n"
+      "\t   vfmax.vf   %[x], %[x], %[b]       \n"
       /* 1. Split x = a - e */
-      "\t   vfmul.vf   v16,  v8, %[S]    \n"
-      "\t   vfsub.vv   v24, v16, v8      \n"
+      "\t   vfmul.vf   %[y], %[x], %[S]       \n"
+      "\t   vfsub.vv   %[z], %[y], %[x]       \n"
       /* 2. Compute o = exp(a) and p = exp(e) */
-      "\t   sf.vfexp.v v16, v16          \n"
-      "\t   sf.vfexp.v v24, v24          \n"
-      "\t   vmslt.vi    v0,  v8, 0       \n"
-      "\t   vfadd.vv    v8, v16, v24     \n"
+      "\t   sf.vfexp.v %[y], %[y]             \n"
+      "\t   sf.vfexp.v %[z], %[z]             \n"
+      "\t   vmslt.vi   %[w], %[x], 0          \n"
+      "\t   vfadd.vv   %[x], %[y], %[z]       \n"
       /* 3. Assemble numerator: n = x>0 ? p : o */
-      "\t   vmerge.vvm v16, v16, v24, v0 \n"
-      "\t   vfmv.v.f    v0, %[one]       \n"
+      "\t   vmerge.vvm %[y], %[y], %[z], %[w] \n"
+      "\t   vfmv.v.f   %[w], %[one]           \n"
       /* 4. Approximate r = 1 / (d = o + p) */
-      "\t   vfrec7.v   v24, v8 \n"
-      "\t   vfnmsac.vv  v0, v8, v24      \n"
-      "\t   vfmadd.vv  v24, v0, v24      \n"
-      "\t   vfmul.vv    v0, v0, v0       \n"
-      "\t   vfmadd.vv  v24, v0, v24      \n"
-      /* 5. Finally, n * r ~ n / d */
-      "\t   vfmul.vv   v16, v16, v24     \n"
-      "\t   vse32.v    v16, (%[out])"
-      : [vl] "=&r"(vl)
-      : [n] "r"(n), [in] "r"(in), [out] "r"(out), [S] "f"(S),
-        [b] "f"(b), [one] "f"(1.0f)
+      "\t   vfrec7.v   %[z], %[x] \n"
+      "\t   vfnmsac.vv %[w], %[x], %[z]       \n"
+      "\t   vfmadd.vv  %[z], %[w], %[z]       \n"
+      "\t   vfmul.vv   %[w], %[w], %[w]       \n"
+      "\t   vfmadd.vv  %[z], %[w], %[z]       \n"
+      /* 5. Finally, n / d ~ n * r */
+      "\t   vfmul.vv   %[y], %[y], %[z]       \n"
+      "\t   vse32.v    %[y], (%[out])"
+      : [vl] "=&r"(vl),
+	[w] "=vr"(w), [x] "=vd"(x), [y] "=vd"(y), [z] "=vd"(z)
+      : [n] "r"(n), [in] "r"(in), [out] "r"(out),
+	[b] "f"(b), [S] "f"(S), [one] "f"(1.0f)
       : "vtype", "vl", "memory");
   // clang-format on
 }

--- a/src/logistic/logistic_f32_xsfvfexp32e.c
+++ b/src/logistic/logistic_f32_xsfvfexp32e.c
@@ -16,7 +16,7 @@ SKL_FUNC void skl_logistic_5u_f32_xsfvfexp32e(float *out, const float *in,
   size_t vl;
   const float b = -0x1.9fe370p+6f; /* Input lower bound */
   const float S = +0x1.35512ep-1f; /* Input split ratio */
-  vfloat32m8_t w, x, y, z;	   /* NOLINT(*-isolate-declaration) */
+  vfloat32m8_t w, x, y, z;         /* NOLINT(*-isolate-declaration) */
 
   // clang-format off
   for (; n; in += vl, out += vl, n -= vl)

--- a/src/logistic/logistic_f32_xsfvfexp32e.h
+++ b/src/logistic/logistic_f32_xsfvfexp32e.h
@@ -1,0 +1,38 @@
+// Copyright 2026 SiFive, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if !defined(__riscv_xsfvfexp32e)
+#error This file requires the Xsfvfexp32e extension
+#endif
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief FP32 logistic accelerated with Xsfvfexp32e.
+ *
+ * @param out - Array of output elements.
+ * @param in - Array of input elements.
+ * @param n - Number of elements to process.
+ *
+ * Computes the logistic function as defined by:
+ * logistic(x) = 1 / (1 + e^(-x))
+ *
+ * using the SiFive vector floating-point exponential function
+ * instruction to compute the `e^(-x)` component.
+ *
+ * Results are accurate to less than 4.5168 ulp.
+ *
+ * @note
+ * The result for NaN inputs is 0.
+ */
+void skl_logistic_5u_f32_xsfvfexp32e(float *out, const float *in, size_t n);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/test/logistic/logistic_f32.c
+++ b/test/logistic/logistic_f32.c
@@ -75,7 +75,7 @@ int main(void) {
 #endif
 
 #if defined(__riscv_xsfvfexp32e) && defined(RUN_XSFVFEXP32E)
-  RUN(skl_logistic_4p13u_f32_xsfvfexp32e, "xsfvfexp32e", 5);
+  RUN(skl_logistic_5u_f32_xsfvfexp32e, "xsfvfexp32e", 5);
 #endif
 
 #if defined(RUN_SCALAR)

--- a/test/logistic/logistic_f32.c
+++ b/test/logistic/logistic_f32.c
@@ -26,6 +26,7 @@
 #define RUN_SCALAR 1
 #define RUN_RVV 1
 #define RUN_XSFVFEXPA 1
+#define RUN_XSFVFEXP32E 1
 #endif
 
 #if defined(ENABLE_TEST)
@@ -73,11 +74,16 @@ int main(void) {
   RUN(skl_logistic_4u_f32_xsfvfexpa, "xsfvfexpa", 4);
 #endif
 
+#if defined(__riscv_xsfvfexp32e) && defined(RUN_XSFVFEXP32E)
+  RUN(skl_logistic_4p13u_f32_xsfvfexp32e, "xsfvfexp32e", 5);
+#endif
+
 #if defined(RUN_SCALAR)
   RUN(skl_logistic_3u_f32_ref, "reference", 3)
 #endif
 
-#if !(defined(RUN_RVV) || defined(RUN_SCALAR) || defined(RUN_XSFVFEXPA))
+#if !(defined(RUN_RVV) || defined(RUN_SCALAR) || defined(RUN_XSFVFEXPA) ||     \
+      defined(RUN_XSFVFEXP32e))
 #error No tests or benchmarks enabled!
 #endif
 


### PR DESCRIPTION
Inline assembly avoids pessimistic register spills from compilers, lowers memory traffic, and improves performance.

* src/logistic/logistic_f32_xsfvfexp32e.h, src/logistic/logistic_f32_xsfvfexp32e.c: New files
* include/skl.h [__riscv_xsfvfexp32e]: Include header.
* CMakeLists.txt: Add src.
* test/logistic/logistic_f32.c [RUN_XSFVFEXP32E]: Test it.