### PR TITLE
[NFC] Update the License to MIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+# SPDX-License-Identifier: MIT
+
 cmake_minimum_required(VERSION 3.21)
 
 project(SKL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 # Licensed under the MIT License.
 # See LICENSE file in the project root for full license information.
 # SPDX-License-Identifier: MIT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## License
 
-SKL is licensed under the terms of the Apache License v2.0: [LICENSE](LICENSE.txt)
+SKL is licensed under the terms of the MIT License: [LICENSE](LICENSE.txt)
 
 By contributing to this project, you agree to this license and copyright terms and release your contribution under these terms.
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 SiFive, Inc.
+Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,177 +1,20 @@
+MIT License
 
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Copyright (c) 2026 SiFive, Inc.
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
-   1. Definitions.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/cmake/detect_riscv_extensions.cmake
+++ b/cmake/detect_riscv_extensions.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 # Licensed under the MIT License.
 # See LICENSE file in the project root for full license information.
 # SPDX-License-Identifier: MIT

--- a/cmake/detect_riscv_extensions.cmake
+++ b/cmake/detect_riscv_extensions.cmake
@@ -1,3 +1,7 @@
+# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+# SPDX-License-Identifier: MIT
 
 # Use C preprocessor `#define`s to detect which RISC-V extensions are enabled.
 execute_process(COMMAND ${CMAKE_C_COMPILER} -xc -dM -E ${SKL_COMPILE_OPTIONS} /dev/null

--- a/cmake/riscv.cmake
+++ b/cmake/riscv.cmake
@@ -1,3 +1,8 @@
+# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+# SPDX-License-Identifier: MIT
+
 set(CMAKE_SYSTEM_PROCESSOR riscv)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")

--- a/cmake/riscv.cmake
+++ b/cmake/riscv.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 # Licensed under the MIT License.
 # See LICENSE file in the project root for full license information.
 # SPDX-License-Identifier: MIT

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 # Licensed under the MIT License.
 # See LICENSE file in the project root for full license information.
 # SPDX-License-Identifier: MIT

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+# SPDX-License-Identifier: MIT
 
 function(skl_add_example EXAMPLE_NAME EXAMPLE_SRCS REQUIRED_EXTENSIONS OPTS)
   # Only add the example if all extensions in REQUIRED_EXTENSIONS

--- a/example/conv2d/conv2d_nhwc_f32.c
+++ b/example/conv2d/conv2d_nhwc_f32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/example/conv2d/conv2d_nhwc_f32.c
+++ b/example/conv2d/conv2d_nhwc_f32.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @file conv2d_nhwc_f32.c

--- a/example/conv2d/conv2d_nhwc_f32.c
+++ b/example/conv2d/conv2d_nhwc_f32.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @file conv2d_nhwc_f32.c

--- a/example/conv2d/conv2d_nhwc_f32.c
+++ b/example/conv2d/conv2d_nhwc_f32.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @file conv2d_nhwc_f32.c

--- a/example/conv2d/conv2d_nhwc_f32.h
+++ b/example/conv2d/conv2d_nhwc_f32.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/example/conv2d/conv2d_nhwc_f32.h
+++ b/example/conv2d/conv2d_nhwc_f32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/example/conv2d/conv2d_nhwc_f32.h
+++ b/example/conv2d/conv2d_nhwc_f32.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/example/conv2d/conv2d_nhwc_f32.h
+++ b/example/conv2d/conv2d_nhwc_f32.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/example/conv2d/conv2d_utils.h
+++ b/example/conv2d/conv2d_utils.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/example/conv2d/conv2d_utils.h
+++ b/example/conv2d/conv2d_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/example/conv2d/conv2d_utils.h
+++ b/example/conv2d/conv2d_utils.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/example/conv2d/conv2d_utils.h
+++ b/example/conv2d/conv2d_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/example/conv2d/conv2d_utils.h
+++ b/example/conv2d/conv2d_utils.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/example/conv2d/im2row_hwc.h
+++ b/example/conv2d/im2row_hwc.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/example/conv2d/im2row_hwc.h
+++ b/example/conv2d/im2row_hwc.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/example/conv2d/im2row_hwc.h
+++ b/example/conv2d/im2row_hwc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/example/conv2d/im2row_hwc.h
+++ b/example/conv2d/im2row_hwc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/example/conv2d/im2row_hwc.h
+++ b/example/conv2d/im2row_hwc.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/example/conv2d/main.c
+++ b/example/conv2d/main.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(SKL_ENABLE_TESTS) && !defined(SKL_ENABLE_BENCHMARKS)
 #error Must define at least one of SKL_ENABLE_TESTS or SKL_ENABLE_BENCHMARKS

--- a/example/conv2d/main.c
+++ b/example/conv2d/main.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/example/conv2d/main.c
+++ b/example/conv2d/main.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(SKL_ENABLE_TESTS) && !defined(SKL_ENABLE_BENCHMARKS)
 #error Must define at least one of SKL_ENABLE_TESTS or SKL_ENABLE_BENCHMARKS

--- a/example/conv2d/main.c
+++ b/example/conv2d/main.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(SKL_ENABLE_TESTS) && !defined(SKL_ENABLE_BENCHMARKS)
 #error Must define at least one of SKL_ENABLE_TESTS or SKL_ENABLE_BENCHMARKS

--- a/include/skl-common.h
+++ b/include/skl-common.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/include/skl-common.h
+++ b/include/skl-common.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/include/skl-common.h
+++ b/include/skl-common.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/include/skl-common.h
+++ b/include/skl-common.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/include/skl-ref.h
+++ b/include/skl-ref.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/include/skl-ref.h
+++ b/include/skl-ref.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/include/skl-ref.h
+++ b/include/skl-ref.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/include/skl-ref.h
+++ b/include/skl-ref.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/include/skl.h
+++ b/include/skl.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/include/skl.h
+++ b/include/skl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/include/skl.h
+++ b/include/skl.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/include/skl.h
+++ b/include/skl.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/CMakeLists.txt
+++ b/ref/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 # Licensed under the MIT License.
 # See LICENSE file in the project root for full license information.
 # SPDX-License-Identifier: MIT

--- a/ref/CMakeLists.txt
+++ b/ref/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+# SPDX-License-Identifier: MIT
+
 # Build the reference library
 
 add_library(skl-ref

--- a/ref/cvt/cvt_ofp4.c
+++ b/ref/cvt/cvt_ofp4.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/cvt/cvt_ofp4.c
+++ b/ref/cvt/cvt_ofp4.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/cvt/cvt_ofp4.c
+++ b/ref/cvt/cvt_ofp4.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/cvt/cvt_ofp4.c
+++ b/ref/cvt/cvt_ofp4.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/cvt/cvt_ofp4.h
+++ b/ref/cvt/cvt_ofp4.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/cvt/cvt_ofp4.h
+++ b/ref/cvt/cvt_ofp4.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/cvt/cvt_ofp4.h
+++ b/ref/cvt/cvt_ofp4.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/cvt/cvt_ofp4.h
+++ b/ref/cvt/cvt_ofp4.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/cvt/cvt_ofp8.c
+++ b/ref/cvt/cvt_ofp8.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/cvt/cvt_ofp8.c
+++ b/ref/cvt/cvt_ofp8.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/cvt/cvt_ofp8.c
+++ b/ref/cvt/cvt_ofp8.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/cvt/cvt_ofp8.c
+++ b/ref/cvt/cvt_ofp8.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/cvt/cvt_ofp8.h
+++ b/ref/cvt/cvt_ofp8.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/cvt/cvt_ofp8.h
+++ b/ref/cvt/cvt_ofp8.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/cvt/cvt_ofp8.h
+++ b/ref/cvt/cvt_ofp8.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/cvt/cvt_ofp8.h
+++ b/ref/cvt/cvt_ofp8.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/exp/exp_f16.c
+++ b/ref/exp/exp_f16.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/exp/exp_f16.c
+++ b/ref/exp/exp_f16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/exp/exp_f16.c
+++ b/ref/exp/exp_f16.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/exp/exp_f16.c
+++ b/ref/exp/exp_f16.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/exp/exp_f16.h
+++ b/ref/exp/exp_f16.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/exp/exp_f16.h
+++ b/ref/exp/exp_f16.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/exp/exp_f16.h
+++ b/ref/exp/exp_f16.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/exp/exp_f16.h
+++ b/ref/exp/exp_f16.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/exp/exp_f32.c
+++ b/ref/exp/exp_f32.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/exp/exp_f32.c
+++ b/ref/exp/exp_f32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/exp/exp_f32.c
+++ b/ref/exp/exp_f32.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/exp/exp_f32.c
+++ b/ref/exp/exp_f32.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/exp/exp_f32.h
+++ b/ref/exp/exp_f32.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/exp/exp_f32.h
+++ b/ref/exp/exp_f32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/exp/exp_f32.h
+++ b/ref/exp/exp_f32.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/exp/exp_f32.h
+++ b/ref/exp/exp_f32.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_bf16rc_bf16rc_f32rc.c
+++ b/ref/gemm/gemm_bf16rc_bf16rc_f32rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_bf16rc_bf16rc_f32rc.c
+++ b/ref/gemm/gemm_bf16rc_bf16rc_f32rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_bf16rc_bf16rc_f32rc.c
+++ b/ref/gemm/gemm_bf16rc_bf16rc_f32rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_bf16rc_bf16rc_f32rc.c
+++ b/ref/gemm/gemm_bf16rc_bf16rc_f32rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_bf16rc_bf16rc_f32rc.h
+++ b/ref/gemm/gemm_bf16rc_bf16rc_f32rc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/gemm/gemm_bf16rc_bf16rc_f32rc.h
+++ b/ref/gemm/gemm_bf16rc_bf16rc_f32rc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_bf16rc_bf16rc_f32rc.h
+++ b/ref/gemm/gemm_bf16rc_bf16rc_f32rc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_bf16rc_bf16rc_f32rc.h
+++ b/ref/gemm/gemm_bf16rc_bf16rc_f32rc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f16rc_f16rc_f16rc.c
+++ b/ref/gemm/gemm_f16rc_f16rc_f16rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f16rc_f16rc_f16rc.c
+++ b/ref/gemm/gemm_f16rc_f16rc_f16rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f16rc_f16rc_f16rc.c
+++ b/ref/gemm/gemm_f16rc_f16rc_f16rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f16rc_f16rc_f16rc.c
+++ b/ref/gemm/gemm_f16rc_f16rc_f16rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f16rc_f16rc_f16rc.h
+++ b/ref/gemm/gemm_f16rc_f16rc_f16rc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/gemm/gemm_f16rc_f16rc_f16rc.h
+++ b/ref/gemm/gemm_f16rc_f16rc_f16rc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f16rc_f16rc_f16rc.h
+++ b/ref/gemm/gemm_f16rc_f16rc_f16rc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f16rc_f16rc_f16rc.h
+++ b/ref/gemm/gemm_f16rc_f16rc_f16rc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/ref/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/ref/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/ref/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/ref/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f16rc_f16rc_f32rc.h
+++ b/ref/gemm/gemm_f16rc_f16rc_f32rc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/gemm/gemm_f16rc_f16rc_f32rc.h
+++ b/ref/gemm/gemm_f16rc_f16rc_f32rc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f16rc_f16rc_f32rc.h
+++ b/ref/gemm/gemm_f16rc_f16rc_f32rc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f16rc_f16rc_f32rc.h
+++ b/ref/gemm/gemm_f16rc_f16rc_f32rc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f32rc_f32rc_f32rc.c
+++ b/ref/gemm/gemm_f32rc_f32rc_f32rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f32rc_f32rc_f32rc.c
+++ b/ref/gemm/gemm_f32rc_f32rc_f32rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f32rc_f32rc_f32rc.c
+++ b/ref/gemm/gemm_f32rc_f32rc_f32rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f32rc_f32rc_f32rc.c
+++ b/ref/gemm/gemm_f32rc_f32rc_f32rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f32rc_f32rc_f32rc.h
+++ b/ref/gemm/gemm_f32rc_f32rc_f32rc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/gemm/gemm_f32rc_f32rc_f32rc.h
+++ b/ref/gemm/gemm_f32rc_f32rc_f32rc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f32rc_f32rc_f32rc.h
+++ b/ref/gemm/gemm_f32rc_f32rc_f32rc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f32rc_f32rc_f32rc.h
+++ b/ref/gemm/gemm_f32rc_f32rc_f32rc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f64rc_f64rc_f64rc.c
+++ b/ref/gemm/gemm_f64rc_f64rc_f64rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f64rc_f64rc_f64rc.c
+++ b/ref/gemm/gemm_f64rc_f64rc_f64rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f64rc_f64rc_f64rc.c
+++ b/ref/gemm/gemm_f64rc_f64rc_f64rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f64rc_f64rc_f64rc.c
+++ b/ref/gemm/gemm_f64rc_f64rc_f64rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f64rc_f64rc_f64rc.h
+++ b/ref/gemm/gemm_f64rc_f64rc_f64rc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/gemm/gemm_f64rc_f64rc_f64rc.h
+++ b/ref/gemm/gemm_f64rc_f64rc_f64rc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f64rc_f64rc_f64rc.h
+++ b/ref/gemm/gemm_f64rc_f64rc_f64rc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f64rc_f64rc_f64rc.h
+++ b/ref/gemm/gemm_f64rc_f64rc_f64rc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.c
+++ b/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.c
+++ b/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.c
+++ b/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.c
+++ b/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.h
+++ b/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.h
+++ b/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.h
+++ b/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.h
+++ b/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
+++ b/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
+++ b/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
+++ b/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
+++ b/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.h
+++ b/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.h
+++ b/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.h
+++ b/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.h
+++ b/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
+++ b/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
+++ b/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
+++ b/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
+++ b/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.h
+++ b/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.h
+++ b/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.h
+++ b/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.h
+++ b/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include "skl-ref.h"

--- a/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_i8rc_i8rc_i32rc.c
+++ b/ref/gemm/gemm_i8rc_i8rc_i32rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_i8rc_i8rc_i32rc.c
+++ b/ref/gemm/gemm_i8rc_i8rc_i32rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_i8rc_i8rc_i32rc.c
+++ b/ref/gemm/gemm_i8rc_i8rc_i32rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_i8rc_i8rc_i32rc.c
+++ b/ref/gemm/gemm_i8rc_i8rc_i32rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_i8rc_i8rc_i32rc.h
+++ b/ref/gemm/gemm_i8rc_i8rc_i32rc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/gemm/gemm_i8rc_i8rc_i32rc.h
+++ b/ref/gemm/gemm_i8rc_i8rc_i32rc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_i8rc_i8rc_i32rc.h
+++ b/ref/gemm/gemm_i8rc_i8rc_i32rc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_i8rc_i8rc_i32rc.h
+++ b/ref/gemm/gemm_i8rc_i8rc_i32rc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h
+++ b/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h
+++ b/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h
+++ b/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h
+++ b/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <stddef.h>

--- a/ref/logistic/logistic_f16.c
+++ b/ref/logistic/logistic_f16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/logistic/logistic_f16.c
+++ b/ref/logistic/logistic_f16.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 

--- a/ref/logistic/logistic_f16.c
+++ b/ref/logistic/logistic_f16.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 

--- a/ref/logistic/logistic_f16.c
+++ b/ref/logistic/logistic_f16.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 

--- a/ref/logistic/logistic_f16.h
+++ b/ref/logistic/logistic_f16.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/logistic/logistic_f16.h
+++ b/ref/logistic/logistic_f16.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/logistic/logistic_f16.h
+++ b/ref/logistic/logistic_f16.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/logistic/logistic_f16.h
+++ b/ref/logistic/logistic_f16.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/logistic/logistic_f32.c
+++ b/ref/logistic/logistic_f32.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/logistic/logistic_f32.c
+++ b/ref/logistic/logistic_f32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/logistic/logistic_f32.c
+++ b/ref/logistic/logistic_f32.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/logistic/logistic_f32.c
+++ b/ref/logistic/logistic_f32.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/logistic/logistic_f32.h
+++ b/ref/logistic/logistic_f32.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/logistic/logistic_f32.h
+++ b/ref/logistic/logistic_f32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/logistic/logistic_f32.h
+++ b/ref/logistic/logistic_f32.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/logistic/logistic_f32.h
+++ b/ref/logistic/logistic_f32.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/silu/silu_f16.c
+++ b/ref/silu/silu_f16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/silu/silu_f16.c
+++ b/ref/silu/silu_f16.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 

--- a/ref/silu/silu_f16.c
+++ b/ref/silu/silu_f16.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 

--- a/ref/silu/silu_f16.c
+++ b/ref/silu/silu_f16.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 

--- a/ref/silu/silu_f16.h
+++ b/ref/silu/silu_f16.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/silu/silu_f16.h
+++ b/ref/silu/silu_f16.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/silu/silu_f16.h
+++ b/ref/silu/silu_f16.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/silu/silu_f16.h
+++ b/ref/silu/silu_f16.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/silu/silu_f32.c
+++ b/ref/silu/silu_f32.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/silu/silu_f32.c
+++ b/ref/silu/silu_f32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/silu/silu_f32.c
+++ b/ref/silu/silu_f32.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/silu/silu_f32.c
+++ b/ref/silu/silu_f32.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/silu/silu_f32.h
+++ b/ref/silu/silu_f32.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/silu/silu_f32.h
+++ b/ref/silu/silu_f32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/silu/silu_f32.h
+++ b/ref/silu/silu_f32.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/silu/silu_f32.h
+++ b/ref/silu/silu_f32.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/softmax/softmax_bf16.c
+++ b/ref/softmax/softmax_bf16.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/softmax/softmax_bf16.c
+++ b/ref/softmax/softmax_bf16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/softmax/softmax_bf16.c
+++ b/ref/softmax/softmax_bf16.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/softmax/softmax_bf16.c
+++ b/ref/softmax/softmax_bf16.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/softmax/softmax_bf16.h
+++ b/ref/softmax/softmax_bf16.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/softmax/softmax_bf16.h
+++ b/ref/softmax/softmax_bf16.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/softmax/softmax_bf16.h
+++ b/ref/softmax/softmax_bf16.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/softmax/softmax_bf16.h
+++ b/ref/softmax/softmax_bf16.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/softmax/softmax_f16.c
+++ b/ref/softmax/softmax_f16.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/softmax/softmax_f16.c
+++ b/ref/softmax/softmax_f16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/softmax/softmax_f16.c
+++ b/ref/softmax/softmax_f16.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/softmax/softmax_f16.c
+++ b/ref/softmax/softmax_f16.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/softmax/softmax_f16.h
+++ b/ref/softmax/softmax_f16.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/softmax/softmax_f16.h
+++ b/ref/softmax/softmax_f16.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/softmax/softmax_f16.h
+++ b/ref/softmax/softmax_f16.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/softmax/softmax_f16.h
+++ b/ref/softmax/softmax_f16.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/softmax/softmax_f32.c
+++ b/ref/softmax/softmax_f32.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/softmax/softmax_f32.c
+++ b/ref/softmax/softmax_f32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/softmax/softmax_f32.c
+++ b/ref/softmax/softmax_f32.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/softmax/softmax_f32.c
+++ b/ref/softmax/softmax_f32.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-common.h"
 #include <math.h>

--- a/ref/softmax/softmax_f32.h
+++ b/ref/softmax/softmax_f32.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/softmax/softmax_f32.h
+++ b/ref/softmax/softmax_f32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/softmax/softmax_f32.h
+++ b/ref/softmax/softmax_f32.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/softmax/softmax_f32.h
+++ b/ref/softmax/softmax_f32.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/transpose/transpose_e16.c
+++ b/ref/transpose/transpose_e16.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/transpose/transpose_e16.c
+++ b/ref/transpose/transpose_e16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/transpose/transpose_e16.c
+++ b/ref/transpose/transpose_e16.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/transpose/transpose_e16.c
+++ b/ref/transpose/transpose_e16.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/transpose/transpose_e16.h
+++ b/ref/transpose/transpose_e16.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/transpose/transpose_e16.h
+++ b/ref/transpose/transpose_e16.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/transpose/transpose_e16.h
+++ b/ref/transpose/transpose_e16.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/transpose/transpose_e16.h
+++ b/ref/transpose/transpose_e16.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/transpose/transpose_e32.c
+++ b/ref/transpose/transpose_e32.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/transpose/transpose_e32.c
+++ b/ref/transpose/transpose_e32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/transpose/transpose_e32.c
+++ b/ref/transpose/transpose_e32.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/transpose/transpose_e32.c
+++ b/ref/transpose/transpose_e32.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/transpose/transpose_e32.h
+++ b/ref/transpose/transpose_e32.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/transpose/transpose_e32.h
+++ b/ref/transpose/transpose_e32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/transpose/transpose_e32.h
+++ b/ref/transpose/transpose_e32.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/transpose/transpose_e32.h
+++ b/ref/transpose/transpose_e32.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/transpose/transpose_e8.c
+++ b/ref/transpose/transpose_e8.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/transpose/transpose_e8.c
+++ b/ref/transpose/transpose_e8.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/transpose/transpose_e8.c
+++ b/ref/transpose/transpose_e8.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/transpose/transpose_e8.c
+++ b/ref/transpose/transpose_e8.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/ref/transpose/transpose_e8.h
+++ b/ref/transpose/transpose_e8.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/ref/transpose/transpose_e8.h
+++ b/ref/transpose/transpose_e8.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/ref/transpose/transpose_e8.h
+++ b/ref/transpose/transpose_e8.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/ref/transpose/transpose_e8.h
+++ b/ref/transpose/transpose_e8.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
+++ b/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zvfofp8min)
 #error This file requires the Zvfofp8min extension

--- a/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
+++ b/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
+++ b/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfofp8min)
 #error This file requires the Zvfofp8min extension

--- a/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
+++ b/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfofp8min)
 #error This file requires the Zvfofp8min extension

