### PR TITLE
[Test][GEMM] Convert `bf16_bf16_f32` harness and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,10 +206,6 @@ if (SKL_BUILD_TESTS OR SKL_BUILD_BENCHMARKS)
     skl_add_test_legacy(logistic_f16_zvfh logistic/logistic_f16.c "-DRUN_ALL")
     skl_add_test_legacy(silu_f16_zvfh silu/silu_f16.c "-DRUN_ALL")
   endif()
-  if("zvfbfwma" IN_LIST RISCV_EXTENSIONS)
-    skl_add_test_legacy(skl_gemm_bf16_bf16_f32_zvfbfwma_wrapper gemm/gemm_bf16rc_bf16rc_f32rc.c
-      "-DM=4;-DN=16;-DK=128;-DALPHA=1.f;-DBETA=0.f")
-  endif()
   skl_add_test_legacy(softmax_f16 softmax/softmax_f16.c "-DRUN_ALL;-DBETA=0.5")
   skl_add_test_legacy(softmax_bf16 softmax/softmax_bf16.c "-DRUN_ALL;-DBETA=0.5")
   skl_add_test_legacy(softmax_f32 softmax/softmax_f32.c "-DRUN_ALL;-DBETA=0.5")
@@ -240,12 +236,6 @@ if (SKL_BUILD_TESTS OR SKL_BUILD_BENCHMARKS)
       "-DRSA=1;-DCSA=128;-DM=128;-DN=128;-DK=32;-DALPHA=1;-DBETA=0")
     skl_add_test_legacy(skl_gemm_a1b01_i8pc_i8cp_i32rcp_xsfmm32a8i_wrapper gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
       "-DM0=${XSFMM_TE};-DN0=${XSFMM_TE};-DK0=1;-DM1=2;-DN1=2;-DK1=32;-DRSA0=1;-DCSA0=0;-DRSB0=0;-DCSB0=1;-DRSB1=(K0 * N0);-DCSB1=(K0 * N0 * K1);-DALPHA=1;-DBETA=0")