--- a/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.h
+++ b/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.h
+++ b/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.h
+++ b/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.h
+++ b/src/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/cvt/cvt_f32_f8_zvfofp8min.c
+++ b/src/cvt/cvt_f32_f8_zvfofp8min.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zvfofp8min)
 #error This file requires the Zvfofp8min extension

--- a/src/cvt/cvt_f32_f8_zvfofp8min.c
+++ b/src/cvt/cvt_f32_f8_zvfofp8min.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/cvt/cvt_f32_f8_zvfofp8min.c
+++ b/src/cvt/cvt_f32_f8_zvfofp8min.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfofp8min)
 #error This file requires the Zvfofp8min extension

--- a/src/cvt/cvt_f32_f8_zvfofp8min.c
+++ b/src/cvt/cvt_f32_f8_zvfofp8min.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfofp8min)
 #error This file requires the Zvfofp8min extension

--- a/src/cvt/cvt_f32_f8_zvfofp8min.h
+++ b/src/cvt/cvt_f32_f8_zvfofp8min.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/cvt/cvt_f32_f8_zvfofp8min.h
+++ b/src/cvt/cvt_f32_f8_zvfofp8min.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/cvt/cvt_f32_f8_zvfofp8min.h
+++ b/src/cvt/cvt_f32_f8_zvfofp8min.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/cvt/cvt_f32_f8_zvfofp8min.h
+++ b/src/cvt/cvt_f32_f8_zvfofp8min.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/cvt/cvt_f4_f8_zvfofp4min.c
+++ b/src/cvt/cvt_f4_f8_zvfofp4min.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zvfofp4min)
 #error This file requires the Zvfofp4min extension

--- a/src/cvt/cvt_f4_f8_zvfofp4min.c
+++ b/src/cvt/cvt_f4_f8_zvfofp4min.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfofp4min)
 #error This file requires the Zvfofp4min extension

--- a/src/cvt/cvt_f4_f8_zvfofp4min.c
+++ b/src/cvt/cvt_f4_f8_zvfofp4min.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/cvt/cvt_f4_f8_zvfofp4min.c
+++ b/src/cvt/cvt_f4_f8_zvfofp4min.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfofp4min)
 #error This file requires the Zvfofp4min extension

--- a/src/cvt/cvt_f4_f8_zvfofp4min.h
+++ b/src/cvt/cvt_f4_f8_zvfofp4min.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/cvt/cvt_f4_f8_zvfofp4min.h
+++ b/src/cvt/cvt_f4_f8_zvfofp4min.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/cvt/cvt_f4_f8_zvfofp4min.h
+++ b/src/cvt/cvt_f4_f8_zvfofp4min.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/cvt/cvt_f4_f8_zvfofp4min.h
+++ b/src/cvt/cvt_f4_f8_zvfofp4min.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/cvt/cvt_f8_bf16_zvfofp8min.c
+++ b/src/cvt/cvt_f8_bf16_zvfofp8min.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zvfofp8min)
 #error This file requires the Zvfofp8min extension

--- a/src/cvt/cvt_f8_bf16_zvfofp8min.c
+++ b/src/cvt/cvt_f8_bf16_zvfofp8min.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/cvt/cvt_f8_bf16_zvfofp8min.c
+++ b/src/cvt/cvt_f8_bf16_zvfofp8min.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfofp8min)
 #error This file requires the Zvfofp8min extension

--- a/src/cvt/cvt_f8_bf16_zvfofp8min.c
+++ b/src/cvt/cvt_f8_bf16_zvfofp8min.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfofp8min)
 #error This file requires the Zvfofp8min extension

--- a/src/cvt/cvt_f8_bf16_zvfofp8min.h
+++ b/src/cvt/cvt_f8_bf16_zvfofp8min.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/cvt/cvt_f8_bf16_zvfofp8min.h
+++ b/src/cvt/cvt_f8_bf16_zvfofp8min.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/cvt/cvt_f8_bf16_zvfofp8min.h
+++ b/src/cvt/cvt_f8_bf16_zvfofp8min.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/cvt/cvt_f8_bf16_zvfofp8min.h
+++ b/src/cvt/cvt_f8_bf16_zvfofp8min.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32x)
 #error This file requires the Zve32x extension

--- a/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This file requires the Zve32x extension

--- a/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This file requires the Zve32x extension

--- a/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_bf16_xsfvfbfa.c
+++ b/src/exp/exp_bf16_xsfvfbfa.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_bf16_xsfvfbfa.c
+++ b/src/exp/exp_bf16_xsfvfbfa.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfbfa)
 #error This file requires the Xsfvfbfa extension

--- a/src/exp/exp_bf16_xsfvfbfa.c
+++ b/src/exp/exp_bf16_xsfvfbfa.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfbfa)
 #error This file requires the Xsfvfbfa extension

--- a/src/exp/exp_bf16_xsfvfbfa.c
+++ b/src/exp/exp_bf16_xsfvfbfa.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfbfa)
 #error This file requires the Xsfvfbfa extension

--- a/src/exp/exp_bf16_xsfvfbfa.h
+++ b/src/exp/exp_bf16_xsfvfbfa.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_bf16_xsfvfbfa.h
+++ b/src/exp/exp_bf16_xsfvfbfa.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_bf16_xsfvfbfa.h
+++ b/src/exp/exp_bf16_xsfvfbfa.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/exp/exp_bf16_xsfvfbfa.h
+++ b/src/exp/exp_bf16_xsfvfbfa.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_bf16_xsfvfbfa.h
+++ b/src/exp/exp_bf16_xsfvfbfa.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_bf16_xsfvfbfexp16e.c
+++ b/src/exp/exp_bf16_xsfvfbfexp16e.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfbfexp16e)
 #error This file requires the Xsfvfbfexp16e extension

--- a/src/exp/exp_bf16_xsfvfbfexp16e.c
+++ b/src/exp/exp_bf16_xsfvfbfexp16e.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_bf16_xsfvfbfexp16e.c
+++ b/src/exp/exp_bf16_xsfvfbfexp16e.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfbfexp16e)
 #error This file requires the Xsfvfbfexp16e extension

--- a/src/exp/exp_bf16_xsfvfbfexp16e.c
+++ b/src/exp/exp_bf16_xsfvfbfexp16e.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_bf16_xsfvfbfexp16e.c
+++ b/src/exp/exp_bf16_xsfvfbfexp16e.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfbfexp16e)
 #error This file requires the Xsfvfbfexp16e extension

--- a/src/exp/exp_bf16_xsfvfbfexp16e.h
+++ b/src/exp/exp_bf16_xsfvfbfexp16e.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_bf16_xsfvfbfexp16e.h
+++ b/src/exp/exp_bf16_xsfvfbfexp16e.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_bf16_xsfvfbfexp16e.h
+++ b/src/exp/exp_bf16_xsfvfbfexp16e.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/exp/exp_bf16_xsfvfbfexp16e.h
+++ b/src/exp/exp_bf16_xsfvfbfexp16e.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_bf16_xsfvfbfexp16e.h
+++ b/src/exp/exp_bf16_xsfvfbfexp16e.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.c
+++ b/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.c
+++ b/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfbfmin)
 #error This file requires the Xsfvfexpa and Zvfbfmin extensions

--- a/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.c
+++ b/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfbfmin)
 #error This file requires the Xsfvfexpa and Zvfbfmin extensions

--- a/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.c
+++ b/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfbfmin)
 #error This file requires the Xsfvfexpa and Zvfbfmin extensions

--- a/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.c
+++ b/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.h
+++ b/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.h
+++ b/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.h
+++ b/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.h
+++ b/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.h
+++ b/src/exp/exp_bf16_xsfvfexpa_zvfbfmin.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_bf16_zve32f.c
+++ b/src/exp/exp_bf16_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_bf16_zve32f.c
+++ b/src/exp/exp_bf16_zve32f.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/exp/exp_bf16_zve32f.c
+++ b/src/exp/exp_bf16_zve32f.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/exp/exp_bf16_zve32f.c
+++ b/src/exp/exp_bf16_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_bf16_zve32f.c
+++ b/src/exp/exp_bf16_zve32f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/exp/exp_bf16_zve32f.h
+++ b/src/exp/exp_bf16_zve32f.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_bf16_zve32f.h
+++ b/src/exp/exp_bf16_zve32f.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_bf16_zve32f.h
+++ b/src/exp/exp_bf16_zve32f.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/exp/exp_bf16_zve32f.h
+++ b/src/exp/exp_bf16_zve32f.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_bf16_zve32f.h
+++ b/src/exp/exp_bf16_zve32f.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_bf16_zvfbfmin.c
+++ b/src/exp/exp_bf16_zvfbfmin.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfbfmin)
 #error This file requires the Zvfbfmin extension

--- a/src/exp/exp_bf16_zvfbfmin.c
+++ b/src/exp/exp_bf16_zvfbfmin.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_bf16_zvfbfmin.c
+++ b/src/exp/exp_bf16_zvfbfmin.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfbfmin)
 #error This file requires the Zvfbfmin extension

--- a/src/exp/exp_bf16_zvfbfmin.c
+++ b/src/exp/exp_bf16_zvfbfmin.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zvfbfmin)
 #error This file requires the Zvfbfmin extension

--- a/src/exp/exp_bf16_zvfbfmin.c
+++ b/src/exp/exp_bf16_zvfbfmin.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_bf16_zvfbfmin.h
+++ b/src/exp/exp_bf16_zvfbfmin.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_bf16_zvfbfmin.h
+++ b/src/exp/exp_bf16_zvfbfmin.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_bf16_zvfbfmin.h
+++ b/src/exp/exp_bf16_zvfbfmin.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/exp/exp_bf16_zvfbfmin.h
+++ b/src/exp/exp_bf16_zvfbfmin.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_bf16_zvfbfmin.h
+++ b/src/exp/exp_bf16_zvfbfmin.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_f16_xsfvfexp16e.c
+++ b/src/exp/exp_f16_xsfvfexp16e.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp16e)
 #error This file requires the Xsfvfexp16e extension

--- a/src/exp/exp_f16_xsfvfexp16e.c
+++ b/src/exp/exp_f16_xsfvfexp16e.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_f16_xsfvfexp16e.c
+++ b/src/exp/exp_f16_xsfvfexp16e.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexp16e)
 #error This file requires the Xsfvfexp16e extension

--- a/src/exp/exp_f16_xsfvfexp16e.c
+++ b/src/exp/exp_f16_xsfvfexp16e.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp16e)
 #error This file requires the Xsfvfexp16e extension

--- a/src/exp/exp_f16_xsfvfexp16e.c
+++ b/src/exp/exp_f16_xsfvfexp16e.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_f16_xsfvfexp16e.h
+++ b/src/exp/exp_f16_xsfvfexp16e.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_f16_xsfvfexp16e.h
+++ b/src/exp/exp_f16_xsfvfexp16e.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_f16_xsfvfexp16e.h
+++ b/src/exp/exp_f16_xsfvfexp16e.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/exp/exp_f16_xsfvfexp16e.h
+++ b/src/exp/exp_f16_xsfvfexp16e.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_f16_xsfvfexp16e.h
+++ b/src/exp/exp_f16_xsfvfexp16e.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_f16_xsfvfexpa_zvfh.c
+++ b/src/exp/exp_f16_xsfvfexpa_zvfh.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfh)
 #error This file requires the Xsfvfexpa and Zvfh extensions

--- a/src/exp/exp_f16_xsfvfexpa_zvfh.c
+++ b/src/exp/exp_f16_xsfvfexpa_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_f16_xsfvfexpa_zvfh.c
+++ b/src/exp/exp_f16_xsfvfexpa_zvfh.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfh)
 #error This file requires the Xsfvfexpa and Zvfh extensions

--- a/src/exp/exp_f16_xsfvfexpa_zvfh.c
+++ b/src/exp/exp_f16_xsfvfexpa_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_f16_xsfvfexpa_zvfh.c
+++ b/src/exp/exp_f16_xsfvfexpa_zvfh.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfh)
 #error This file requires the Xsfvfexpa and Zvfh extensions

--- a/src/exp/exp_f16_xsfvfexpa_zvfh.h
+++ b/src/exp/exp_f16_xsfvfexpa_zvfh.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_f16_xsfvfexpa_zvfh.h
+++ b/src/exp/exp_f16_xsfvfexpa_zvfh.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_f16_xsfvfexpa_zvfh.h
+++ b/src/exp/exp_f16_xsfvfexpa_zvfh.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/exp/exp_f16_xsfvfexpa_zvfh.h
+++ b/src/exp/exp_f16_xsfvfexpa_zvfh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_f16_xsfvfexpa_zvfh.h
+++ b/src/exp/exp_f16_xsfvfexpa_zvfh.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_f16_zvfh.c
+++ b/src/exp/exp_f16_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_f16_zvfh.c
+++ b/src/exp/exp_f16_zvfh.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/exp/exp_f16_zvfh.c
+++ b/src/exp/exp_f16_zvfh.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/exp/exp_f16_zvfh.c
+++ b/src/exp/exp_f16_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_f16_zvfh.c
+++ b/src/exp/exp_f16_zvfh.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/exp/exp_f16_zvfh.h
+++ b/src/exp/exp_f16_zvfh.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_f16_zvfh.h
+++ b/src/exp/exp_f16_zvfh.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_f16_zvfh.h
+++ b/src/exp/exp_f16_zvfh.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/exp/exp_f16_zvfh.h
+++ b/src/exp/exp_f16_zvfh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_f16_zvfh.h
+++ b/src/exp/exp_f16_zvfh.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_f32_xsfvfexp32e.c
+++ b/src/exp/exp_f32_xsfvfexp32e.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexp32e)
 #error This file requires the Xsfvfexp32e extension

--- a/src/exp/exp_f32_xsfvfexp32e.c
+++ b/src/exp/exp_f32_xsfvfexp32e.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_f32_xsfvfexp32e.c
+++ b/src/exp/exp_f32_xsfvfexp32e.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp32e)
 #error This file requires the Xsfvfexp32e extension

--- a/src/exp/exp_f32_xsfvfexp32e.c
+++ b/src/exp/exp_f32_xsfvfexp32e.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_f32_xsfvfexp32e.c
+++ b/src/exp/exp_f32_xsfvfexp32e.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp32e)
 #error This file requires the Xsfvfexp32e extension