-  endif()
-  if("xsfmm32a16f" IN_LIST RISCV_EXTENSIONS)
-    skl_add_test_legacy(skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f_wrapper gemm/gemm_bf16rc_bf16rc_f32rc.c
-      "-DRSA=1;-DCSA=128;-DM=128;-DN=128;-DK=32;-DALPHA=1.f;-DBETA=0.f")
-    skl_add_test_legacy(skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f_wrapper gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
-      "-DM0=${XSFMM_TE};-DN0=${XSFMM_TE};-DK0=1;-DM1=2;-DN1=2;-DK1=32;-DRSA0=1;-DCSA0=0;-DRSB0=0;-DCSB0=1;-DRSB1=(K0 * N0);-DCSB1=(K0 * N0 * K1);-DALPHA=1.f;-DBETA=0.f")
   endif()
   if("xsfvqdotq" IN_LIST RISCV_EXTENSIONS)
     skl_add_test_legacy(skl_gemm_i8_i8pc_i32_xsfvqdotq gemm/gemm_i8_i8pc_i32_xsfvqdotq.c "-DM=128;-DN=128;-DK=256;-DALPHA=1;-DBETA=1")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -123,6 +123,27 @@ skl_add_test(
   ""
 )
 skl_add_test(
+  skl_gemm_bf16_bf16_f32_zvfbfwma
+  gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+  gemm/rvv/skl_gemm_bf16_bf16_f32_zvfbfwma.c
+  "zvfbfwma"
+  ""
+)
+skl_add_test(
+  skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f
+  gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+  gemm/xsfmm/skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+  "xsfmm32a16f"
+  ""
+)
+skl_add_test(
+  skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f
+  gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+  gemm/xsfmm/skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f.c
+  "xsfmm32a16f"
+  ""
+)
+skl_add_test(
   skl_gemm_f16_f16_f32_zvfh_x390
   gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
   gemm/rvv/skl_gemm_f16_f16_f32_zvfh_x390.c

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -93,7 +93,6 @@ void gemm_bf16rcprc_bf16rcprc_f32rcprc_init(skl_test_t *t) {
 }
 
 void gemm_bf16rcprc_bf16rcprc_f32rcprc_verify(skl_test_t *t) {
-  /* Compute the reference matrix output. */
   gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
       (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
 

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -15,11 +15,8 @@
 #include "skl-ref.h"
 #include "skl-test-driver.h"
 #include "skl_test_gemm.h"
-#include <inttypes.h>
 #include <math.h>
 #include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -3,186 +3,133 @@
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT
 
-/* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
+/**
+ * @brief Implementation of the gemm_bf16rcprc_bf16rcprc_f32rcprc test harness.
  *
- * A is packed M1 x K1 with row stride RSA1 and column stride CSA1.
- * Blocks of A are M0 x K0 with row stride RSA0 and column stride CSA0.
- * B is packed K1 x N1 with row stride RSB1 and column stride CSB1.
- * Blocks of B are K0 x N0 with row stride RSB0 and column stride CSB0.
- * C is packed M1 x N1 with row stride RSC1 and column stride CSC1.
- * Blocks of C are M0 x N0 with row stride RSC0 and column stride CSC0.
- *
- * Users must provide the values of the following as compiler flags using -D:
- *  - All dimensions M0, N0, K0, M1, N1, and K1;
- *  - Both RSA0 and CSA0; or neither (implying RSA0 = K0, CSA0 = 1)
- *  - Both RSA1 and CSA1; or neither (implying RSA1 = M0 * K0 * K1,
- *    CSA1 = M0 * K0)
- *  - Both RSB0 and CSB0; or neither (implying RSB0 = N0, CSB0 = 1)
- *  - Both RSB1 and CSB1; or neither (implying RSB1 = K0 * N0 * N1,
- *    CSB1 = K0 * N0)
- *  - Both RSC0 and CSC0; or neither (implying RSC0 = N0, CSC0 = 1)
- *  - Both RSC1 and CSC1; or neither (implying RSC1 = M0 * N0 * N1,
- *    CSC1 = M0 * N0)
- *  - Both ALPHA and BETA, as floating point literals.
+ * This file defines all harness functions _except_ `skl_test_execute`, which is
+ * defined in the test file (e.g.
+ * xsfmm/skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f.c).
  */
 
-#if !(defined(ENABLE_TEST) || defined(ENABLE_BENCHMARK))
-#error Must define at least one of ENABLE_TEST and ENABLE_BENCHMARK
-#endif
-
-#ifndef M0
-#error Must define M0
-#endif
-
-#ifndef N0
-#error Must define N0
-#endif
-
-#ifndef K0
-#error Must define K0
-#endif
-
-#ifndef M1
-#error Must define M1
-#endif
-
-#ifndef N1
-#error Must define N1
-#endif
-
-#ifndef K1
-#error Must define K1
-#endif
-
-#ifndef ALPHA
-#error Must define ALPHA
-#endif
-
-#ifndef BETA
-#error Must define BETA
-#endif
-
-#if defined(ENABLE_TEST)
-#include <math.h>
-#endif
-
-#ifndef SKL_TEST_PERF_REPORT
-#define SKL_TEST_PERF_REPORT report_perf_mpc
-#endif
-
+#include "gemm_bf16rcprc_bf16rcprc_f32rcprc.h"
 #include "skl-ref.h"
-#include "skl-test.h"
-#include "skl.h"
+#include "skl-test-driver.h"
+#include "skl_test_gemm.h"
 #include <inttypes.h>
+#include <math.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-/* Include various BF16 GEMM kernels depending on ISA compatibility. */
-#if defined(__riscv_xsfmm32a16f)
-void skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f_wrapper(
-    size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    float alpha, const __bf16 *a_pack, size_t rsa0,
-    __attribute__((unused)) size_t csa0, size_t rsa1, size_t csa1,
-    const __bf16 *b_pack, __attribute__((unused)) size_t rsb0, size_t csb0,
-    size_t rsb1, size_t csb1, float beta, float *c_pack, size_t rsc0,
-    size_t csc0, size_t rsc1, size_t csc1) {
-  int status = 0;
-  size_t te = skl_get_te_xsfmmbase();
-  SKL_TEST_REQUIRE(status, m0 == te);
-  SKL_TEST_REQUIRE(status, n0 == te);
-  SKL_TEST_REQUIRE(status, k0 == 1);
-  SKL_TEST_REQUIRE(status, rsa0 == 1);
-  SKL_TEST_REQUIRE(status, csa1 == m0 * k0);
-  SKL_TEST_REQUIRE(status, csb0 == 1);
-  SKL_TEST_REQUIRE(status, rsb1 == k0 * n0);
-  SKL_TEST_REQUIRE(status, rsc0 == n0);
-  SKL_TEST_REQUIRE(status, csc0 == 1);
-  SKL_TEST_REQUIRE(status, alpha == 1.f);
-  SKL_TEST_REQUIRE(status, beta == 0.f || beta == 1.f);
-  if (status) {
-    exit(status);
+void gemm_bf16rcprc_bf16rcprc_f32rcprc_init(skl_test_t *t) {
+  gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
+      (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
+
+  size_t m0 = h->m0;
+  size_t n0 = h->n0;
+  size_t k0 = h->k0;
+  size_t m1 = h->m1;
+  size_t n1 = h->n1;
+  size_t k1 = h->k1;
+  size_t rsa0 = h->rsa0;
+  size_t csa0 = h->csa0;
+  size_t rsa1 = h->rsa1;
+  size_t csa1 = h->csa1;
+  size_t rsb0 = h->rsb0;
+  size_t csb0 = h->csb0;
+  size_t rsb1 = h->rsb1;
+  size_t csb1 = h->csb1;
+  size_t rsc0 = h->rsc0;
+  size_t csc0 = h->csc0;
+  size_t rsc1 = h->rsc1;
+  size_t csc1 = h->csc1;
+
+  skl_test_check_matrix_params_rcprc(t, m0, k0, m1, k1, rsa0, csa0, rsa1, csa1);
+  skl_test_check_matrix_params_rcprc(t, k0, n0, k1, n1, rsb0, csb0, rsb1, csb1);
+  skl_test_check_matrix_params_rcprc(t, m0, n0, m1, n1, rsc0, csc0, rsc1, csc1);
+
+  if (t->status.init_status != SKL_TEST_PASS) {
+    return;
   }
-  skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(m1, n1, k0 * k1, a_pack, rsa1,
-                                                  b_pack, csb1, c_pack, rsc1,
-                                                  csc1, beta != 0.f);
+
+  if (m1 == 0 || k1 == 0) {
+    h->a_pack.len = 0;
+  } else {
+    h->a_pack.len = (m1 - 1) * rsa1 + (k1 - 1) * csa1 + (m0 - 1) * rsa0 +
+                    (k0 - 1) * csa0 + 1;
+  }
+
+  if (k1 == 0 || n1 == 0) {
+    h->b_pack.len = 0;
+  } else {
+    h->b_pack.len = (k1 - 1) * rsb1 + (n1 - 1) * csb1 + (k0 - 1) * rsb0 +
+                    (n0 - 1) * csb0 + 1;
+  }
+
+  if (m1 == 0 || n1 == 0) {
+    h->c_pack.len = 0;
+  } else {
+    h->c_pack.len = (m1 - 1) * rsc1 + (n1 - 1) * csc1 + (m0 - 1) * rsc0 +
+                    (n0 - 1) * csc0 + 1;
+  }
+
+  // Allocate buffers
+  SKL_TEST_BUF_CREATE(t, __bf16, &h->a_pack);
+  SKL_TEST_BUF_CREATE(t, __bf16, &h->b_pack);
+  SKL_TEST_BUF_CREATE(t, float, &h->c_pack);
+  if (h->steps.verify) {
+    h->ctx.a_wide =
+        h->a_pack.len ? malloc(h->a_pack.len * sizeof(*(h->ctx.a_wide))) : NULL;
+    h->ctx.b_wide =
+        h->b_pack.len ? malloc(h->b_pack.len * sizeof(*(h->ctx.b_wide))) : NULL;
+    h->ctx.ref_c =
+        h->c_pack.len ? malloc(h->c_pack.len * sizeof(*(h->ctx.ref_c))) : NULL;
+    h->ctx.bound =
+        h->c_pack.len ? malloc(h->c_pack.len * sizeof(*(h->ctx.bound))) : NULL;
+    if (h->c_pack.len) {
+      memcpy(h->ctx.ref_c, h->c_pack.data,
+             h->c_pack.len * sizeof(*(h->c_pack.data)));
+    }
+  }
 }
-#endif
 
-/* The macros below set the matrix strides. */
-#if !defined(RSA0) && !defined(CSA0)
-#define RSA0 K0 // Default to row major
-#define CSA0 1
-#elif !defined(RSA0) || !defined(CSA0)
-#error Must define both RSA0 and CSA0, or neither
-#endif
-#if !defined(RSA1) && !defined(CSA1)
-#define RSA1 (M0 * K0 * K1) // Default to row major
-#define CSA1 (M0 * K0)
-#elif !defined(RSA1) || !defined(CSA1)
-#error Must define both RSA1 and CSA1, or neither
-#endif
-#if !defined(RSB0) && !defined(CSB0)
-#define RSB0 N0 // Default to row major
-#define CSB0 1
-#elif !defined(RSB0) || !defined(CSB0)
-#error Must define both RSB0 and CSB0, or neither
-#endif
-#if !defined(RSB1) && !defined(CSB1)
-#define RSB1 (K0 * N0 * N1) // Default to row major
-#define CSB1 (K0 * N0)
-#elif !defined(RSB1) || !defined(CSB1)
-#error Must define both RSB1 and CSB1, or neither
-#endif
-#if !defined(RSC0) && !defined(CSC0)
-#define RSC0 N0 // Default to row major
-#define CSC0 1
-#elif !defined(RSC0) || !defined(CSC0)
-#error Must define both RSC0 and CSC0, or neither
-#endif
-#if !defined(RSC1) && !defined(CSC1)
-#define RSC1 (M0 * N0 * N1) // Default to row major
-#define CSC1 (M0 * N0)
-#elif !defined(RSC1) || !defined(CSC1)
-#error Must define both RSC1 and CSC1, or neither
-#endif
-
-/* Input, output, reference, and error bound arrays */
-enum {
-  ALIGN = 4096,
-  // NOLINTBEGIN(misc-redundant-expression)
-  CLEN = ((M1 - 1) * RSC1 + (N1 - 1) * CSC1 + (M0 - 1) * RSC0 +
-          (N0 - 1) * CSC0 + 1),
-  ALEN = ((M1 - 1) * RSA1 + (K1 - 1) * CSA1 + (M0 - 1) * RSA0 +
-          (K0 - 1) * CSA0 + 1),
-  BLEN = ((K1 - 1) * RSB1 + (N1 - 1) * CSB1 + (K0 - 1) * RSB0 +
-          (N0 - 1) * CSB0 + 1),
-  // NOLINTEND(misc-redundant-expression)
-};
-_Alignas(ALIGN) __bf16 a[ALEN];
-_Alignas(ALIGN) __bf16 b[BLEN];
-_Alignas(ALIGN) float c[CLEN];
-#if defined(ENABLE_TEST)
-double a_wide[ALEN];
-double b_wide[BLEN];
-float ref_c[CLEN], test_c[CLEN];
-double bound[CLEN];
-#endif // ENABLE_TEST
-
-#if defined(ENABLE_TEST)
-/* Check result after executing test and reference functions.
- *
- * Compares the test_c and ref_c matrices based on a bound derived from
- * problem parameters. Returns nonzero in case of an error, and prints
- * first incorrect output matrix element. */
-int check_error(void) {
+void gemm_bf16rcprc_bf16rcprc_f32rcprc_verify(skl_test_t *t) {
   /* Compute the reference matrix output. */
-  skl_gemm_bf16rcprc_bf16rcprc_f32rcprc_ref(
-      M0, N0, K0, M1, N1, K1, ALPHA, a, RSA0, CSA0, (size_t)RSA1, (size_t)CSA1,
-      b, RSB0, CSB0, (size_t)RSB1, (size_t)CSB1, BETA, ref_c, RSC0, CSC0,
-      (size_t)RSC1, (size_t)CSC1);
+  gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
+      (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
+
+  size_t m0 = h->m0;
+  size_t n0 = h->n0;
+  size_t k0 = h->k0;
+  size_t m1 = h->m1;
+  size_t n1 = h->n1;
+  size_t k1 = h->k1;
+  size_t rsa0 = h->rsa0;
+  size_t csa0 = h->csa0;
+  size_t rsa1 = h->rsa1;
+  size_t csa1 = h->csa1;
+  size_t rsb0 = h->rsb0;
+  size_t csb0 = h->csb0;
+  size_t rsb1 = h->rsb1;
+  size_t csb1 = h->csb1;
+  size_t rsc0 = h->rsc0;
+  size_t csc0 = h->csc0;
+  size_t rsc1 = h->rsc1;
+  size_t csc1 = h->csc1;
+  float alpha = h->alpha;
+  float beta = h->beta;
+  __bf16 *a_pack = h->a_pack.data;
+  __bf16 *b_pack = h->b_pack.data;
+  float *c_pack = h->c_pack.data;
+  size_t a_pack_len = h->a_pack.len;
+  size_t b_pack_len = h->b_pack.len;
+  size_t c_pack_len = h->c_pack.len;
+  double *a_wide = h->ctx.a_wide;
+  double *b_wide = h->ctx.b_wide;
+  float *ref_c = h->ctx.ref_c;
+  double *bound = h->ctx.bound;
 
   //
   // Compute the error bound array for comparing test vs reference results.
@@ -200,80 +147,93 @@ int check_error(void) {
   // Since both test and reference results have roundoff errors, we double this
   // bound using the triangle inequality to get the final comparison threshold.
   //
-  for (size_t i = 0; i < ALEN; ++i) {
-    a_wide[i] = fabsf(a[i]);
+  // Note: h->ctx.ref_c contains the original C values (copied in
+  // skl_test_init) which are needed for the |beta| * |C| term in the error
+  // bound.
+  //
+  for (size_t i = 0; i < a_pack_len; ++i) {
+    a_wide[i] = fabsf(a_pack[i]);
   }
-  for (size_t i = 0; i < BLEN; ++i) {
-    b_wide[i] = fabsf(b[i]);
+  for (size_t i = 0; i < b_pack_len; ++i) {
+    b_wide[i] = fabsf(b_pack[i]);
   }
-  for (size_t i = 0; i < CLEN; ++i) {
-    bound[i] = fabsf(c[i]);
+  for (size_t i = 0; i < c_pack_len; ++i) {
+    bound[i] = fabsf(ref_c[i]);
   }
   const int P = 24; // 23 bits of mantissa for float32 accumulator
   const double u = ldexp(1.0, -P); // Maximum relative roundoff error
-  // Compute 2 * ((1 + u)^(K + 2) - 1) by change of base formula:
-  const double roundoff_scaling = 2 * expm1((K0 * K1 + 2) * log1p(u));
+  // Compute 2 * ((1 + u)^(K1 * K0 + 2) - 1) by change of base formula:
+  const double roundoff_scaling = 2 * expm1((double)(k1 * k0 + 2) * log1p(u));
   skl_gemm_f64rcprc_f64rcprc_f64rcprc_ref(
-      M0, N0, K0, M1, N1, K1, roundoff_scaling * fabs((double)ALPHA), a_wide,
-      RSA0, CSA0, (size_t)RSA1, (size_t)CSA1, b_wide, RSB0, CSB0, (size_t)RSB1,
-      (size_t)CSB1, roundoff_scaling * fabs((double)BETA), bound, RSC0, CSC0,
-      (size_t)RSC1, (size_t)CSC1);
+      m0, n0, k0, m1, n1, k1, roundoff_scaling * fabs((double)alpha), a_wide,
+      rsa0, csa0, rsa1, csa1, b_wide, rsb0, csb0, rsb1, csb1,
+      roundoff_scaling * fabs((double)beta), bound, rsc0, csc0, rsc1, csc1);
+
+  // Compute the reference result using h->ctx.ref_c
+  // h->ctx.ref_c contains the original C values (copied in skl_test_init)
+  skl_gemm_bf16rcprc_bf16rcprc_f32rcprc_ref(
+      m0, n0, k0, m1, n1, k1, alpha, a_pack, rsa0, csa0, rsa1, csa1, b_pack,
+      rsb0, csb0, rsb1, csb1, beta, ref_c, rsc0, csc0, rsc1, csc1);
 
   /* Compare the reference and test outputs. */
-  for (size_t i1 = 0; i1 < M1; ++i1) {
-    for (size_t j1 = 0; j1 < N1; ++j1) {
-      for (size_t i0 = 0; i0 < M0; ++i0) {
-        for (size_t j0 = 0; j0 < N0; ++j0) {
-          size_t idx =
-              i1 * (size_t)RSC1 + j1 * (size_t)CSC1 + i0 * RSC0 + j0 * CSC0;
-          if (fabs((double)test_c[idx] - (double)ref_c[idx]) > bound[idx]) {
-            printf("result [%zu, %zu, %zu, %zu] (%f) != reference (%f)\n", i0,
-                   j0, i1, j1, test_c[idx], ref_c[idx]);
-            return 1;
+  for (size_t i1 = 0; i1 < m1; ++i1) {
+    for (size_t j1 = 0; j1 < n1; ++j1) {
+      for (size_t i0 = 0; i0 < m0; ++i0) {
+        for (size_t j0 = 0; j0 < n0; ++j0) {
+          size_t idx = i1 * rsc1 + j1 * csc1 + i0 * rsc0 + j0 * csc0;
+          if (fabs((double)c_pack[idx] - (double)ref_c[idx]) > bound[idx]) {
+            SKL_TEST_LOG(t, SKL_TEST_LOG_ERROR,
+                         "result [%zu, %zu, %zu, %zu] (%f) != reference (%f) "
+                         "[bound = %f]\n",
+                         i1, j1, i0, j0, c_pack[idx], ref_c[idx], bound[idx]);
+            t->status.verify_status = SKL_TEST_FAIL;
+            return;
           }
         }
       }
     }
   }
 
-  return 0;
+  /* Check for clobbered elements. */
+  skl_test_check_matrix_clobbered_rcprc(t, sizeof(*c_pack), c_pack_len, m0, n0,
+                                        m1, n1, c_pack, ref_c, rsc0, csc0, rsc1,
+                                        csc1);
 }
-#endif // ENABLE_TEST
 
-int main(void) {
-  int res = EXIT_SUCCESS;
+void gemm_bf16rcprc_bf16rcprc_f32rcprc_test_report(skl_test_t *t) {
+  gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
+      (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
 
-  printf("%s:\n", skl_test_name);
-  printf("M0 = %u, N0 = %u, K0 = %u\n", M0, N0, K0);
-  printf("M1 = %u, N1 = %u, K1 = %u\n", M1, N1, K1);
-  printf("ALPHA = %f, BETA = %f\n", ALPHA, BETA);
-  printf("RSA0 = %u, CSA0 = %u, RSA1 = %u, CSA1 = %u\n", RSA0, CSA0, RSA1,
-         CSA1);
-  printf("RSB0 = %u, CSB0 = %u, RSB1 = %u, CSB1 = %u\n", RSB0, CSB0, RSB1,
-         CSB1);
-  printf("RSC0 = %u, CSC0 = %u, RSC1 = %u, CSC1 = %u\n", RSC0, CSC0, RSC1,
-         CSC1);
+  gemm_rcprc_rcprc_rcprc_report_matrix_params(
+      t, h->m0, h->n0, h->k0, h->m1, h->n1, h->k1, h->rsa0, h->csa0, h->rsa1,
+      h->csa1, h->rsb0, h->csb0, h->rsb1, h->csb1, h->rsc0, h->csc0, h->rsc1,
+      h->csc1);
+  SKL_TEST_LOG(t, SKL_TEST_LOG_INFO, "Alpha: %f, Beta: %f\n", h->alpha,
+               h->beta);
+}
 
-  /* Populate the matrices. */
-  skl_test_init_bf16(a, ALEN, SKL_TEST_MIN_BF16, SKL_TEST_MAX_BF16);
-  skl_test_init_bf16(b, BLEN, SKL_TEST_MIN_BF16, SKL_TEST_MAX_BF16);
-  skl_test_init_f32(c, CLEN, SKL_TEST_MIN_F32, SKL_TEST_MAX_F32);
+void gemm_bf16rcprc_bf16rcprc_f32rcprc_benchmark_report(skl_test_t *t) {
+  gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
+      (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
 
-#if defined(ENABLE_TEST)
-  /* Make copies of C to write the reference and test outputs to. */
-  memcpy(ref_c, c, CLEN * sizeof(float));
-  memcpy(test_c, c, CLEN * sizeof(float));
-  SKL_TEST_NAME(M0, N0, K0, M1, N1, K1, ALPHA, a, RSA0, CSA0, (size_t)RSA1,
-                (size_t)CSA1, b, RSB0, CSB0, (size_t)RSB1, (size_t)CSB1, BETA,
-                test_c, RSC0, CSC0, (size_t)RSC1, (size_t)CSC1);
-  res += check_error();
-#endif // ENABLE_TEST
+  gemm_bf16rcprc_bf16rcprc_f32rcprc_test_report(t);
 
-  SKL_BENCHMARK_RUN(skl_test_name, M0 * N0 * K0 * M1 * N1 * K1, SKL_TEST_WARMUP,
-                    SKL_TEST_NAME, M0, N0, K0, M1, N1, K1, ALPHA, a, RSA0, CSA0,
-                    (size_t)RSA1, (size_t)CSA1, b, RSB0, CSB0, (size_t)RSB1,
-                    (size_t)CSB1, BETA, c, RSC0, CSC0, (size_t)RSC1,
-                    (size_t)CSC1);
+  size_t maccs = h->m1 * h->n1 * h->k1 * h->m0 * h->n0 * h->k0;
+  gemm_rcprc_rcprc_rcprc_report_perf(t, h->steps.warmup, maccs);
+}
 
-  return res;
+void gemm_bf16rcprc_bf16rcprc_f32rcprc_cleanup(skl_test_t *t) {
+  gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
+      (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
+
+  // Free buffers
+  SKL_TEST_BUF_FREE(t, &h->a_pack);
+  SKL_TEST_BUF_FREE(t, &h->b_pack);
+  SKL_TEST_BUF_FREE(t, &h->c_pack);
+  if (h->steps.verify) {
+    free(h->ctx.a_wide);
+    free(h->ctx.b_wide);
+    free(h->ctx.ref_c);
+    free(h->ctx.bound);
+  }
 }

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
@@ -28,9 +28,7 @@
 #pragma once
 
 #include "skl-test-driver.h"
-#include <stdbool.h>
 #include <stddef.h>
-#include <stdint.h>
 
 typedef struct {
   // Test function pointers for various steps

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @brief Test and benchmark for packed GEMM: C_pack = alpha * A_pack * B_pack +
+ * beta * C_pack.
+ *
+ * This test uses a table-driven approach where test configurations are defined
+ * in the `tests` array. Each test specifies:
+ *  - Block dimensions m0, n0, and k0
+ *  - Packed matrix dimensions m1, n1, and k1
+ *  - Scalar coefficients alpha and beta
+ *  - Row and column strides (rsa0, csa0, rsa1, csa1, rsb0, csb0, rsb1, csb1,
+ *    rsc0, csc0, rsc1, csc1)
+ *  - The GEMM kernel function to test
+ *
+ * Matrix layouts:
+ *  - A_pack is packed m1 x k1 with block size m0 x k0 and strides rsa0, csa0,
+ *    rsa1, csa1
+ *  - B_pack is packed k1 x n1 with block size k0 x n0 and strides rsb0, csb0,
+ *    rsb1, csb1
+ *  - C_pack is packed m1 x n1 with block size m0 x n0 and strides rsc0, csc0,
+ *    rsc1, csc1
+ */
+
+#pragma once
+
+#include "skl-test-driver.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+  // Test function pointers for various steps
+  // *** This field must be placed first within this struct ***
+  skl_test_steps_t steps;
+
+  // Configurable parameters (arguments to GEMM function)
+  size_t m0, n0, k0;
+  size_t m1, n1, k1;
+  float alpha;
+  size_t rsa0, csa0, rsa1, csa1;
+  size_t rsb0, csb0, rsb1, csb1;
+  float beta;
+  size_t rsc0, csc0, rsc1, csc1;
+
+  // Buffer generation settings for A_pack, B_pack, C_pack
+  SKL_TEST_BUFFER(__bf16) a_pack;
+  SKL_TEST_BUFFER(__bf16) b_pack;
+  SKL_TEST_BUFFER(float) c_pack;
+
+  // Derived parameters & buffers (private to the test harness)
+  struct {
+    double *a_wide, *b_wide;
+    float *ref_c;
+    double *bound;
+  } ctx;
+} gemm_bf16rcprc_bf16rcprc_f32rcprc_t;
+
+void gemm_bf16rcprc_bf16rcprc_f32rcprc_init(skl_test_t *t);
+void gemm_bf16rcprc_bf16rcprc_f32rcprc_verify(skl_test_t *t);
+void gemm_bf16rcprc_bf16rcprc_f32rcprc_test_report(skl_test_t *t);
+void gemm_bf16rcprc_bf16rcprc_f32rcprc_benchmark_report(skl_test_t *t);
+void gemm_bf16rcprc_bf16rcprc_f32rcprc_cleanup(skl_test_t *t);
+
+#define GEMM_BF16RCPRC_BF16RCPRC_F32RCPRC_DEFAULTS                             \
+  .a_pack = {.min = (__bf16)-1.0f,                                             \
+             .max = (__bf16)1.0f,                                              \
+             .mode = SKL_TEST_RANDOM},                                         \
+  .b_pack = {.min = (__bf16)-1.0f,                                             \
+             .max = (__bf16)1.0f,                                              \
+             .mode = SKL_TEST_RANDOM},                                         \
+  .c_pack = {.min = -1.0f, .max = 1.0f, .mode = SKL_TEST_RANDOM}

--- a/test/gemm/rvv/skl_gemm_bf16_bf16_f32_zvfbfwma.c
+++ b/test/gemm/rvv/skl_gemm_bf16_bf16_f32_zvfbfwma.c
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#include "gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h"
+#include "skl-test-driver.h"
+#include "skl.h"
+#include <stddef.h>
+
+#if !defined(__riscv_zvfbfwma)
+#error This file requires the Zvfbfwma extension
+#endif
+
+/**
+ * @brief Test cases for GEMM with Zvfbfwma extension.
+ *
+ * This test uses the gemm_bf16rcprc_bf16rcprc_f32rcprc harness with the
+ * following restrictions on the input parameters:
+ *  - The block dimensions are m0 = 1, n0 = 1, and k0 = 1
+ *  - All matrices are row-major (csa1 == 1, csb1 == 1, csc1 == 1)
+ */
+
+#define TEST                                                                   \
+  GEMM_BF16RCPRC_BF16RCPRC_F32RCPRC_DEFAULTS,                                  \
+      .steps = {                                                               \
+          .init = init,                                                        \
+          .warmup = NULL,                                                      \
+          .execute = execute,                                                  \
+          .verify = gemm_bf16rcprc_bf16rcprc_f32rcprc_verify,                  \
+          .report = gemm_bf16rcprc_bf16rcprc_f32rcprc_test_report,             \
+          .cleanup = gemm_bf16rcprc_bf16rcprc_f32rcprc_cleanup,                \
+  }
+
+#define BENCH                                                                  \
+  GEMM_BF16RCPRC_BF16RCPRC_F32RCPRC_DEFAULTS,                                  \
+      .steps = {                                                               \
+          .init = init,                                                        \
+          .warmup = execute,                                                   \
+          .execute = execute,                                                  \
+          .verify = NULL,                                                      \
+          .report = gemm_bf16rcprc_bf16rcprc_f32rcprc_benchmark_report,        \
+          .cleanup = gemm_bf16rcprc_bf16rcprc_f32rcprc_cleanup,                \
+  }
+
+static void init(skl_test_t *t);
+static void execute(skl_test_t *t);
+
+// clang-format off
+gemm_bf16rcprc_bf16rcprc_f32rcprc_t tests[] = {
+#ifdef SKL_ENABLE_BENCHMARKS
+    // Benchmark tests
+    {BENCH, .m1 =  64, .n1 = 128, .k1 = 128, .alpha = 1.f},
+#endif // SKL_ENABLE_BENCHMARKS
+
+#ifdef SKL_ENABLE_TESTS
+    // Verification tests - comprehensive coverage for RVV GEMM
+    /* Edge cases: minimal dimensions */
+    {TEST, .m1 = 1,   .n1 = 1,   .k1 = 0,  .alpha = 1.f},
+    {TEST, .m1 = 1,   .n1 = 1,   .k1 = 1,  .alpha = 1.f},
+    /* Small odd dimensions for remainder handling */
+    {TEST, .m1 = 7,   .n1 = 7,   .k1 = 7,  .alpha = 1.f},
+    {TEST, .m1 = 17,  .n1 = 17,  .k1 = 17, .alpha = 1.f},
+    /* Skinny matrices (one dimension = 1) */
+    {TEST, .m1 = 1,   .n1 = 33,  .k1 = 31, .alpha = 1.f},
+    {TEST, .m1 = 33,  .n1 = 1,   .k1 = 31, .alpha = 1.f},
+    /* k=0 edge case (C = beta*C, no A*B contribution) */
+    {TEST, .m1 = 33,  .n1 = 33,  .k1 = 0,  .alpha = 1.f},
+    {TEST, .m1 = 16,  .n1 = 16,  .k1 = 0,  .alpha = 1.f,  .beta = 1.f},
+    /* Vector length boundary tests (multiples of 4, 8, 16, 32) */
+    {TEST, .m1 = 16,  .n1 = 16,  .k1 = 16, .alpha = 1.f},
+    {TEST, .m1 = 32,  .n1 = 32,  .k1 = 32, .alpha = 1.f},
+    /* Near-boundary tests (±1 from vector length multiples) */
+    {TEST, .m1 = 15,  .n1 = 17,  .k1 = 31, .alpha = 1.f},
+    {TEST, .m1 = 31,  .n1 = 33,  .k1 = 15, .alpha = 1.f},
+    /* Wide and tall matrices */
+    {TEST, .m1 = 33,  .n1 = 129, .k1 = 32, .alpha = 1.f},
+    {TEST, .m1 = 129, .n1 = 33,  .k1 = 32, .alpha = 1.f},
+    {TEST, .m1 = 31,  .n1 = 133, .k1 = 32, .alpha = 1.f},
+    /* Beta scaling test (beta=1, accumulate into existing C) */
+    {TEST, .m1 = 32,  .n1 = 32,  .k1 = 32, .alpha = 1.f,  .beta = 1.f},
+#endif // SKL_ENABLE_TESTS
+};
+// clang-format on
+
+static skl_test_suite_t suite = {
+    .name = "skl_gemm_bf16_bf16_f32_zvfbfwma",
+    .num_tests = sizeof(tests) / sizeof(tests[0]),
+    .test_size = sizeof(gemm_bf16rcprc_bf16rcprc_f32rcprc_t),
+    .tests = tests};
+
+static void init(skl_test_t *t) {
+  const gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
+      (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
+
+  SKL_TEST_REQUIRE(t, init_status, h->m0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->n0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->k0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->csa1 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->csb1 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->csc1 == 1);
+
+  gemm_bf16rcprc_bf16rcprc_f32rcprc_init(t);
+}
+
+static void execute(skl_test_t *t) {
+  const gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
+      (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
+
+  skl_gemm_bf16_bf16_f32_zvfbfwma(h->m1, h->n1, h->k1, h->alpha, h->a_pack.data,
+                                  h->rsa1, h->b_pack.data, h->rsb1, h->beta,
+                                  h->c_pack.data, h->rsc1);
+}
+
+int main(void) {
+  // Set default strides: all matrices are row-major
+  for (size_t i = 0; i < suite.num_tests; ++i) {
+    tests[i].m0 = 1;
+    tests[i].n0 = 1;
+    tests[i].k0 = 1;
+
+    tests[i].rsa0 = 1;
+    tests[i].csa0 = 1;
+    tests[i].rsa1 = tests[i].rsa1 ? tests[i].rsa1 : tests[i].k1;
+    tests[i].csa1 = tests[i].csa1 ? tests[i].csa1 : 1;
+
+    tests[i].rsb0 = 1;
+    tests[i].csb0 = 1;
+    tests[i].rsb1 = tests[i].rsb1 ? tests[i].rsb1 : tests[i].n1;
+    tests[i].csb1 = tests[i].csb1 ? tests[i].csb1 : 1;
+
+    tests[i].rsc0 = 1;
+    tests[i].csc0 = 1;
+    tests[i].rsc1 = tests[i].rsc1 ? tests[i].rsc1 : tests[i].n1;
+    tests[i].csc1 = tests[i].csc1 ? tests[i].csc1 : 1;
+  }
+
+  return skl_test_driver_run_suite(&suite);
+}

--- a/test/gemm/rvv/skl_gemm_bf16_bf16_f32_zvfbfwma.c
+++ b/test/gemm/rvv/skl_gemm_bf16_bf16_f32_zvfbfwma.c
@@ -13,7 +13,7 @@
 #endif
 
 /**
- * @brief Test cases for GEMM with Zvfbfwma extension.
+ * @brief Test cases for the skl_gemm_bf16_bf16_f32_zvfbfwma kernel.
  *
  * This test uses the gemm_bf16rcprc_bf16rcprc_f32rcprc harness with the
  * following restrictions on the input parameters:
@@ -56,29 +56,36 @@ gemm_bf16rcprc_bf16rcprc_f32rcprc_t tests[] = {
 #ifdef SKL_ENABLE_TESTS
     // Verification tests - comprehensive coverage for RVV GEMM
     /* Edge cases: minimal dimensions */
-    {TEST, .m1 = 1,   .n1 = 1,   .k1 = 0,  .alpha = 1.f},
-    {TEST, .m1 = 1,   .n1 = 1,   .k1 = 1,  .alpha = 1.f},
+    {TEST, .m1 = 1,   .n1 = 1,   .k1 = 0,  .alpha = 2.f},
+    {TEST, .m1 = 1,   .n1 = 1,   .k1 = 1,  .alpha = 2.f},
+
     /* Small odd dimensions for remainder handling */
-    {TEST, .m1 = 7,   .n1 = 7,   .k1 = 7,  .alpha = 1.f},
-    {TEST, .m1 = 17,  .n1 = 17,  .k1 = 17, .alpha = 1.f},
+    {TEST, .m1 = 7,   .n1 = 7,   .k1 = 7,  .alpha = 2.f},
+    {TEST, .m1 = 17,  .n1 = 17,  .k1 = 17, .alpha = 2.f},
+
     /* Skinny matrices (one dimension = 1) */
-    {TEST, .m1 = 1,   .n1 = 33,  .k1 = 31, .alpha = 1.f},
-    {TEST, .m1 = 33,  .n1 = 1,   .k1 = 31, .alpha = 1.f},
+    {TEST, .m1 = 1,   .n1 = 33,  .k1 = 31, .alpha = 2.f},
+    {TEST, .m1 = 33,  .n1 = 1,   .k1 = 31, .alpha = 2.f},
+
     /* k=0 edge case (C = beta*C, no A*B contribution) */
-    {TEST, .m1 = 33,  .n1 = 33,  .k1 = 0,  .alpha = 1.f},
-    {TEST, .m1 = 16,  .n1 = 16,  .k1 = 0,  .alpha = 1.f,  .beta = 1.f},
+    {TEST, .m1 = 33,  .n1 = 33,  .k1 = 0,  .alpha = 2.f},
+    {TEST, .m1 = 16,  .n1 = 16,  .k1 = 0,  .alpha = 2.f,  .beta = 2.f},
+
     /* Vector length boundary tests (multiples of 4, 8, 16, 32) */
-    {TEST, .m1 = 16,  .n1 = 16,  .k1 = 16, .alpha = 1.f},
-    {TEST, .m1 = 32,  .n1 = 32,  .k1 = 32, .alpha = 1.f},
+    {TEST, .m1 = 16,  .n1 = 16,  .k1 = 16, .alpha = 2.f},
+    {TEST, .m1 = 32,  .n1 = 32,  .k1 = 32, .alpha = 2.f},
+
     /* Near-boundary tests (±1 from vector length multiples) */
-    {TEST, .m1 = 15,  .n1 = 17,  .k1 = 31, .alpha = 1.f},
-    {TEST, .m1 = 31,  .n1 = 33,  .k1 = 15, .alpha = 1.f},
+    {TEST, .m1 = 15,  .n1 = 17,  .k1 = 31, .alpha = 2.f},
+    {TEST, .m1 = 31,  .n1 = 33,  .k1 = 15, .alpha = 2.f},
+
     /* Wide and tall matrices */
-    {TEST, .m1 = 33,  .n1 = 129, .k1 = 32, .alpha = 1.f},
-    {TEST, .m1 = 129, .n1 = 33,  .k1 = 32, .alpha = 1.f},
-    {TEST, .m1 = 31,  .n1 = 133, .k1 = 32, .alpha = 1.f},
+    {TEST, .m1 = 33,  .n1 = 129, .k1 = 32, .alpha = 2.f},
+    {TEST, .m1 = 129, .n1 = 33,  .k1 = 32, .alpha = 2.f},
+    {TEST, .m1 = 31,  .n1 = 133, .k1 = 32, .alpha = 2.f},
+
     /* Beta scaling test (beta=1, accumulate into existing C) */
-    {TEST, .m1 = 32,  .n1 = 32,  .k1 = 32, .alpha = 1.f,  .beta = 1.f},
+    {TEST, .m1 = 32,  .n1 = 32,  .k1 = 32, .alpha = 2.f,  .beta = 1.f},
 #endif // SKL_ENABLE_TESTS
 };
 // clang-format on

--- a/test/gemm/xsfmm/skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#include "gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h"
+#include "skl-test-driver.h"
+#include "skl.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+#if !defined(__riscv_xsfmm32a16f)
+#error This file requires the Xsfmm32a16f extension
+#endif
+
+/**
+ * @brief Test cases for GEMM with Xsfmm32a16f extension.
+ *
+ * This test uses the gemm_bf16rcprc_bf16rcprc_f32rcprc harness with the
+ * following restrictions on the input parameters:
+ *  - The block dimensions are m0 = 1, n0 = 1, and k0 = 1
+ *  - Matrix A is column-major (rsa1 == 1)
+ *  - Matrix B is row-major (csb1 == 1)
+ *  - Matrix C is row-major (csc1 == 1)
+ *  - Alpha must be 1.0
+ *  - Beta must be 0.0 or 1.0
+ *
+ * The kernel computes C = A * B (beta = 0) or C += A * B (beta = 1).
+ */
+
+#define TEST                                                                   \
+  GEMM_BF16RCPRC_BF16RCPRC_F32RCPRC_DEFAULTS,                                  \
+      .steps = {                                                               \
+          .init = init,                                                        \
+          .warmup = NULL,                                                      \
+          .execute = execute,                                                  \
+          .verify = gemm_bf16rcprc_bf16rcprc_f32rcprc_verify,                  \
+          .report = gemm_bf16rcprc_bf16rcprc_f32rcprc_test_report,             \
+          .cleanup = gemm_bf16rcprc_bf16rcprc_f32rcprc_cleanup,                \
+  }
+
+#define BENCH                                                                  \
+  GEMM_BF16RCPRC_BF16RCPRC_F32RCPRC_DEFAULTS,                                  \
+      .steps = {                                                               \
+          .init = init,                                                        \
+          .warmup = execute,                                                   \
+          .execute = execute,                                                  \
+          .verify = NULL,                                                      \
+          .report = gemm_bf16rcprc_bf16rcprc_f32rcprc_benchmark_report,        \
+          .cleanup = gemm_bf16rcprc_bf16rcprc_f32rcprc_cleanup,                \
+  }
+
+static void init(skl_test_t *t);
+static void execute(skl_test_t *t);
+
+// clang-format off
+gemm_bf16rcprc_bf16rcprc_f32rcprc_t tests[] = {
+#ifdef SKL_ENABLE_BENCHMARKS
+    // Benchmark tests
+    {BENCH, .m1 = 128, .n1 = 128, .k1 = 2048, .alpha = 1.f, .beta = 0.f},
+    {BENCH, .m1 = 128, .n1 = 128, .k1 = 2048, .alpha = 1.f, .beta = 1.f},
+#endif // SKL_ENABLE_BENCHMARKS
+
+#ifdef SKL_ENABLE_TESTS
+    // Verification tests - comprehensive coverage for Xsfmm A1B01 layout (ETE=64)
+    /* Edge case: 1x1 matrix with k=0 (no computation, C = beta * C) */
+    {TEST, .m1 = 1,   .n1 = 1,   .k1 = 0, .alpha = 1.f},
+    /* Edge case: 1x1 matrix with k=1 (minimal computation) */
+    {TEST, .m1 = 1,   .n1 = 1,   .k1 = 1, .alpha = 1.f},
+    /* ETE-1 boundary: 63 = 64-1, tests just below tile edge */
+    {TEST, .m1 = 63,  .n1 = 63,  .k1 = 1, .alpha = 1.f},
+    {TEST, .m1 = 63,  .n1 = 63,  .k1 = 2, .alpha = 1.f},
+    {TEST, .m1 = 63,  .n1 = 63,  .k1 = 5, .alpha = 1.f},
+    /* Exact ETE boundary: 64x64 tiles */
+    {TEST, .m1 = 64,  .n1 = 64,  .k1 = 1, .alpha = 1.f},
+    {TEST, .m1 = 64,  .n1 = 64,  .k1 = 5, .alpha = 1.f},
+    /* ETE+1 boundary: 65 = 64+1, tests just past tile edge */
+    {TEST, .m1 = 65,  .n1 = 65,  .k1 = 1, .alpha = 1.f},
+    {TEST, .m1 = 65,  .n1 = 65,  .k1 = 5, .alpha = 1.f},
+    /* Multi-tile: 2*ETE = 128 */
+    {TEST, .m1 = 128, .n1 = 128, .k1 = 1, .alpha = 1.f},
+    {TEST, .m1 = 128, .n1 = 128, .k1 = 5, .alpha = 1.f},
+    /* Multi-tile+1: 2*ETE+1 = 129 */
+    {TEST, .m1 = 129, .n1 = 129, .k1 = 1, .alpha = 1.f},
+    {TEST, .m1 = 129, .n1 = 129, .k1 = 5, .alpha = 1.f},
+    /* Non-square matrices (rectangular tiles) */
+    {TEST, .m1 = 129, .n1 = 63,  .k1 = 1, .alpha = 1.f},
+    {TEST, .m1 = 65,  .n1 = 129, .k1 = 2, .alpha = 1.f},
+    {TEST, .m1 = 64,  .n1 = 128, .k1 = 5, .alpha = 1.f},
+    /* Beta=1 tests (accumulate into existing C) */
+    {TEST, .m1 = 65,  .n1 = 65,  .k1 = 0,  .alpha = 1.f, .beta = 1.f},
+    {TEST, .m1 = 65,  .n1 = 65,  .k1 = 1,  .alpha = 1.f, .beta = 1.f},
+    {TEST, .m1 = 65,  .n1 = 65,  .k1 = 33, .alpha = 1.f, .beta = 1.f},
+    {TEST, .m1 = 128, .n1 = 128, .k1 = 33, .alpha = 1.f, .beta = 1.f},
+#endif // SKL_ENABLE_TESTS
+};
+// clang-format on
+
+static skl_test_suite_t suite = {
+    .name = "skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f",
+    .num_tests = sizeof(tests) / sizeof(tests[0]),
+    .test_size = sizeof(gemm_bf16rcprc_bf16rcprc_f32rcprc_t),
+    .tests = tests};
+
+static void init(skl_test_t *t) {
+  const gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
+      (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
+
+  SKL_TEST_REQUIRE(t, init_status, h->m0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->n0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->k0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->rsa1 == 1); // Note: column-major
+  SKL_TEST_REQUIRE(t, init_status, h->csb1 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->csc1 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->alpha == 1.f);
+  SKL_TEST_REQUIRE(t, init_status, h->beta == 0.f || h->beta == 1.f);
+
+  gemm_bf16rcprc_bf16rcprc_f32rcprc_init(t);
+}
+
+static void execute(skl_test_t *t) {
+  const gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
+      (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
+
+  skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f(
+      h->m1, h->n1, h->k1, h->a_pack.data, h->csa1, h->b_pack.data, h->rsb1,
+      h->c_pack.data, h->rsc1, h->beta != 0.f);
+}
+
+int main(void) {
+  // Set default strides: A is column-major, B is row-major, C is row-major
+  for (size_t i = 0; i < suite.num_tests; ++i) {
+    tests[i].m0 = 1;
+    tests[i].n0 = 1;
+    tests[i].k0 = 1;
+
+    tests[i].rsa0 = 1;
+    tests[i].csa0 = 1;
+    tests[i].rsa1 = tests[i].rsa1 ? tests[i].rsa1 : 1;
+    tests[i].csa1 = tests[i].csa1 ? tests[i].csa1 : tests[i].m1;
+
+    tests[i].rsb0 = 1;
+    tests[i].csb0 = 1;
+    tests[i].rsb1 = tests[i].rsb1 ? tests[i].rsb1 : tests[i].n1;
+    tests[i].csb1 = tests[i].csb1 ? tests[i].csb1 : 1;
+
+    tests[i].rsc0 = 1;
+    tests[i].csc0 = 1;
+    tests[i].rsc1 = tests[i].rsc1 ? tests[i].rsc1 : tests[i].n1;
+    tests[i].csc1 = tests[i].csc1 ? tests[i].csc1 : 1;
+  }
+
+  return skl_test_driver_run_suite(&suite);
+}

--- a/test/gemm/xsfmm/skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -6,7 +6,6 @@
 #include "gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h"
 #include "skl-test-driver.h"
 #include "skl.h"
-#include <stdbool.h>
 #include <stddef.h>
 
 #if !defined(__riscv_xsfmm32a16f)

--- a/test/gemm/xsfmm/skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -56,8 +56,8 @@ static void execute(skl_test_t *t);
 gemm_bf16rcprc_bf16rcprc_f32rcprc_t tests[] = {
 #ifdef SKL_ENABLE_BENCHMARKS
     // Benchmark tests
-    {BENCH, .m1 = 128, .n1 = 128, .k1 = 2048, .alpha = 1.f, .beta = 0.f},
-    {BENCH, .m1 = 128, .n1 = 128, .k1 = 2048, .alpha = 1.f, .beta = 1.f},
+    {BENCH, .m1 = 128, .n1 = 128, .k1 = 4096, .alpha = 1.f, .beta = 0.f},
+    {BENCH, .m1 = 128, .n1 = 128, .k1 = 4096, .alpha = 1.f, .beta = 1.f},
 #endif // SKL_ENABLE_BENCHMARKS
 
 #ifdef SKL_ENABLE_TESTS

--- a/test/gemm/xsfmm/skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f.c
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#include "gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h"
+#include "gemm/skl_test_gemm.h"
+#include "skl-test-driver.h"
+#include "skl.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+#if !defined(__riscv_xsfmm32a16f)
+#error This file requires the Xsfmm32a16f extension
+#endif
+
+/**
+ * @brief Test cases for the skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f
+ * kernel.
+ *
+ * This test uses the gemm_bf16rcprc_bf16rcprc_f32rcprc harness with the
+ * following restrictions on the input parameters:
+ *  - The block dimensions are m0 = TE, n0 = TE, and k0 = 1
+ *  - Matrix A_pack is block-row-major with column-major blocks (rsa0 == 1, csa1
+ *    == m0 * k0)
+ *  - Matrix B_pack is block-column-major with row-major blocks (csb0 == 1, rsb1
+ *    == k0 * n0)
+ *  - Matrix C_pack has row-major blocks (rsc0 == n0, csc0 == 1)
+ *  - Alpha must be 1.0
+ *  - Beta must be 0.0 or 1.0
+ *
+ * The kernel computes C_pack = A_pack * B_pack (beta = 0) or C_pack += A_pack *
+ * B_pack (beta = 1).
+ */
+
+#define TEST                                                                   \
+  GEMM_BF16RCPRC_BF16RCPRC_F32RCPRC_DEFAULTS,                                  \
+      .steps = {                                                               \
+          .init = init,                                                        \
+          .warmup = NULL,                                                      \
+          .execute = execute,                                                  \
+          .verify = gemm_bf16rcprc_bf16rcprc_f32rcprc_verify,                  \
+          .report = gemm_bf16rcprc_bf16rcprc_f32rcprc_test_report,             \
+          .cleanup = gemm_bf16rcprc_bf16rcprc_f32rcprc_cleanup,                \
+  }
+
+#define BENCH                                                                  \
+  GEMM_BF16RCPRC_BF16RCPRC_F32RCPRC_DEFAULTS,                                  \
+      .steps = {                                                               \
+          .init = init,                                                        \
+          .warmup = execute,                                                   \
+          .execute = execute,                                                  \
+          .verify = NULL,                                                      \
+          .report = gemm_bf16rcprc_bf16rcprc_f32rcprc_benchmark_report,        \
+          .cleanup = gemm_bf16rcprc_bf16rcprc_f32rcprc_cleanup,                \
+  }
+
+static void init(skl_test_t *t);
+static void execute(skl_test_t *t);
+
+// clang-format off
+gemm_bf16rcprc_bf16rcprc_f32rcprc_t tests[] = {
+#ifdef SKL_ENABLE_BENCHMARKS
+    // Benchmark tests
+    {BENCH, .m1 = 2, .n1 = 2, .k1 = 2048, .alpha = 1.f, .beta = 0.f},
+    {BENCH, .m1 = 2, .n1 = 2, .k1 = 2048, .alpha = 1.f, .beta = 1.f},
+#endif // SKL_ENABLE_BENCHMARKS
+
+#ifdef SKL_ENABLE_TESTS
+    // Verification tests - comprehensive coverage for Xsfmm A1B01
+    {TEST, .m1 = 7, .n1 = 1, .k1 = 0, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 2, .k1 = 0, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 3, .k1 = 0, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 4, .k1 = 0, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 5, .k1 = 0, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 6, .k1 = 0, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 7, .k1 = 0, .alpha = 1.f, .beta = 0.f},
+
+    {TEST, .m1 = 7, .n1 = 1, .k1 = 1, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 2, .k1 = 1, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 3, .k1 = 1, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 4, .k1 = 1, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 5, .k1 = 1, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 6, .k1 = 1, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 7, .k1 = 1, .alpha = 1.f, .beta = 0.f},
+
+    {TEST, .m1 = 7, .n1 = 1, .k1 = 2, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 2, .k1 = 2, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 3, .k1 = 2, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 4, .k1 = 2, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 5, .k1 = 2, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 6, .k1 = 2, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 7, .k1 = 2, .alpha = 1.f, .beta = 0.f},
+
+    {TEST, .m1 = 1, .n1 = 1, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 1, .n1 = 2, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 1, .n1 = 3, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 1, .n1 = 4, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 1, .n1 = 5, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 1, .n1 = 6, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 1, .n1 = 7, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+
+    {TEST, .m1 = 2, .n1 = 1, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 2, .n1 = 2, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 2, .n1 = 3, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 2, .n1 = 4, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 2, .n1 = 5, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 2, .n1 = 6, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 2, .n1 = 7, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+
+    {TEST, .m1 = 3, .n1 = 1, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 3, .n1 = 2, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 3, .n1 = 3, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 3, .n1 = 4, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 3, .n1 = 5, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 3, .n1 = 6, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 3, .n1 = 7, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+
+    {TEST, .m1 = 4, .n1 = 1, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 4, .n1 = 2, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 4, .n1 = 3, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 4, .n1 = 4, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 4, .n1 = 5, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 4, .n1 = 6, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 4, .n1 = 7, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+
+    {TEST, .m1 = 5, .n1 = 1, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 5, .n1 = 2, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 5, .n1 = 3, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 5, .n1 = 4, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 5, .n1 = 5, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 5, .n1 = 6, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 5, .n1 = 7, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+
+    {TEST, .m1 = 6, .n1 = 1, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 6, .n1 = 2, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 6, .n1 = 3, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 6, .n1 = 4, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 6, .n1 = 5, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 6, .n1 = 6, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 6, .n1 = 7, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+
+    {TEST, .m1 = 7, .n1 = 1, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 2, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 3, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 4, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 5, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 6, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 7, .k1 = 15, .alpha = 1.f, .beta = 0.f},
+
+    {TEST, .m1 = 7, .n1 = 1, .k1 = 15, .alpha = 1.f, .beta = 1.f},
+    {TEST, .m1 = 7, .n1 = 2, .k1 = 15, .alpha = 1.f, .beta = 1.f},
+    {TEST, .m1 = 7, .n1 = 3, .k1 = 15, .alpha = 1.f, .beta = 1.f},
+    {TEST, .m1 = 7, .n1 = 4, .k1 = 15, .alpha = 1.f, .beta = 1.f},
+    {TEST, .m1 = 7, .n1 = 5, .k1 = 15, .alpha = 1.f, .beta = 1.f},
+    {TEST, .m1 = 7, .n1 = 6, .k1 = 15, .alpha = 1.f, .beta = 1.f},
+    {TEST, .m1 = 7, .n1 = 7, .k1 = 15, .alpha = 1.f, .beta = 1.f},
+#endif // SKL_ENABLE_TESTS
+};
+// clang-format on
+
+static skl_test_suite_t suite = {
+    .name = "skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f",
+    .num_tests = sizeof(tests) / sizeof(tests[0]),
+    .test_size = sizeof(gemm_bf16rcprc_bf16rcprc_f32rcprc_t),
+    .tests = tests};
+
+static void init(skl_test_t *t) {
+  const gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
+      (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
+
+  size_t ete = skl_get_ete_xsfmmbase();
+  SKL_TEST_REQUIRE(t, init_status, h->m0 == ete);
+  SKL_TEST_REQUIRE(t, init_status, h->n0 == ete);
+  SKL_TEST_REQUIRE(t, init_status, h->k0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->rsa0 == 1); // Note: column-major
+  SKL_TEST_REQUIRE(t, init_status, h->csa1 == h->m0 * h->k0);
+  SKL_TEST_REQUIRE(t, init_status, h->csb0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->rsb1 == h->k0 * h->n0);
+  SKL_TEST_REQUIRE(t, init_status, h->rsc0 == h->n0);
+  SKL_TEST_REQUIRE(t, init_status, h->csc0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->alpha == 1.f);
+  SKL_TEST_REQUIRE(t, init_status, h->beta == 0.f || h->beta == 1.f);
+
+  gemm_bf16rcprc_bf16rcprc_f32rcprc_init(t);
+}
+
+static void execute(skl_test_t *t) {
+  const gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
+      (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
+
+  skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+      h->m1, h->n1, h->k1, h->a_pack.data, h->rsa1, h->b_pack.data, h->csb1,
+      h->c_pack.data, h->rsc1, h->csc1, h->beta != 0.f);
+}
+
+int main(void) {
+  // Set default strides: A is block-row-major with column-major blocks, B is
+  // block-column-major with row-major blocks, C has row-major blocks
+  size_t ete = skl_get_ete_xsfmmbase();
+  for (size_t i = 0; i < suite.num_tests; ++i) {
+    tests[i].m0 = ete;
+    tests[i].n0 = ete;
+    tests[i].k0 = 1;
+
+    tests[i].rsa0 = 1;
+    tests[i].csa0 = tests[i].m0;
+    tests[i].csa1 = tests[i].m0 * tests[i].k0;
+    tests[i].rsa1 = tests[i].rsa1 ? tests[i].rsa1 : tests[i].k1 * tests[i].csa1;
+
+    tests[i].rsb0 = tests[i].n0;
+    tests[i].csb0 = 1;
+    tests[i].rsb1 = tests[i].k0 * tests[i].n0;
+    tests[i].csb1 = tests[i].csb1 ? tests[i].csb1 : tests[i].k1 * tests[i].rsb1;
+
+    tests[i].rsc0 = tests[i].n0;
+    tests[i].csc0 = 1;
+    tests[i].csc1 = tests[i].csc1 ? tests[i].csc1 : tests[i].m0 * tests[i].n0;
+    tests[i].rsc1 = tests[i].rsc1 ? tests[i].rsc1 : tests[i].n1 * tests[i].csc1;
+  }
+
+  return skl_test_driver_run_suite(&suite);
+}

--- a/test/gemm/xsfmm/skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f.c
@@ -61,8 +61,8 @@ static void execute(skl_test_t *t);
 gemm_bf16rcprc_bf16rcprc_f32rcprc_t tests[] = {
 #ifdef SKL_ENABLE_BENCHMARKS
     // Benchmark tests
-    {BENCH, .m1 = 2, .n1 = 2, .k1 = 2048, .alpha = 1.f, .beta = 0.f},
-    {BENCH, .m1 = 2, .n1 = 2, .k1 = 2048, .alpha = 1.f, .beta = 1.f},
+    {BENCH, .m1 = 2, .n1 = 2, .k1 = 4096, .alpha = 1.f, .beta = 0.f},
+    {BENCH, .m1 = 2, .n1 = 2, .k1 = 4096, .alpha = 1.f, .beta = 1.f},
 #endif // SKL_ENABLE_BENCHMARKS
 
 #ifdef SKL_ENABLE_TESTS
@@ -90,6 +90,30 @@ gemm_bf16rcprc_bf16rcprc_f32rcprc_t tests[] = {
     {TEST, .m1 = 7, .n1 = 5, .k1 = 2, .alpha = 1.f, .beta = 0.f},
     {TEST, .m1 = 7, .n1 = 6, .k1 = 2, .alpha = 1.f, .beta = 0.f},
     {TEST, .m1 = 7, .n1 = 7, .k1 = 2, .alpha = 1.f, .beta = 0.f},
+
+    {TEST, .m1 = 7, .n1 = 1, .k1 = 3, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 2, .k1 = 3, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 3, .k1 = 3, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 4, .k1 = 3, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 5, .k1 = 3, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 6, .k1 = 3, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 7, .k1 = 3, .alpha = 1.f, .beta = 0.f},
+
+    {TEST, .m1 = 7, .n1 = 1, .k1 = 4, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 2, .k1 = 4, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 3, .k1 = 4, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 4, .k1 = 4, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 5, .k1 = 4, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 6, .k1 = 4, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 7, .k1 = 4, .alpha = 1.f, .beta = 0.f},
+
+    {TEST, .m1 = 7, .n1 = 1, .k1 = 5, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 2, .k1 = 5, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 3, .k1 = 5, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 4, .k1 = 5, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 5, .k1 = 5, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 6, .k1 = 5, .alpha = 1.f, .beta = 0.f},
+    {TEST, .m1 = 7, .n1 = 7, .k1 = 5, .alpha = 1.f, .beta = 0.f},
 
     {TEST, .m1 = 1, .n1 = 1, .k1 = 15, .alpha = 1.f, .beta = 0.f},
     {TEST, .m1 = 1, .n1 = 2, .k1 = 15, .alpha = 1.f, .beta = 0.f},

--- a/test/gemm/xsfmm/skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f.c
@@ -7,7 +7,6 @@
 #include "gemm/skl_test_gemm.h"
 #include "skl-test-driver.h"
 #include "skl.h"
-#include <stdbool.h>
 #include <stddef.h>
 
 #if !defined(__riscv_xsfmm32a16f)


### PR DESCRIPTION
This converts the widening bf16 GEMM harness into the new format introduced in #56. Tests for these three kernels are added using the new harness:
- `skl_gemm_bf16_bf16_f32_zvfbfwma`
- `skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f`
- `skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f`