--- a/src/exp/exp_f32_xsfvfexp32e.h
+++ b/src/exp/exp_f32_xsfvfexp32e.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_f32_xsfvfexp32e.h
+++ b/src/exp/exp_f32_xsfvfexp32e.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_f32_xsfvfexp32e.h
+++ b/src/exp/exp_f32_xsfvfexp32e.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/exp/exp_f32_xsfvfexp32e.h
+++ b/src/exp/exp_f32_xsfvfexp32e.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_f32_xsfvfexp32e.h
+++ b/src/exp/exp_f32_xsfvfexp32e.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_f32_xsfvfexpa.c
+++ b/src/exp/exp_f32_xsfvfexpa.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/src/exp/exp_f32_xsfvfexpa.c
+++ b/src/exp/exp_f32_xsfvfexpa.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/src/exp/exp_f32_xsfvfexpa.c
+++ b/src/exp/exp_f32_xsfvfexpa.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_f32_xsfvfexpa.c
+++ b/src/exp/exp_f32_xsfvfexpa.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/src/exp/exp_f32_xsfvfexpa.c
+++ b/src/exp/exp_f32_xsfvfexpa.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_f32_xsfvfexpa.h
+++ b/src/exp/exp_f32_xsfvfexpa.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_f32_xsfvfexpa.h
+++ b/src/exp/exp_f32_xsfvfexpa.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_f32_xsfvfexpa.h
+++ b/src/exp/exp_f32_xsfvfexpa.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/exp/exp_f32_xsfvfexpa.h
+++ b/src/exp/exp_f32_xsfvfexpa.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_f32_xsfvfexpa.h
+++ b/src/exp/exp_f32_xsfvfexpa.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_f32_zve32f.c
+++ b/src/exp/exp_f32_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_f32_zve32f.c
+++ b/src/exp/exp_f32_zve32f.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/exp/exp_f32_zve32f.c
+++ b/src/exp/exp_f32_zve32f.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/exp/exp_f32_zve32f.c
+++ b/src/exp/exp_f32_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_f32_zve32f.c
+++ b/src/exp/exp_f32_zve32f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/exp/exp_f32_zve32f.h
+++ b/src/exp/exp_f32_zve32f.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/exp/exp_f32_zve32f.h
+++ b/src/exp/exp_f32_zve32f.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/exp/exp_f32_zve32f.h
+++ b/src/exp/exp_f32_zve32f.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/exp/exp_f32_zve32f.h
+++ b/src/exp/exp_f32_zve32f.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/exp/exp_f32_zve32f.h
+++ b/src/exp/exp_f32_zve32f.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gelu/gelu_f32_zve32f.c
+++ b/src/gelu/gelu_f32_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/gelu/gelu_f32_zve32f.c
+++ b/src/gelu/gelu_f32_zve32f.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/gelu/gelu_f32_zve32f.c
+++ b/src/gelu/gelu_f32_zve32f.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/gelu/gelu_f32_zve32f.c
+++ b/src/gelu/gelu_f32_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gelu/gelu_f32_zve32f.c
+++ b/src/gelu/gelu_f32_zve32f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/gelu/gelu_f32_zve32f.h
+++ b/src/gelu/gelu_f32_zve32f.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gelu/gelu_f32_zve32f.h
+++ b/src/gelu/gelu_f32_zve32f.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/gelu/gelu_f32_zve32f.h
+++ b/src/gelu/gelu_f32_zve32f.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gelu/gelu_f32_zve32f.h
+++ b/src/gelu/gelu_f32_zve32f.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gelu/gelu_f32_zve32f.h
+++ b/src/gelu/gelu_f32_zve32f.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfbfwma)
 #error This file requires the RISC-V Zvfbfwma extension.

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfbfwma)
 #error This file requires the RISC-V Zvfbfwma extension.

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zvfbfwma)
 #error This file requires the RISC-V Zvfbfwma extension.

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.h
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.h
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.h
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.h
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zvfh) || __riscv_zvfh < 1000000
 #error This file requires the RISC-V zvfh extension, version 1000000.

--- a/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfh) || __riscv_zvfh < 1000000
 #error This file requires the RISC-V zvfh extension, version 1000000.

--- a/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfh) || __riscv_zvfh < 1000000
 #error This file requires the RISC-V zvfh extension, version 1000000.

--- a/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.h
+++ b/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.h
+++ b/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.h
+++ b/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.h
+++ b/src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zvfh) || __riscv_zvfh < 1000000
 #error This file requires the RISC-V Zvfh extension, version 1000000.

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfh) || __riscv_zvfh < 1000000
 #error This file requires the RISC-V Zvfh extension, version 1000000.

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfh) || __riscv_zvfh < 1000000
 #error This file requires the RISC-V Zvfh extension, version 1000000.

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.h
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.h
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.h
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.h
+++ b/src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
+++ b/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
+++ b/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
+++ b/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
+++ b/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.h
+++ b/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.h
+++ b/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.h
+++ b/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.h
+++ b/src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.c
+++ b/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.c
+++ b/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve64d) || __riscv_zve64d < 1000000
 #error This file requires the RISC-V zve64d extension, version 1000000.

--- a/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.c
+++ b/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve64d) || __riscv_zve64d < 1000000
 #error This file requires the RISC-V zve64d extension, version 1000000.

--- a/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.c
+++ b/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve64d) || __riscv_zve64d < 1000000
 #error This file requires the RISC-V zve64d extension, version 1000000.

--- a/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.h
+++ b/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.h
+++ b/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.h
+++ b/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.h
+++ b/src/gemm/rvv/gemm_f64_f64_f64_zve64d_x390.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.c
+++ b/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.c
+++ b/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x) || __riscv_zve32x < 1000000
 #error This file requires the RISC-V Zve32x extension, version 1000000.

--- a/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.c
+++ b/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x) || __riscv_zve32x < 1000000
 #error This file requires the RISC-V Zve32x extension, version 1000000.

--- a/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.c
+++ b/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32x) || __riscv_zve32x < 1000000
 #error This file requires the RISC-V Zve32x extension, version 1000000.

--- a/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.h
+++ b/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.h
+++ b/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.h
+++ b/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.h
+++ b/src/gemm/rvv/gemm_i8_i8_i32_zve32x_x390.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfmm32a16f)
 #error This file requires the Xsfmm32a16f extension

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmm32a16f)
 #error This file requires the Xsfmm32a16f extension

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmm32a16f)
 #error This file requires the Xsfmm32a16f extension

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfmm32a16f)
 #error This file requires the Xsfmm32a16f extension

--- a/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmm32a16f)
 #error This file requires the Xsfmm32a16f extension

--- a/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmm32a16f)
 #error This file requires the Xsfmm32a16f extension

--- a/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfmm32a32f)
 #error This file requires the Xsfmm32a32f extension

--- a/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmm32a32f)
 #error This file requires the Xsfmm32a32f extension

--- a/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmm32a32f)
 #error This file requires the Xsfmm32a32f extension

--- a/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmm32a8f)
 #error This file requires the Xsfmm32a8f extension

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfmm32a8f)
 #error This file requires the Xsfmm32a8f extension

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmm32a8f)
 #error This file requires the Xsfmm32a8f extension

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmm32a8f)
 #error This file requires the Xsfmm32a8f extension

--- a/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfmm32a8f)
 #error This file requires the Xsfmm32a8f extension

--- a/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmm32a8f)
 #error This file requires the Xsfmm32a8f extension

--- a/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
+++ b/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
+++ b/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfmm32a8i)
 #error This file requires the Xsfmm32a8i extension

--- a/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
+++ b/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmm32a8i)
 #error This file requires the Xsfmm32a8i extension

--- a/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
+++ b/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmm32a8i)
 #error This file requires the Xsfmm32a8i extension

--- a/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
+++ b/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.h
+++ b/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.h
+++ b/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.h
+++ b/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.h
+++ b/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.c
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This source file requires compiler support for the RISC-V Zve32x extension.

--- a/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.c
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32x)
 #error This source file requires compiler support for the RISC-V Zve32x extension.

--- a/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.c
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.c
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This source file requires compiler support for the RISC-V Zve32x extension.

--- a/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.c
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.c
+++ b/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This source file requires compiler support for the RISC-V Zve32x extension.

--- a/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.c
+++ b/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32x)
 #error This source file requires compiler support for the RISC-V Zve32x extension.

--- a/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.c
+++ b/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.c
+++ b/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This source file requires compiler support for the RISC-V Zve32x extension.

--- a/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.c
+++ b/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/pack_b_xsfvqdotq.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/logistic/logistic_f16_xsfvfexp16e.c
+++ b/src/logistic/logistic_f16_xsfvfexp16e.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp16e)
 #error This file requires the Xsfvfexp16e extension

--- a/src/logistic/logistic_f16_xsfvfexp16e.c
+++ b/src/logistic/logistic_f16_xsfvfexp16e.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/logistic/logistic_f16_xsfvfexp16e.c
+++ b/src/logistic/logistic_f16_xsfvfexp16e.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexp16e)
 #error This file requires the Xsfvfexp16e extension

--- a/src/logistic/logistic_f16_xsfvfexp16e.c
+++ b/src/logistic/logistic_f16_xsfvfexp16e.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp16e)
 #error This file requires the Xsfvfexp16e extension

--- a/src/logistic/logistic_f16_xsfvfexp16e.c
+++ b/src/logistic/logistic_f16_xsfvfexp16e.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/logistic/logistic_f16_xsfvfexp16e.h
+++ b/src/logistic/logistic_f16_xsfvfexp16e.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/logistic/logistic_f16_xsfvfexp16e.h
+++ b/src/logistic/logistic_f16_xsfvfexp16e.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/logistic/logistic_f16_xsfvfexp16e.h
+++ b/src/logistic/logistic_f16_xsfvfexp16e.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/logistic/logistic_f16_xsfvfexp16e.h
+++ b/src/logistic/logistic_f16_xsfvfexp16e.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/logistic/logistic_f16_xsfvfexp16e.h
+++ b/src/logistic/logistic_f16_xsfvfexp16e.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/logistic/logistic_f16_zvfh.c
+++ b/src/logistic/logistic_f16_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/logistic/logistic_f16_zvfh.c
+++ b/src/logistic/logistic_f16_zvfh.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/logistic/logistic_f16_zvfh.c
+++ b/src/logistic/logistic_f16_zvfh.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/logistic/logistic_f16_zvfh.c
+++ b/src/logistic/logistic_f16_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/logistic/logistic_f16_zvfh.c
+++ b/src/logistic/logistic_f16_zvfh.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/logistic/logistic_f16_zvfh.h
+++ b/src/logistic/logistic_f16_zvfh.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/logistic/logistic_f16_zvfh.h
+++ b/src/logistic/logistic_f16_zvfh.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/logistic/logistic_f16_zvfh.h
+++ b/src/logistic/logistic_f16_zvfh.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/logistic/logistic_f16_zvfh.h
+++ b/src/logistic/logistic_f16_zvfh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/logistic/logistic_f16_zvfh.h
+++ b/src/logistic/logistic_f16_zvfh.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/logistic/logistic_f32_xsfvfexp32e.c
+++ b/src/logistic/logistic_f32_xsfvfexp32e.c
@@ -1,5 +1,7 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexp32e)
 #error This file requires the Xsfvfexp32e extension

--- a/src/logistic/logistic_f32_xsfvfexp32e.h
+++ b/src/logistic/logistic_f32_xsfvfexp32e.h
@@ -1,5 +1,7 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/logistic/logistic_f32_xsfvfexpa.c
+++ b/src/logistic/logistic_f32_xsfvfexpa.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/src/logistic/logistic_f32_xsfvfexpa.c
+++ b/src/logistic/logistic_f32_xsfvfexpa.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/src/logistic/logistic_f32_xsfvfexpa.c
+++ b/src/logistic/logistic_f32_xsfvfexpa.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/logistic/logistic_f32_xsfvfexpa.c
+++ b/src/logistic/logistic_f32_xsfvfexpa.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/src/logistic/logistic_f32_xsfvfexpa.c
+++ b/src/logistic/logistic_f32_xsfvfexpa.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/logistic/logistic_f32_xsfvfexpa.h
+++ b/src/logistic/logistic_f32_xsfvfexpa.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/logistic/logistic_f32_xsfvfexpa.h
+++ b/src/logistic/logistic_f32_xsfvfexpa.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/logistic/logistic_f32_xsfvfexpa.h
+++ b/src/logistic/logistic_f32_xsfvfexpa.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/logistic/logistic_f32_xsfvfexpa.h
+++ b/src/logistic/logistic_f32_xsfvfexpa.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/logistic/logistic_f32_xsfvfexpa.h
+++ b/src/logistic/logistic_f32_xsfvfexpa.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/logistic/logistic_f32_zve32f.c
+++ b/src/logistic/logistic_f32_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/logistic/logistic_f32_zve32f.c
+++ b/src/logistic/logistic_f32_zve32f.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/logistic/logistic_f32_zve32f.c
+++ b/src/logistic/logistic_f32_zve32f.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/logistic/logistic_f32_zve32f.c
+++ b/src/logistic/logistic_f32_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/logistic/logistic_f32_zve32f.c
+++ b/src/logistic/logistic_f32_zve32f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/logistic/logistic_f32_zve32f.h
+++ b/src/logistic/logistic_f32_zve32f.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/logistic/logistic_f32_zve32f.h
+++ b/src/logistic/logistic_f32_zve32f.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/logistic/logistic_f32_zve32f.h
+++ b/src/logistic/logistic_f32_zve32f.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/logistic/logistic_f32_zve32f.h
+++ b/src/logistic/logistic_f32_zve32f.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/logistic/logistic_f32_zve32f.h
+++ b/src/logistic/logistic_f32_zve32f.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/silu/silu_f16_xsfvfexp16e.c
+++ b/src/silu/silu_f16_xsfvfexp16e.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp16e)
 #error This file requires the Xsfvfexp16e extension

--- a/src/silu/silu_f16_xsfvfexp16e.c
+++ b/src/silu/silu_f16_xsfvfexp16e.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/silu/silu_f16_xsfvfexp16e.c
+++ b/src/silu/silu_f16_xsfvfexp16e.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp16e)
 #error This file requires the Xsfvfexp16e extension

--- a/src/silu/silu_f16_xsfvfexp16e.c
+++ b/src/silu/silu_f16_xsfvfexp16e.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexp16e)
 #error This file requires the Xsfvfexp16e extension

--- a/src/silu/silu_f16_xsfvfexp16e.h
+++ b/src/silu/silu_f16_xsfvfexp16e.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/silu/silu_f16_xsfvfexp16e.h
+++ b/src/silu/silu_f16_xsfvfexp16e.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/silu/silu_f16_xsfvfexp16e.h
+++ b/src/silu/silu_f16_xsfvfexp16e.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/silu/silu_f16_xsfvfexp16e.h
+++ b/src/silu/silu_f16_xsfvfexp16e.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/silu/silu_f16_xsfvfexpa_zvfh.c
+++ b/src/silu/silu_f16_xsfvfexpa_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/silu/silu_f16_xsfvfexpa_zvfh.c
+++ b/src/silu/silu_f16_xsfvfexpa_zvfh.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfh)
 #error This file requires the Xsfvfexpa and Zvfh extensions

--- a/src/silu/silu_f16_xsfvfexpa_zvfh.c
+++ b/src/silu/silu_f16_xsfvfexpa_zvfh.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfh)
 #error This file requires the Xsfvfexpa and Zvfh extensions

--- a/src/silu/silu_f16_xsfvfexpa_zvfh.c
+++ b/src/silu/silu_f16_xsfvfexpa_zvfh.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfh)
 #error This file requires the Xsfvfexpa and Zvfh extensions

--- a/src/silu/silu_f16_xsfvfexpa_zvfh.h
+++ b/src/silu/silu_f16_xsfvfexpa_zvfh.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/silu/silu_f16_xsfvfexpa_zvfh.h
+++ b/src/silu/silu_f16_xsfvfexpa_zvfh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/silu/silu_f16_xsfvfexpa_zvfh.h
+++ b/src/silu/silu_f16_xsfvfexpa_zvfh.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/silu/silu_f16_xsfvfexpa_zvfh.h
+++ b/src/silu/silu_f16_xsfvfexpa_zvfh.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/silu/silu_f16_zvfh.c
+++ b/src/silu/silu_f16_zvfh.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/silu/silu_f16_zvfh.c
+++ b/src/silu/silu_f16_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/silu/silu_f16_zvfh.c
+++ b/src/silu/silu_f16_zvfh.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/silu/silu_f16_zvfh.c
+++ b/src/silu/silu_f16_zvfh.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/silu/silu_f16_zvfh.h
+++ b/src/silu/silu_f16_zvfh.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/silu/silu_f16_zvfh.h
+++ b/src/silu/silu_f16_zvfh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/silu/silu_f16_zvfh.h
+++ b/src/silu/silu_f16_zvfh.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/silu/silu_f16_zvfh.h
+++ b/src/silu/silu_f16_zvfh.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/silu/silu_f32_xsfvfexp32e.c
+++ b/src/silu/silu_f32_xsfvfexp32e.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp32e)
 #error This file requires the Xsfvfexp32e extension

--- a/src/silu/silu_f32_xsfvfexp32e.c
+++ b/src/silu/silu_f32_xsfvfexp32e.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/silu/silu_f32_xsfvfexp32e.c
+++ b/src/silu/silu_f32_xsfvfexp32e.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexp32e)
 #error This file requires the Xsfvfexp32e extension

--- a/src/silu/silu_f32_xsfvfexp32e.c
+++ b/src/silu/silu_f32_xsfvfexp32e.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp32e)
 #error This file requires the Xsfvfexp32e extension

--- a/src/silu/silu_f32_xsfvfexp32e.h
+++ b/src/silu/silu_f32_xsfvfexp32e.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/silu/silu_f32_xsfvfexp32e.h
+++ b/src/silu/silu_f32_xsfvfexp32e.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/silu/silu_f32_xsfvfexp32e.h
+++ b/src/silu/silu_f32_xsfvfexp32e.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/silu/silu_f32_xsfvfexp32e.h
+++ b/src/silu/silu_f32_xsfvfexp32e.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/silu/silu_f32_xsfvfexpa.c
+++ b/src/silu/silu_f32_xsfvfexpa.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/src/silu/silu_f32_xsfvfexpa.c
+++ b/src/silu/silu_f32_xsfvfexpa.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/silu/silu_f32_xsfvfexpa.c
+++ b/src/silu/silu_f32_xsfvfexpa.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/src/silu/silu_f32_xsfvfexpa.c
+++ b/src/silu/silu_f32_xsfvfexpa.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/src/silu/silu_f32_xsfvfexpa.h
+++ b/src/silu/silu_f32_xsfvfexpa.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/silu/silu_f32_xsfvfexpa.h
+++ b/src/silu/silu_f32_xsfvfexpa.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/silu/silu_f32_xsfvfexpa.h
+++ b/src/silu/silu_f32_xsfvfexpa.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/silu/silu_f32_xsfvfexpa.h
+++ b/src/silu/silu_f32_xsfvfexpa.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/silu/silu_f32_zve32f.c
+++ b/src/silu/silu_f32_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/silu/silu_f32_zve32f.c
+++ b/src/silu/silu_f32_zve32f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/silu/silu_f32_zve32f.c
+++ b/src/silu/silu_f32_zve32f.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/silu/silu_f32_zve32f.c
+++ b/src/silu/silu_f32_zve32f.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/silu/silu_f32_zve32f.h
+++ b/src/silu/silu_f32_zve32f.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/silu/silu_f32_zve32f.h
+++ b/src/silu/silu_f32_zve32f.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/silu/silu_f32_zve32f.h
+++ b/src/silu/silu_f32_zve32f.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/silu/silu_f32_zve32f.h
+++ b/src/silu/silu_f32_zve32f.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfbfa.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfbfa.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfbfa)
 #error This file requires the Xsfvfbfa extension

--- a/src/softmax/softmax_bf16_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfbfa.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfbfa)
 #error This file requires the Xsfvfbfa extension

--- a/src/softmax/softmax_bf16_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfbfa.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfbfa)
 #error This file requires the Xsfvfbfa extension

--- a/src/softmax/softmax_bf16_xsfvfbfa.h
+++ b/src/softmax/softmax_bf16_xsfvfbfa.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfbfa.h
+++ b/src/softmax/softmax_bf16_xsfvfbfa.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_xsfvfbfa.h
+++ b/src/softmax/softmax_bf16_xsfvfbfa.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfbfa.h
+++ b/src/softmax/softmax_bf16_xsfvfbfa.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfbfexp16e) || !defined(__riscv_xsfvfbfa)
 #error This file requires the Xsfvfbfexp16e and Xsfvfbfa extensions

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfbfexp16e) || !defined(__riscv_xsfvfbfa)
 #error This file requires the Xsfvfbfexp16e and Xsfvfbfa extensions

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfbfexp16e) || !defined(__riscv_xsfvfbfa)
 #error This file requires the Xsfvfbfexp16e and Xsfvfbfa extensions

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.h
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.h
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.h
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.h
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_xsfvfbfa.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfbfexp16e) || !defined(__riscv_zvfbfmin)
 #error This file requires the Xsfvfbfexp16e and Zvfbfmin extensions

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfbfexp16e) || !defined(__riscv_zvfbfmin)
 #error This file requires the Xsfvfbfexp16e and Zvfbfmin extensions

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfbfexp16e) || !defined(__riscv_zvfbfmin)
 #error This file requires the Xsfvfbfexp16e and Zvfbfmin extensions

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_xsfvfbfexp16e_zvfbfmin.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp32e) || !defined(__riscv_zvfbfmin)
 #error This file requires the Xsfvfexp32e and Zvfbfmin extensions

--- a/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexp32e) || !defined(__riscv_zvfbfmin)
 #error This file requires the Xsfvfexp32e and Zvfbfmin extensions

--- a/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp32e) || !defined(__riscv_zvfbfmin)
 #error This file requires the Xsfvfexp32e and Zvfbfmin extensions

--- a/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_xsfvfexp32e_zvfbfmin.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_xsfvfbfa)
 #error This file requires the Xsfvfexpa and Xsfvfbfa extensions

--- a/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_xsfvfbfa)
 #error This file requires the Xsfvfexpa and Xsfvfbfa extensions

--- a/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.c
+++ b/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_xsfvfbfa)
 #error This file requires the Xsfvfexpa and Xsfvfbfa extensions

--- a/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.h
+++ b/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.h
+++ b/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.h
+++ b/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.h
+++ b/src/softmax/softmax_bf16_xsfvfexpa_xsfvfbfa.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfbfmin)
 #error This file requires the Xsfvfexpa and Zvfbfmin extensions

--- a/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfbfmin)
 #error This file requires the Xsfvfexpa and Zvfbfmin extensions

--- a/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfbfmin)
 #error This file requires the Xsfvfexpa and Zvfbfmin extensions

--- a/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_xsfvfexpa_zvfbfmin.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_zve32f.c
+++ b/src/softmax/softmax_bf16_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/softmax/softmax_bf16_zve32f.c
+++ b/src/softmax/softmax_bf16_zve32f.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/softmax/softmax_bf16_zve32f.c
+++ b/src/softmax/softmax_bf16_zve32f.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/softmax/softmax_bf16_zve32f.c
+++ b/src/softmax/softmax_bf16_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_zve32f.c
+++ b/src/softmax/softmax_bf16_zve32f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/softmax/softmax_bf16_zve32f.h
+++ b/src/softmax/softmax_bf16_zve32f.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_zve32f.h
+++ b/src/softmax/softmax_bf16_zve32f.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_zve32f.h
+++ b/src/softmax/softmax_bf16_zve32f.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_zve32f.h
+++ b/src/softmax/softmax_bf16_zve32f.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_zvfbfmin.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfbfmin)
 #error This file requires the Zvfbfmin extension

--- a/src/softmax/softmax_bf16_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_zvfbfmin.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/softmax/softmax_bf16_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_zvfbfmin.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfbfmin)
 #error This file requires the Zvfbfmin extension

--- a/src/softmax/softmax_bf16_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_zvfbfmin.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zvfbfmin)
 #error This file requires the Zvfbfmin extension

--- a/src/softmax/softmax_bf16_zvfbfmin.c
+++ b/src/softmax/softmax_bf16_zvfbfmin.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_zvfbfmin.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_zvfbfmin.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_bf16_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_zvfbfmin.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_bf16_zvfbfmin.h
+++ b/src/softmax/softmax_bf16_zvfbfmin.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_f16_xsfvfexp16e.c
+++ b/src/softmax/softmax_f16_xsfvfexp16e.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp16e)
 #error This file requires the Xsfvfexp16e extension

--- a/src/softmax/softmax_f16_xsfvfexp16e.c
+++ b/src/softmax/softmax_f16_xsfvfexp16e.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/softmax/softmax_f16_xsfvfexp16e.c
+++ b/src/softmax/softmax_f16_xsfvfexp16e.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexp16e)
 #error This file requires the Xsfvfexp16e extension

--- a/src/softmax/softmax_f16_xsfvfexp16e.c
+++ b/src/softmax/softmax_f16_xsfvfexp16e.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp16e)
 #error This file requires the Xsfvfexp16e extension

--- a/src/softmax/softmax_f16_xsfvfexp16e.c
+++ b/src/softmax/softmax_f16_xsfvfexp16e.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_f16_xsfvfexp16e.h
+++ b/src/softmax/softmax_f16_xsfvfexp16e.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/softmax/softmax_f16_xsfvfexp16e.h
+++ b/src/softmax/softmax_f16_xsfvfexp16e.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_f16_xsfvfexp16e.h
+++ b/src/softmax/softmax_f16_xsfvfexp16e.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_f16_xsfvfexp16e.h
+++ b/src/softmax/softmax_f16_xsfvfexp16e.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_f16_xsfvfexpa_zvfh.c
+++ b/src/softmax/softmax_f16_xsfvfexpa_zvfh.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfh)
 #error This file requires the Xsfvfexpa and Zvfh extensions

--- a/src/softmax/softmax_f16_xsfvfexpa_zvfh.c
+++ b/src/softmax/softmax_f16_xsfvfexpa_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/softmax/softmax_f16_xsfvfexpa_zvfh.c
+++ b/src/softmax/softmax_f16_xsfvfexpa_zvfh.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfh)
 #error This file requires the Xsfvfexpa and Zvfh extensions

--- a/src/softmax/softmax_f16_xsfvfexpa_zvfh.c
+++ b/src/softmax/softmax_f16_xsfvfexpa_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_f16_xsfvfexpa_zvfh.c
+++ b/src/softmax/softmax_f16_xsfvfexpa_zvfh.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa) || !defined(__riscv_zvfh)
 #error This file requires the Xsfvfexpa and Zvfh extensions

--- a/src/softmax/softmax_f16_xsfvfexpa_zvfh.h
+++ b/src/softmax/softmax_f16_xsfvfexpa_zvfh.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/softmax/softmax_f16_xsfvfexpa_zvfh.h
+++ b/src/softmax/softmax_f16_xsfvfexpa_zvfh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_f16_xsfvfexpa_zvfh.h
+++ b/src/softmax/softmax_f16_xsfvfexpa_zvfh.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_f16_xsfvfexpa_zvfh.h
+++ b/src/softmax/softmax_f16_xsfvfexpa_zvfh.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_f16_zvfh.c
+++ b/src/softmax/softmax_f16_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/softmax/softmax_f16_zvfh.c
+++ b/src/softmax/softmax_f16_zvfh.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/softmax/softmax_f16_zvfh.c
+++ b/src/softmax/softmax_f16_zvfh.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/softmax/softmax_f16_zvfh.c
+++ b/src/softmax/softmax_f16_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_f16_zvfh.c
+++ b/src/softmax/softmax_f16_zvfh.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zvfh)
 #error This file requires the Zvfh extension

--- a/src/softmax/softmax_f16_zvfh.h
+++ b/src/softmax/softmax_f16_zvfh.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/softmax/softmax_f16_zvfh.h
+++ b/src/softmax/softmax_f16_zvfh.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_f16_zvfh.h
+++ b/src/softmax/softmax_f16_zvfh.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_f16_zvfh.h
+++ b/src/softmax/softmax_f16_zvfh.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_f32_xsfvfexp32e.c
+++ b/src/softmax/softmax_f32_xsfvfexp32e.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp32e)
 #error This file requires the Xsfvfexp32e extension

--- a/src/softmax/softmax_f32_xsfvfexp32e.c
+++ b/src/softmax/softmax_f32_xsfvfexp32e.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_f32_xsfvfexp32e.c
+++ b/src/softmax/softmax_f32_xsfvfexp32e.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexp32e)
 #error This file requires the Xsfvfexp32e extension

--- a/src/softmax/softmax_f32_xsfvfexp32e.c
+++ b/src/softmax/softmax_f32_xsfvfexp32e.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp32e)
 #error This file requires the Xsfvfexp32e extension

--- a/src/softmax/softmax_f32_xsfvfexp32e.h
+++ b/src/softmax/softmax_f32_xsfvfexp32e.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/softmax/softmax_f32_xsfvfexp32e.h
+++ b/src/softmax/softmax_f32_xsfvfexp32e.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_f32_xsfvfexp32e.h
+++ b/src/softmax/softmax_f32_xsfvfexp32e.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_f32_xsfvfexp32e.h
+++ b/src/softmax/softmax_f32_xsfvfexp32e.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_f32_xsfvfexpa.c
+++ b/src/softmax/softmax_f32_xsfvfexpa.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/src/softmax/softmax_f32_xsfvfexpa.c
+++ b/src/softmax/softmax_f32_xsfvfexpa.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/src/softmax/softmax_f32_xsfvfexpa.c
+++ b/src/softmax/softmax_f32_xsfvfexpa.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/softmax/softmax_f32_xsfvfexpa.c
+++ b/src/softmax/softmax_f32_xsfvfexpa.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/src/softmax/softmax_f32_xsfvfexpa.c
+++ b/src/softmax/softmax_f32_xsfvfexpa.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_f32_xsfvfexpa.h
+++ b/src/softmax/softmax_f32_xsfvfexpa.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/softmax/softmax_f32_xsfvfexpa.h
+++ b/src/softmax/softmax_f32_xsfvfexpa.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_f32_xsfvfexpa.h
+++ b/src/softmax/softmax_f32_xsfvfexpa.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_f32_xsfvfexpa.h
+++ b/src/softmax/softmax_f32_xsfvfexpa.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_f32_zve32f.c
+++ b/src/softmax/softmax_f32_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/softmax/softmax_f32_zve32f.c
+++ b/src/softmax/softmax_f32_zve32f.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/softmax/softmax_f32_zve32f.c
+++ b/src/softmax/softmax_f32_zve32f.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/softmax/softmax_f32_zve32f.c
+++ b/src/softmax/softmax_f32_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_f32_zve32f.c
+++ b/src/softmax/softmax_f32_zve32f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/src/softmax/softmax_f32_zve32f.h
+++ b/src/softmax/softmax_f32_zve32f.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/softmax/softmax_f32_zve32f.h
+++ b/src/softmax/softmax_f32_zve32f.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/softmax/softmax_f32_zve32f.h
+++ b/src/softmax/softmax_f32_zve32f.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/softmax/softmax_f32_zve32f.h
+++ b/src/softmax/softmax_f32_zve32f.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/transpose/rvv/transpose_e16_zve32x.c
+++ b/src/transpose/rvv/transpose_e16_zve32x.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32x)
 #error This file requires the Zve32x extension

--- a/src/transpose/rvv/transpose_e16_zve32x.c
+++ b/src/transpose/rvv/transpose_e16_zve32x.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/transpose/rvv/transpose_e16_zve32x.c
+++ b/src/transpose/rvv/transpose_e16_zve32x.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This file requires the Zve32x extension

--- a/src/transpose/rvv/transpose_e16_zve32x.c
+++ b/src/transpose/rvv/transpose_e16_zve32x.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/transpose/rvv/transpose_e16_zve32x.c
+++ b/src/transpose/rvv/transpose_e16_zve32x.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This file requires the Zve32x extension

--- a/src/transpose/rvv/transpose_e16_zve32x.h
+++ b/src/transpose/rvv/transpose_e16_zve32x.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/transpose/rvv/transpose_e16_zve32x.h
+++ b/src/transpose/rvv/transpose_e16_zve32x.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/transpose/rvv/transpose_e16_zve32x.h
+++ b/src/transpose/rvv/transpose_e16_zve32x.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/transpose/rvv/transpose_e16_zve32x.h
+++ b/src/transpose/rvv/transpose_e16_zve32x.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/transpose/rvv/transpose_e32_zve32x.c
+++ b/src/transpose/rvv/transpose_e32_zve32x.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32x)
 #error This file requires the Zve32x extension

--- a/src/transpose/rvv/transpose_e32_zve32x.c
+++ b/src/transpose/rvv/transpose_e32_zve32x.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/transpose/rvv/transpose_e32_zve32x.c
+++ b/src/transpose/rvv/transpose_e32_zve32x.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This file requires the Zve32x extension

--- a/src/transpose/rvv/transpose_e32_zve32x.c
+++ b/src/transpose/rvv/transpose_e32_zve32x.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/transpose/rvv/transpose_e32_zve32x.c
+++ b/src/transpose/rvv/transpose_e32_zve32x.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This file requires the Zve32x extension

--- a/src/transpose/rvv/transpose_e32_zve32x.h
+++ b/src/transpose/rvv/transpose_e32_zve32x.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/transpose/rvv/transpose_e32_zve32x.h
+++ b/src/transpose/rvv/transpose_e32_zve32x.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/transpose/rvv/transpose_e32_zve32x.h
+++ b/src/transpose/rvv/transpose_e32_zve32x.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/transpose/rvv/transpose_e32_zve32x.h
+++ b/src/transpose/rvv/transpose_e32_zve32x.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/transpose/rvv/transpose_e8_zve32x.c
+++ b/src/transpose/rvv/transpose_e8_zve32x.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32x)
 #error This file requires the Zve32x extension

--- a/src/transpose/rvv/transpose_e8_zve32x.c
+++ b/src/transpose/rvv/transpose_e8_zve32x.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/transpose/rvv/transpose_e8_zve32x.c
+++ b/src/transpose/rvv/transpose_e8_zve32x.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This file requires the Zve32x extension

--- a/src/transpose/rvv/transpose_e8_zve32x.c
+++ b/src/transpose/rvv/transpose_e8_zve32x.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/transpose/rvv/transpose_e8_zve32x.c
+++ b/src/transpose/rvv/transpose_e8_zve32x.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This file requires the Zve32x extension

--- a/src/transpose/rvv/transpose_e8_zve32x.h
+++ b/src/transpose/rvv/transpose_e8_zve32x.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/transpose/rvv/transpose_e8_zve32x.h
+++ b/src/transpose/rvv/transpose_e8_zve32x.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/transpose/rvv/transpose_e8_zve32x.h
+++ b/src/transpose/rvv/transpose_e8_zve32x.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/transpose/rvv/transpose_e8_zve32x.h
+++ b/src/transpose/rvv/transpose_e8_zve32x.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/transpose/xsfmm/transpose_e16_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e16_xsfmmbase.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/transpose/xsfmm/transpose_e16_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e16_xsfmmbase.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmmbase)
 #error This file requires the Xsfmmbase extension

--- a/src/transpose/xsfmm/transpose_e16_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e16_xsfmmbase.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfmmbase)
 #error This file requires the Xsfmmbase extension

--- a/src/transpose/xsfmm/transpose_e16_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e16_xsfmmbase.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmmbase)
 #error This file requires the Xsfmmbase extension

--- a/src/transpose/xsfmm/transpose_e16_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e16_xsfmmbase.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/transpose/xsfmm/transpose_e16_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e16_xsfmmbase.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/transpose/xsfmm/transpose_e16_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e16_xsfmmbase.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/transpose/xsfmm/transpose_e16_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e16_xsfmmbase.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/transpose/xsfmm/transpose_e16_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e16_xsfmmbase.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/transpose/xsfmm/transpose_e16_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e16_xsfmmbase.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/transpose/xsfmm/transpose_e32_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e32_xsfmmbase.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/transpose/xsfmm/transpose_e32_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e32_xsfmmbase.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmmbase)
 #error This file requires the Xsfmmbase extension

--- a/src/transpose/xsfmm/transpose_e32_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e32_xsfmmbase.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfmmbase)
 #error This file requires the Xsfmmbase extension

--- a/src/transpose/xsfmm/transpose_e32_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e32_xsfmmbase.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmmbase)
 #error This file requires the Xsfmmbase extension

--- a/src/transpose/xsfmm/transpose_e32_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e32_xsfmmbase.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/transpose/xsfmm/transpose_e32_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e32_xsfmmbase.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/transpose/xsfmm/transpose_e32_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e32_xsfmmbase.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/transpose/xsfmm/transpose_e32_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e32_xsfmmbase.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/transpose/xsfmm/transpose_e32_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e32_xsfmmbase.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/transpose/xsfmm/transpose_e32_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e32_xsfmmbase.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/transpose/xsfmm/transpose_e8_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e8_xsfmmbase.c
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/transpose/xsfmm/transpose_e8_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e8_xsfmmbase.c
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmmbase)
 #error This file requires the Xsfmmbase extension

--- a/src/transpose/xsfmm/transpose_e8_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e8_xsfmmbase.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfmmbase)
 #error This file requires the Xsfmmbase extension

--- a/src/transpose/xsfmm/transpose_e8_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e8_xsfmmbase.c
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfmmbase)
 #error This file requires the Xsfmmbase extension

--- a/src/transpose/xsfmm/transpose_e8_xsfmmbase.c
+++ b/src/transpose/xsfmm/transpose_e8_xsfmmbase.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/transpose/xsfmm/transpose_e8_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e8_xsfmmbase.h
@@ -1,5 +1,6 @@
 // Copyright 2025 SiFive, Inc.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/src/transpose/xsfmm/transpose_e8_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e8_xsfmmbase.h
@@ -1,4 +1,4 @@
-// Copyright 2025 SiFive, Inc.
+// Copyright (c) 2025 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 

--- a/src/transpose/xsfmm/transpose_e8_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e8_xsfmmbase.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2025 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/src/transpose/xsfmm/transpose_e8_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e8_xsfmmbase.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/transpose/xsfmm/transpose_e8_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e8_xsfmmbase.h
@@ -1,5 +1,5 @@
 // Copyright 2025 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 # Licensed under the MIT License.
 # See LICENSE file in the project root for full license information.
 # SPDX-License-Identifier: MIT

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+# SPDX-License-Identifier: MIT
 
 # Set default configuration
 set(SKL_TEST_LOG_LEVEL SKL_TEST_LOG_INFO CACHE STRING "Test log level")

--- a/test/cvt/cvt_bf16_f8.c
+++ b/test/cvt/cvt_bf16_f8.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the cvt_f16_f8 test harness.

--- a/test/cvt/cvt_bf16_f8.c
+++ b/test/cvt/cvt_bf16_f8.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/cvt/cvt_bf16_f8.c
+++ b/test/cvt/cvt_bf16_f8.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the cvt_f16_f8 test harness.

--- a/test/cvt/cvt_bf16_f8.c
+++ b/test/cvt/cvt_bf16_f8.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @brief Implementation of the cvt_f16_f8 test harness.

--- a/test/cvt/cvt_bf16_f8.h
+++ b/test/cvt/cvt_bf16_f8.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/test/cvt/cvt_bf16_f8.h
+++ b/test/cvt/cvt_bf16_f8.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/cvt/cvt_bf16_f8.h
+++ b/test/cvt/cvt_bf16_f8.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/cvt/cvt_bf16_f8.h
+++ b/test/cvt/cvt_bf16_f8.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
+++ b/test/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "cvt_bf16_f8.h"
 #include "skl-test-driver.h"

--- a/test/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
+++ b/test/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
+++ b/test/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "cvt_bf16_f8.h"
 #include "skl-test-driver.h"

--- a/test/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
+++ b/test/cvt/cvt_bf16_f8_zvfofp8min_zvfbfmin.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "cvt_bf16_f8.h"
 #include "skl-test-driver.h"

--- a/test/cvt/cvt_f32_f8.c
+++ b/test/cvt/cvt_f32_f8.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the cvt_f32_f8 test harness.

--- a/test/cvt/cvt_f32_f8.c
+++ b/test/cvt/cvt_f32_f8.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/cvt/cvt_f32_f8.c
+++ b/test/cvt/cvt_f32_f8.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the cvt_f32_f8 test harness.

--- a/test/cvt/cvt_f32_f8.c
+++ b/test/cvt/cvt_f32_f8.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @brief Implementation of the cvt_f32_f8 test harness.

--- a/test/cvt/cvt_f32_f8.h
+++ b/test/cvt/cvt_f32_f8.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/test/cvt/cvt_f32_f8.h
+++ b/test/cvt/cvt_f32_f8.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/cvt/cvt_f32_f8.h
+++ b/test/cvt/cvt_f32_f8.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/cvt/cvt_f32_f8.h
+++ b/test/cvt/cvt_f32_f8.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/cvt/cvt_f32_f8_zvfofp8min.c
+++ b/test/cvt/cvt_f32_f8_zvfofp8min.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/cvt/cvt_f32_f8_zvfofp8min.c
+++ b/test/cvt/cvt_f32_f8_zvfofp8min.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "cvt_f32_f8.h"
 #include "skl-test-driver.h"

--- a/test/cvt/cvt_f32_f8_zvfofp8min.c
+++ b/test/cvt/cvt_f32_f8_zvfofp8min.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "cvt_f32_f8.h"
 #include "skl-test-driver.h"

--- a/test/cvt/cvt_f32_f8_zvfofp8min.c
+++ b/test/cvt/cvt_f32_f8_zvfofp8min.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "cvt_f32_f8.h"
 #include "skl-test-driver.h"

--- a/test/cvt/cvt_f4_f8.c
+++ b/test/cvt/cvt_f4_f8.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the cvt_f4_f8 test harness.

--- a/test/cvt/cvt_f4_f8.c
+++ b/test/cvt/cvt_f4_f8.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/cvt/cvt_f4_f8.c
+++ b/test/cvt/cvt_f4_f8.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the cvt_f4_f8 test harness.

--- a/test/cvt/cvt_f4_f8.c
+++ b/test/cvt/cvt_f4_f8.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @brief Implementation of the cvt_f4_f8 test harness.

--- a/test/cvt/cvt_f4_f8.h
+++ b/test/cvt/cvt_f4_f8.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/test/cvt/cvt_f4_f8.h
+++ b/test/cvt/cvt_f4_f8.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/cvt/cvt_f4_f8.h
+++ b/test/cvt/cvt_f4_f8.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/cvt/cvt_f4_f8.h
+++ b/test/cvt/cvt_f4_f8.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/cvt/cvt_f4_f8_zvfofp4min.c
+++ b/test/cvt/cvt_f4_f8_zvfofp4min.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/cvt/cvt_f4_f8_zvfofp4min.c
+++ b/test/cvt/cvt_f4_f8_zvfofp4min.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "cvt_f4_f8.h"
 #include "skl-test-driver.h"

--- a/test/cvt/cvt_f4_f8_zvfofp4min.c
+++ b/test/cvt/cvt_f4_f8_zvfofp4min.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "cvt_f4_f8.h"
 #include "skl-test-driver.h"

--- a/test/cvt/cvt_f4_f8_zvfofp4min.c
+++ b/test/cvt/cvt_f4_f8_zvfofp4min.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "cvt_f4_f8.h"
 #include "skl-test-driver.h"

--- a/test/cvt/cvt_f8_bf16.c
+++ b/test/cvt/cvt_f8_bf16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/cvt/cvt_f8_bf16.c
+++ b/test/cvt/cvt_f8_bf16.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the cvt_f8_bf16 test harness.

--- a/test/cvt/cvt_f8_bf16.c
+++ b/test/cvt/cvt_f8_bf16.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @brief Implementation of the cvt_f8_bf16 test harness.

--- a/test/cvt/cvt_f8_bf16.c
+++ b/test/cvt/cvt_f8_bf16.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the cvt_f8_bf16 test harness.

--- a/test/cvt/cvt_f8_bf16.h
+++ b/test/cvt/cvt_f8_bf16.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/test/cvt/cvt_f8_bf16.h
+++ b/test/cvt/cvt_f8_bf16.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/cvt/cvt_f8_bf16.h
+++ b/test/cvt/cvt_f8_bf16.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/cvt/cvt_f8_bf16.h
+++ b/test/cvt/cvt_f8_bf16.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/cvt/cvt_f8_bf16_zvfofp8min.c
+++ b/test/cvt/cvt_f8_bf16_zvfofp8min.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 #include "cvt_f8_bf16.h"
 #include "skl-test-driver.h"
 #include "skl.h"

--- a/test/cvt/cvt_f8_bf16_zvfofp8min.c
+++ b/test/cvt/cvt_f8_bf16_zvfofp8min.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/cvt/cvt_f8_bf16_zvfofp8min.c
+++ b/test/cvt/cvt_f8_bf16_zvfofp8min.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 #include "cvt_f8_bf16.h"
 #include "skl-test-driver.h"
 #include "skl.h"

--- a/test/cvt/cvt_f8_bf16_zvfofp8min.c
+++ b/test/cvt/cvt_f8_bf16_zvfofp8min.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 #include "cvt_f8_bf16.h"
 #include "skl-test-driver.h"
 #include "skl.h"

--- a/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the depthwise_conv2d_f16_f16_f16 test harness.

--- a/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @brief Implementation of the depthwise_conv2d_f16_f16_f16 test harness.

--- a/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the depthwise_conv2d_f16_f16_f16 test harness.

--- a/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
+++ b/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
+++ b/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
+++ b/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
+++ b/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the depthwise_conv2d_f32_f32_f32 test harness.

--- a/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @brief Implementation of the depthwise_conv2d_f32_f32_f32 test harness.

--- a/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the depthwise_conv2d_f32_f32_f32 test harness.

--- a/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
+++ b/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
+++ b/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
+++ b/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
+++ b/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the depthwise_conv2d_i8_i8_i32 test harness.

--- a/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the depthwise_conv2d_i8_i8_i32 test harness.

--- a/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @brief Implementation of the depthwise_conv2d_i8_i8_i32 test harness.

--- a/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
+++ b/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
+++ b/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
+++ b/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
+++ b/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_f16_f16_f16_zvfh.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_f16_f16_f16_zvfh.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h"
 #include "depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h"

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_f16_f16_f16_zvfh.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_f16_f16_f16_zvfh.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_f16_f16_f16_zvfh.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_f16_f16_f16_zvfh.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h"
 #include "depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h"

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_f16_f16_f16_zvfh.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_f16_f16_f16_zvfh.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h"
 #include "depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h"

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_f32_f32_f32_zve32f.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_f32_f32_f32_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_f32_f32_f32_zve32f.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_f32_f32_f32_zve32f.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h"
 #include "depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h"

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_f32_f32_f32_zve32f.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_f32_f32_f32_zve32f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h"
 #include "depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h"

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_f32_f32_f32_zve32f.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_f32_f32_f32_zve32f.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h"
 #include "depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h"

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_i8_i8_i32_zve32x.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_i8_i8_i32_zve32x.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h"
 #include "depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h"

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_i8_i8_i32_zve32x.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_i8_i8_i32_zve32x.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_i8_i8_i32_zve32x.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_i8_i8_i32_zve32x.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h"
 #include "depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h"

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_i8_i8_i32_zve32x.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_i8_i8_i32_zve32x.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h"
 #include "depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h"

--- a/test/elementwise/unary_f32.c
+++ b/test/elementwise/unary_f32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/elementwise/unary_f32.c
+++ b/test/elementwise/unary_f32.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @brief Generic test harness for f32 unary element-wise functions.

--- a/test/elementwise/unary_f32.c
+++ b/test/elementwise/unary_f32.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @brief Generic test harness for f32 unary element-wise functions.

--- a/test/elementwise/unary_f32.c
+++ b/test/elementwise/unary_f32.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @brief Generic test harness for f32 unary element-wise functions.

--- a/test/elementwise/unary_f32.h
+++ b/test/elementwise/unary_f32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/elementwise/unary_f32.h
+++ b/test/elementwise/unary_f32.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @brief Test and benchmark for FP32 unary functions f(x) = y.

--- a/test/elementwise/unary_f32.h
+++ b/test/elementwise/unary_f32.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @brief Test and benchmark for FP32 unary functions f(x) = y.

--- a/test/elementwise/unary_f32.h
+++ b/test/elementwise/unary_f32.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @brief Test and benchmark for FP32 unary functions f(x) = y.

--- a/test/exp/exp_bf16.c
+++ b/test/exp/exp_bf16.c
@@ -1,3 +1,8 @@
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST or ENABLE_BENCHMARK
 #endif

--- a/test/exp/exp_bf16.c
+++ b/test/exp/exp_bf16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/exp/exp_f16.c
+++ b/test/exp/exp_f16.c
@@ -1,3 +1,8 @@
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST or ENABLE_BENCHMARK
 #endif

--- a/test/exp/exp_f16.c
+++ b/test/exp/exp_f16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/exp/exp_f32_xsfvfexp32e.c
+++ b/test/exp/exp_f32_xsfvfexp32e.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp32e)
 #error This file requires the Xsfvfexp32e extension

--- a/test/exp/exp_f32_xsfvfexp32e.c
+++ b/test/exp/exp_f32_xsfvfexp32e.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/exp/exp_f32_xsfvfexp32e.c
+++ b/test/exp/exp_f32_xsfvfexp32e.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexp32e)
 #error This file requires the Xsfvfexp32e extension

--- a/test/exp/exp_f32_xsfvfexp32e.c
+++ b/test/exp/exp_f32_xsfvfexp32e.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexp32e)
 #error This file requires the Xsfvfexp32e extension

--- a/test/exp/exp_f32_xsfvfexpa.c
+++ b/test/exp/exp_f32_xsfvfexpa.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/test/exp/exp_f32_xsfvfexpa.c
+++ b/test/exp/exp_f32_xsfvfexpa.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/exp/exp_f32_xsfvfexpa.c
+++ b/test/exp/exp_f32_xsfvfexpa.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/test/exp/exp_f32_xsfvfexpa.c
+++ b/test/exp/exp_f32_xsfvfexpa.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_xsfvfexpa)
 #error This file requires the Xsfvfexpa extension

--- a/test/exp/exp_f32_zve32f.c
+++ b/test/exp/exp_f32_zve32f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/exp/exp_f32_zve32f.c
+++ b/test/exp/exp_f32_zve32f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/test/exp/exp_f32_zve32f.c
+++ b/test/exp/exp_f32_zve32f.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/test/exp/exp_f32_zve32f.c
+++ b/test/exp/exp_f32_zve32f.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32f)
 #error This file requires the Zve32f extension

--- a/test/gelu/gelu_f32.c
+++ b/test/gelu/gelu_f32.c
@@ -1,3 +1,8 @@
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
 #if !defined(__riscv_zve32f)
 #error This file require the Zve32f extension
 #endif

--- a/test/gelu/gelu_f32.c
+++ b/test/gelu/gelu_f32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
+++ b/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
+++ b/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
+++ b/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
+++ b/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f16rc_f16rc_f16rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f16rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_f16rc_f16rc_f16rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f16rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f16rc_f16rc_f16rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f16rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f16rc_f16rc_f16rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f16rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @brief Implementation of the gemm_f32rcprc_f32rcprc_f32rcprc test harness.

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the gemm_f32rcprc_f32rcprc_f32rcprc test harness.

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the gemm_f32rcprc_f32rcprc_f32rcprc test harness.

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @brief Test and benchmark for packed GEMM: C_pack = alpha * A_pack * B_pack +

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @brief Test and benchmark for packed GEMM: C_pack = alpha * A_pack * B_pack +

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @brief Test and benchmark for packed GEMM: C_pack = alpha * A_pack * B_pack +

--- a/test/gemm/gemm_f64rc_f64rc_f64rc.c
+++ b/test/gemm/gemm_f64rc_f64rc_f64rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_f64rc_f64rc_f64rc.c
+++ b/test/gemm/gemm_f64rc_f64rc_f64rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f64rc_f64rc_f64rc.c
+++ b/test/gemm/gemm_f64rc_f64rc_f64rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f64rc_f64rc_f64rc.c
+++ b/test/gemm/gemm_f64rc_f64rc_f64rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
+++ b/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
+++ b/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
+++ b/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
+++ b/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
+++ b/test/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
+++ b/test/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
+++ b/test/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
+++ b/test/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_i8_i8pc_i32_xsfvqdotq.c
+++ b/test/gemm/gemm_i8_i8pc_i32_xsfvqdotq.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This source file requires compiler support for the RISC-V Zve32x extension.

--- a/test/gemm/gemm_i8_i8pc_i32_xsfvqdotq.c
+++ b/test/gemm/gemm_i8_i8pc_i32_xsfvqdotq.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_i8_i8pc_i32_xsfvqdotq.c
+++ b/test/gemm/gemm_i8_i8pc_i32_xsfvqdotq.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This source file requires compiler support for the RISC-V Zve32x extension.

--- a/test/gemm/gemm_i8_i8pc_i32_xsfvqdotq.c
+++ b/test/gemm/gemm_i8_i8pc_i32_xsfvqdotq.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32x)
 #error This source file requires compiler support for the RISC-V Zve32x extension.

--- a/test/gemm/gemm_i8rc_i8rc_i32rc.c
+++ b/test/gemm/gemm_i8rc_i8rc_i32rc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_i8rc_i8rc_i32rc.c
+++ b/test/gemm/gemm_i8rc_i8rc_i32rc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_i8rc_i8rc_i32rc.c
+++ b/test/gemm/gemm_i8rc_i8rc_i32rc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_i8rc_i8rc_i32rc.c
+++ b/test/gemm/gemm_i8rc_i8rc_i32rc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /* Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *

--- a/test/gemm/pack_b_i8_xsfvqdotq.c
+++ b/test/gemm/pack_b_i8_xsfvqdotq.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This source file requires compiler support for the RISC-V Zve32x extension.

--- a/test/gemm/pack_b_i8_xsfvqdotq.c
+++ b/test/gemm/pack_b_i8_xsfvqdotq.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/pack_b_i8_xsfvqdotq.c
+++ b/test/gemm/pack_b_i8_xsfvqdotq.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(__riscv_zve32x)
 #error This source file requires compiler support for the RISC-V Zve32x extension.

--- a/test/gemm/pack_b_i8_xsfvqdotq.c
+++ b/test/gemm/pack_b_i8_xsfvqdotq.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(__riscv_zve32x)
 #error This source file requires compiler support for the RISC-V Zve32x extension.

--- a/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
+++ b/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h"
 #include "skl-test-driver.h"

--- a/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
+++ b/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
+++ b/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h"
 #include "skl-test-driver.h"

--- a/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
+++ b/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h"
 #include "skl-test-driver.h"

--- a/test/gemm/skl_test_gemm.h
+++ b/test/gemm/skl_test_gemm.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @file skl_test_gemm.h

--- a/test/gemm/skl_test_gemm.h
+++ b/test/gemm/skl_test_gemm.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/skl_test_gemm.h
+++ b/test/gemm/skl_test_gemm.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @file skl_test_gemm.h

--- a/test/gemm/skl_test_gemm.h
+++ b/test/gemm/skl_test_gemm.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @file skl_test_gemm.h

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h"
 #include "skl-test-driver.h"

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h"
 #include "skl-test-driver.h"

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h"
 #include "skl-test-driver.h"

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h"
 #include "gemm/skl_test_gemm.h"

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h"
 #include "gemm/skl_test_gemm.h"

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h"
 #include "gemm/skl_test_gemm.h"

--- a/test/logistic/logistic_f16.c
+++ b/test/logistic/logistic_f16.c
@@ -1,4 +1,4 @@
-// Copyright 2026 SiFive, Inc.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST or ENABLE_BENCHMARK
 #endif

--- a/test/logistic/logistic_f16.c
+++ b/test/logistic/logistic_f16.c
@@ -1,4 +1,8 @@
 // Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST or ENABLE_BENCHMARK
 #endif

--- a/test/logistic/logistic_f16.c
+++ b/test/logistic/logistic_f16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/logistic/logistic_f16.c
+++ b/test/logistic/logistic_f16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST or ENABLE_BENCHMARK
 #endif

--- a/test/logistic/logistic_f32.c
+++ b/test/logistic/logistic_f32.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST or ENABLE_BENCHMARK

--- a/test/logistic/logistic_f32.c
+++ b/test/logistic/logistic_f32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/logistic/logistic_f32.c
+++ b/test/logistic/logistic_f32.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST or ENABLE_BENCHMARK

--- a/test/logistic/logistic_f32.c
+++ b/test/logistic/logistic_f32.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST or ENABLE_BENCHMARK

--- a/test/silu/silu_f16.c
+++ b/test/silu/silu_f16.c
@@ -1,4 +1,4 @@
-// Copyright 2026 SiFive, Inc.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST or ENABLE_BENCHMARK
 #endif

--- a/test/silu/silu_f16.c
+++ b/test/silu/silu_f16.c
@@ -1,4 +1,8 @@
 // Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST or ENABLE_BENCHMARK
 #endif

--- a/test/silu/silu_f16.c
+++ b/test/silu/silu_f16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/silu/silu_f16.c
+++ b/test/silu/silu_f16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST or ENABLE_BENCHMARK
 #endif

--- a/test/silu/silu_f32.c
+++ b/test/silu/silu_f32.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST or ENABLE_BENCHMARK

--- a/test/silu/silu_f32.c
+++ b/test/silu/silu_f32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/silu/silu_f32.c
+++ b/test/silu/silu_f32.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST or ENABLE_BENCHMARK

--- a/test/silu/silu_f32.c
+++ b/test/silu/silu_f32.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST or ENABLE_BENCHMARK

--- a/test/skl-test-driver.c
+++ b/test/skl-test-driver.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/skl-test-driver.c
+++ b/test/skl-test-driver.c
@@ -1,3 +1,8 @@
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
 #include "skl-test-driver.h"
 #include <inttypes.h>
 #include <stdarg.h>

--- a/test/skl-test-driver.h
+++ b/test/skl-test-driver.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @file skl-test-driver.h

--- a/test/skl-test-driver.h
+++ b/test/skl-test-driver.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @file skl-test-driver.h

--- a/test/skl-test-driver.h
+++ b/test/skl-test-driver.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/skl-test-driver.h
+++ b/test/skl-test-driver.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @file skl-test-driver.h

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/softmax/softmax_2d_f32.c
+++ b/test/softmax/softmax_2d_f32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/softmax/softmax_2d_f32.c
+++ b/test/softmax/softmax_2d_f32.c
@@ -1,3 +1,8 @@
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST and ENABLE_BENCHMARK.
 #endif

--- a/test/softmax/softmax_bf16.c
+++ b/test/softmax/softmax_bf16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/softmax/softmax_bf16.c
+++ b/test/softmax/softmax_bf16.c
@@ -1,3 +1,8 @@
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST and ENABLE_BENCHMARK.
 #endif

--- a/test/softmax/softmax_f16.c
+++ b/test/softmax/softmax_f16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/softmax/softmax_f16.c
+++ b/test/softmax/softmax_f16.c
@@ -1,3 +1,8 @@
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST and ENABLE_BENCHMARK.
 #endif

--- a/test/softmax/softmax_f32.c
+++ b/test/softmax/softmax_f32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/softmax/softmax_f32.c
+++ b/test/softmax/softmax_f32.c
@@ -1,3 +1,8 @@
+// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
 #if !defined(ENABLE_TEST) && !defined(ENABLE_BENCHMARK)
 #error Must define at least one of ENABLE_TEST and ENABLE_BENCHMARK.
 #endif

--- a/test/transpose/rvv/skl_transpose_e8_zve32x.c
+++ b/test/transpose/rvv/skl_transpose_e8_zve32x.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/transpose/rvv/skl_transpose_e8_zve32x.c
+++ b/test/transpose/rvv/skl_transpose_e8_zve32x.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-test-driver.h"
 #include "skl.h"

--- a/test/transpose/rvv/skl_transpose_e8_zve32x.c
+++ b/test/transpose/rvv/skl_transpose_e8_zve32x.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-test-driver.h"
 #include "skl.h"

--- a/test/transpose/rvv/skl_transpose_e8_zve32x.c
+++ b/test/transpose/rvv/skl_transpose_e8_zve32x.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-test-driver.h"
 #include "skl.h"

--- a/test/transpose/transpose_e16.c
+++ b/test/transpose/transpose_e16.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/transpose/transpose_e16.c
+++ b/test/transpose/transpose_e16.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !(defined(ENABLE_TEST) || defined(ENABLE_BENCHMARK))
 #error Must define at least one of ENABLE_TEST and ENABLE_BENCHMARK

--- a/test/transpose/transpose_e16.c
+++ b/test/transpose/transpose_e16.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !(defined(ENABLE_TEST) || defined(ENABLE_BENCHMARK))
 #error Must define at least one of ENABLE_TEST and ENABLE_BENCHMARK

--- a/test/transpose/transpose_e16.c
+++ b/test/transpose/transpose_e16.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !(defined(ENABLE_TEST) || defined(ENABLE_BENCHMARK))
 #error Must define at least one of ENABLE_TEST and ENABLE_BENCHMARK

--- a/test/transpose/transpose_e32.c
+++ b/test/transpose/transpose_e32.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/transpose/transpose_e32.c
+++ b/test/transpose/transpose_e32.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #if !(defined(ENABLE_TEST) || defined(ENABLE_BENCHMARK))
 #error Must define at least one of ENABLE_TEST and ENABLE_BENCHMARK

--- a/test/transpose/transpose_e32.c
+++ b/test/transpose/transpose_e32.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #if !(defined(ENABLE_TEST) || defined(ENABLE_BENCHMARK))
 #error Must define at least one of ENABLE_TEST and ENABLE_BENCHMARK

--- a/test/transpose/transpose_e32.c
+++ b/test/transpose/transpose_e32.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #if !(defined(ENABLE_TEST) || defined(ENABLE_BENCHMARK))
 #error Must define at least one of ENABLE_TEST and ENABLE_BENCHMARK

--- a/test/transpose/transpose_e8.c
+++ b/test/transpose/transpose_e8.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the transpose_e8 test harness.

--- a/test/transpose/transpose_e8.c
+++ b/test/transpose/transpose_e8.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/transpose/transpose_e8.c
+++ b/test/transpose/transpose_e8.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 /**
  * @brief Implementation of the transpose_e8 test harness.

--- a/test/transpose/transpose_e8.c
+++ b/test/transpose/transpose_e8.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 /**
  * @brief Implementation of the transpose_e8 test harness.

--- a/test/transpose/transpose_e8.h
+++ b/test/transpose/transpose_e8.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/test/transpose/transpose_e8.h
+++ b/test/transpose/transpose_e8.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/transpose/transpose_e8.h
+++ b/test/transpose/transpose_e8.h
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/transpose/transpose_e8.h
+++ b/test/transpose/transpose_e8.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #pragma once
 

--- a/test/transpose/xsfmmbase/skl_transpose_e8_xsfmmbase.c
+++ b/test/transpose/xsfmmbase/skl_transpose_e8_xsfmmbase.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/test/transpose/xsfmmbase/skl_transpose_e8_xsfmmbase.c
+++ b/test/transpose/xsfmmbase/skl_transpose_e8_xsfmmbase.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 SiFive, Inc. All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
 
 #include "skl-test-driver.h"
 #include "skl.h"

--- a/test/transpose/xsfmmbase/skl_transpose_e8_xsfmmbase.c
+++ b/test/transpose/xsfmmbase/skl_transpose_e8_xsfmmbase.c
@@ -1,5 +1,5 @@
-// Copyright 2026 SiFive, Inc.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 #include "skl-test-driver.h"
 #include "skl.h"

--- a/test/transpose/xsfmmbase/skl_transpose_e8_xsfmmbase.c
+++ b/test/transpose/xsfmmbase/skl_transpose_e8_xsfmmbase.c
@@ -1,6 +1,7 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026-Present SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 
 #include "skl-test-driver.h"
 #include "skl.h"


### PR DESCRIPTION
Updating the whole project codebase to the MIT license before public release. This is the ultimate decision on the project license. While git history may show this project being under Apache 2 license that we considered previously it was never released under it.

* Change LICENSE
* Update CONTRIBUTING doc
* Update all source headers
* Update years to range
* Added header to makefiles