### PR TITLE
Clean-up .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,5 +30,6 @@ Checks:
 WarningsAsErrors: '*'
 CheckOptions:
   bugprone-reserved-identifier.AllowedIdentifiers: '__riscv_*'
-  readability-function-cognitive-complexity.Threshold: 180
   hicpp-signed-bitwise.IgnorePositiveIntegerLiterals: true
+  misc-include-cleaner.IgnoreHeaders: "skl-ref.h;skl.h"
+  readability-function-cognitive-complexity.Threshold: 180

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,3 +34,4 @@ CheckOptions:
   hicpp-signed-bitwise.IgnorePositiveIntegerLiterals: true
   misc-include-cleaner.IgnoreHeaders: "skl-ref.h;skl.h"
   readability-function-cognitive-complexity.Threshold: 180
+  readability-suspicious-call-argument.MinimumIdentifierNameLength: 4

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,7 @@ Checks:
   - portability-*
   - readability-*
   - -readability-identifier-length
+  - -readability-isolate-declaration
   - -readability-magic-numbers
   - -readability-math-missing-parentheses
   - -*-braces-around-statements

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -894,10 +894,8 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
     size_t tm, size_t tn, size_t k, const __bf16 *a, size_t csa0, size_t rsa1,
     const __bf16 *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm2tn_2tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 3 (= 1 x 3) contiguous tm x tn tiles of c.
@@ -921,10 +919,8 @@ skl_gemm_3tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
     size_t tm, size_t tn, size_t k, const __bf16 *a, size_t csa0, size_t rsa1,
     const __bf16 *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm3tn_3tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 1 x 4) contiguous tm x tn tiles of c.
@@ -947,10 +943,8 @@ SKL_FUNC_PRIVATE void skl_gemm_4tm1tn_a1b01_bf16pc_bf16_f32rcp_xsfmm32a16f(
     size_t tm, size_t tn, size_t k, const __bf16 *a, size_t csa0, size_t rsa1,
     const __bf16 *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm4tn_4tm1tn_a1b01_bf16c_bf16_f32_xsfmm32a16f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 2 x 2) contiguous tn x tn tiles of c. tn must be <= TE. */

--- a/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.c
@@ -895,10 +895,8 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm1tn_a1b01_f16pc_f16_f32rcp_xsfmm32a16f(
     size_t tm, size_t tn, size_t k, const _Float16 *a, size_t csa0, size_t rsa1,
     const _Float16 *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm2tn_2tm1tn_a1b01_f16c_f16_f32_xsfmm32a16f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 3 (= 1 x 3) contiguous tm x tn tiles of c.
@@ -922,10 +920,8 @@ skl_gemm_3tm1tn_a1b01_f16pc_f16_f32rcp_xsfmm32a16f(
     size_t tm, size_t tn, size_t k, const _Float16 *a, size_t csa0, size_t rsa1,
     const _Float16 *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm3tn_3tm1tn_a1b01_f16c_f16_f32_xsfmm32a16f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 1 x 4) contiguous tm x tn tiles of c.
@@ -948,10 +944,8 @@ SKL_FUNC_PRIVATE void skl_gemm_4tm1tn_a1b01_f16pc_f16_f32rcp_xsfmm32a16f(
     size_t tm, size_t tn, size_t k, const _Float16 *a, size_t csa0, size_t rsa1,
     const _Float16 *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm4tn_4tm1tn_a1b01_f16c_f16_f32_xsfmm32a16f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 2 x 2) contiguous tn x tn tiles of c. tn must be <= TE. */

--- a/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
@@ -615,10 +615,8 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm1tn_a1b01_f32pc_f32_f32rcp_xsfmm32a32f(
     size_t tm, size_t tn, size_t k, const float *a, size_t csa0, size_t rsa1,
     const float *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm2tn_2tm1tn_a1b01_f32c_f32_f32_xsfmm32a32f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 3 (= 1 x 3) contiguous tm x tn tiles of c.
@@ -643,10 +641,8 @@ skl_gemm_3tm1tn_a1b01_f32pc_f32_f32rcp_xsfmm32a32f(size_t tm, size_t tn,
                                                    const float *b, size_t rsb,
                                                    float *c, size_t rsc0,
                                                    size_t rsc1, bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm3tn_3tm1tn_a1b01_f32c_f32_f32_xsfmm32a32f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 1 x 4) contiguous tm x tn tiles of c.
@@ -668,10 +664,8 @@ SKL_FUNC_PRIVATE void skl_gemm_4tm1tn_a1b01_f32pc_f32_f32rcp_xsfmm32a32f(
     size_t tm, size_t tn, size_t k, const float *a, size_t csa0, size_t rsa1,
     const float *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm4tn_4tm1tn_a1b01_f32c_f32_f32_xsfmm32a32f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 2 x 2) contiguous tm x tn tiles of c.

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -1852,10 +1852,8 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
     size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
     const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm2tn_2tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 3 (= 1 x 3) contiguous tm x tn tiles of c.
@@ -1879,10 +1877,8 @@ skl_gemm_3tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
     size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
     const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm3tn_3tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 1 x 4) contiguous tm x tn tiles of c.
@@ -1905,10 +1901,8 @@ SKL_FUNC_PRIVATE void skl_gemm_4tm1tn_a1b01_f8e4m3pc_f8e4m3_f32rcp_xsfmm32a8f(
     size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
     const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm4tn_4tm1tn_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 2 x 2) contiguous tn x tn tiles of c. tn must be <= TE. */

--- a/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
@@ -1852,10 +1852,8 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm1tn_a1b01_f8e5m2pc_f8e5m2_f32rcp_xsfmm32a8f(
     size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
     const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm2tn_2tm1tn_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 3 (= 1 x 3) contiguous tm x tn tiles of c.
@@ -1879,10 +1877,8 @@ skl_gemm_3tm1tn_a1b01_f8e5m2pc_f8e5m2_f32rcp_xsfmm32a8f(
     size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
     const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm3tn_3tm1tn_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 1 x 4) contiguous tm x tn tiles of c.
@@ -1905,10 +1901,8 @@ SKL_FUNC_PRIVATE void skl_gemm_4tm1tn_a1b01_f8e5m2pc_f8e5m2_f32rcp_xsfmm32a8f(
     size_t tm, size_t tn, size_t k, const uint8_t *a, size_t csa0, size_t rsa1,
     const uint8_t *b, size_t rsb, float *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm4tn_4tm1tn_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 2 x 2) contiguous tn x tn tiles of c. tn must be <= TE. */

--- a/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
+++ b/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
@@ -1848,10 +1848,8 @@ SKL_FUNC_PRIVATE void skl_gemm_2tm1tn_a1b01_i8pc_i8_i32rcp_xsfmm32a8i(
     size_t tm, size_t tn, size_t k, const int8_t *a, size_t csa0, size_t rsa1,
     const int8_t *b, size_t rsb, int32_t *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm2tn_2tm1tn_a1b01_i8c_i8_i32_xsfmm32a8i(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 3 (= 1 x 3) contiguous tm x tn tiles of c.
@@ -1877,10 +1875,8 @@ skl_gemm_3tm1tn_a1b01_i8pc_i8_i32rcp_xsfmm32a8i(size_t tm, size_t tn, size_t k,
                                                 size_t rsb, int32_t *c,
                                                 size_t rsc0, size_t rsc1,
                                                 bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm3tn_3tm1tn_a1b01_i8c_i8_i32_xsfmm32a8i(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 1 x 4) contiguous tm x tn tiles of c.
@@ -1903,10 +1899,8 @@ SKL_FUNC_PRIVATE void skl_gemm_4tm1tn_a1b01_i8pc_i8_i32rcp_xsfmm32a8i(
     size_t tm, size_t tn, size_t k, const int8_t *a, size_t csa0, size_t rsa1,
     const int8_t *b, size_t rsb, int32_t *c, size_t rsc0, size_t rsc1,
     bool accum) {
-  // NOLINTBEGIN(readability-suspicious-call-argument)
   skl_gemm_1tm4tn_4tm1tn_a1b01_i8c_i8_i32_xsfmm32a8i(
       tm, tn, k, b, rsb, a, csa0, rsa1, c, rsc0, rsc1, accum, true);
-  // NOLINTEND(readability-suspicious-call-argument)
 }
 
 /* Process 4 (= 2 x 2) contiguous tn x tn tiles of c. tn must be <= TE. */

--- a/src/softmax/softmax_f32_xsfvfexp32e.c
+++ b/src/softmax/softmax_f32_xsfvfexp32e.c
@@ -200,7 +200,7 @@ skl_softmax_2d_nvec_f32_xsfvfexp32e(float *s, const size_t rss, const float *a,
 // NOLINTBEGIN(*-confusable-identifiers,*-suspicious-call-argument)
 SKL_FUNC_PRIVATE vfloat32m1x4_t
 skl_softmax_vget_v_f32m1x8_f32m1x4(vfloat32m1x8_t src, size_t index) {
-  vfloat32m1_t v0, v1, v2, v3; // NOLINT(*-isolate-declaration)
+  vfloat32m1_t v0, v1, v2, v3;
   if (index == 0) {
     v0 = __riscv_vget_v_f32m1x8_f32m1(src, 0);
     v1 = __riscv_vget_v_f32m1x8_f32m1(src, 1);

--- a/src/softmax/softmax_f32_xsfvfexp32e.c
+++ b/src/softmax/softmax_f32_xsfvfexp32e.c
@@ -197,7 +197,7 @@ skl_softmax_2d_nvec_f32_xsfvfexp32e(float *s, const size_t rss, const float *a,
   }
 }
 
-// NOLINTBEGIN(*-confusable-identifiers,*-suspicious-call-argument)
+// NOLINTBEGIN(*-confusable-identifiers)
 SKL_FUNC_PRIVATE vfloat32m1x4_t
 skl_softmax_vget_v_f32m1x8_f32m1x4(vfloat32m1x8_t src, size_t index) {
   vfloat32m1_t v0, v1, v2, v3;
@@ -555,7 +555,7 @@ SKL_FUNC_PRIVATE vfloat32m1x8_t skl_softmax_vfmsub_vf_f32m1x8(vfloat32m1x8_t vd,
   v1 = skl_softmax_vfmsub_vf_f32m1x4(v1, rs1, vs2, vl);
   return skl_softmax_vcreate_v_f32m1x4_f32m1x8(v0, v1);
 }
-// NOLINTEND(*-confusable-identifiers,*-suspicious-call-argument)
+// NOLINTEND(*-confusable-identifiers)
 
 /* Element-wise reciprocal approximation where inputs are known to be
    non-zero and infinite inputs are safe to become NaN. */
@@ -784,7 +784,6 @@ SKL_FUNC_PRIVATE void skl_softmax_2d_mvec_f32_xsfvfexp32e(float *s, size_t rss,
     vfloat32m1_t vmax;  /* Global maximum */
     size_t j = 0;       /* column index */
 
-    // NOLINTBEGIN(*-suspicious-call-argument)
     if (n >= 16) {
       vfloat32m1x8_t vx0 =
           __riscv_vlsseg8e32_v_f32m1x8(a + i * rsa + 0, bsa, vl);
@@ -839,7 +838,6 @@ SKL_FUNC_PRIVATE void skl_softmax_2d_mvec_f32_xsfvfexp32e(float *s, size_t rss,
       vss = skl_softmax_vfmadd_vv_f32m1x4(vss, vc, ves, vl);
       vmax = vm;
     }
-    // NOLINTEND(*-suspicious-call-argument)
     for (; j + 8 <= n; j += 8) {
       vfloat32m1x8_t vx =
           __riscv_vlsseg8e32_v_f32m1x8(a + i * rsa + j, bsa, vl);

--- a/test/cvt/cvt_bf16_f8.c
+++ b/test/cvt/cvt_bf16_f8.c
@@ -9,9 +9,8 @@
  */
 
 #include "cvt_bf16_f8.h"
-#include "skl-test-driver.h"
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
+#include "skl-test-driver.h"
 #include <inttypes.h>
 #include <math.h>
 #include <stddef.h>

--- a/test/cvt/cvt_f32_f8.c
+++ b/test/cvt/cvt_f32_f8.c
@@ -9,9 +9,8 @@
  */
 
 #include "cvt_f32_f8.h"
-#include "skl-test-driver.h"
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
+#include "skl-test-driver.h"
 #include <inttypes.h>
 #include <math.h>
 #include <stddef.h>

--- a/test/cvt/cvt_f4_f8.c
+++ b/test/cvt/cvt_f4_f8.c
@@ -9,9 +9,8 @@
  */
 
 #include "cvt_f4_f8.h"
-#include "skl-test-driver.h"
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
+#include "skl-test-driver.h"
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/test/cvt/cvt_f8_bf16.c
+++ b/test/cvt/cvt_f8_bf16.c
@@ -9,9 +9,8 @@
  */
 
 #include "cvt_f8_bf16.h"
-#include "skl-test-driver.h"
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
+#include "skl-test-driver.h"
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
@@ -11,7 +11,7 @@
 #include "depthwise_conv2d_f16_f16_f16.h"
 #include "skl-ref.h"
 #include "skl-test-driver.h"
-#include "skl.h" // NOLINT(misc-include-cleaner)
+#include "skl.h"
 #include <math.h>
 #include <stddef.h>
 #include <stdio.h>

--- a/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
@@ -11,7 +11,7 @@
 #include "depthwise_conv2d_f32_f32_f32.h"
 #include "skl-ref.h"
 #include "skl-test-driver.h"
-#include "skl.h" // NOLINT(misc-include-cleaner)
+#include "skl.h"
 #include <math.h>
 #include <stddef.h>
 #include <stdio.h>

--- a/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
@@ -11,7 +11,7 @@
 #include "depthwise_conv2d_i8_i8_i32.h"
 #include "skl-ref.h"
 #include "skl-test-driver.h"
-#include "skl.h" // NOLINT(misc-include-cleaner)
+#include "skl.h"
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/test/exp/exp_f32_xsfvfexp32e.c
+++ b/test/exp/exp_f32_xsfvfexp32e.c
@@ -12,7 +12,7 @@
  */
 
 #include "elementwise/unary_f32.h"
-#include "skl-ref.h" // NOLINT(misc-include-cleaner)
+#include "skl-ref.h"
 #include "skl-test-driver.h"
 #include "skl.h"
 

--- a/test/exp/exp_f32_xsfvfexpa.c
+++ b/test/exp/exp_f32_xsfvfexpa.c
@@ -12,7 +12,7 @@
  */
 
 #include "elementwise/unary_f32.h"
-#include "skl-ref.h" // NOLINT(misc-include-cleaner)
+#include "skl-ref.h"
 #include "skl-test-driver.h"
 #include "skl.h"
 

--- a/test/exp/exp_f32_zve32f.c
+++ b/test/exp/exp_f32_zve32f.c
@@ -12,7 +12,7 @@
  */
 
 #include "elementwise/unary_f32.h"
-#include "skl-ref.h" // NOLINT(misc-include-cleaner)
+#include "skl-ref.h"
 #include "skl-test-driver.h"
 #include "skl.h"
 

--- a/test/gelu/gelu_f32.c
+++ b/test/gelu/gelu_f32.c
@@ -165,14 +165,12 @@ int main(void) {
 #define RUN(VARIANT, ...)                                                      \
   RUN_(PASTE3(skl_gelu_, VARIANT, _f32_zve32f), "zve32f," #VARIANT, __VA_ARGS__)
 
-  // NOLINTBEGIN(*-signed-bitwise)
   // clang-format off
   RUN(p9,  1.7e7, 5.401e5, 9.384e4, 3.703e4, NINF_NAN);
   RUN(p13, 1.7e7, 6.908e4,    6810,    2300, NINF_NAN);
   RUN(p17, 1.7e7, 2.732e3,     239,     239, NINF_NAN);
   RUN(rat, 1.7e7,      62,       5,       4, NINF_NAN);
   // clang-format on
-  // NOLINTEND(*-signed-bitwise)
 
   return ret > 0;
 }

--- a/test/gelu/gelu_f32.c
+++ b/test/gelu/gelu_f32.c
@@ -94,7 +94,7 @@ static int check_error(const char *name, const float *in, const float *res,
                        const float *ref, float spanning_tol, float gen2_tol,
                        float gen1_tol, float ge0_tol, uint8_t specials,
                        size_t len) {
-  // NOLINTBEGIN(*-signed-bitwise,*-braces-around-statements,*-isolate-declaration)
+  // NOLINTBEGIN(*-signed-bitwise,*-braces-around-statements)
   float spanning_max = 0, gen2_max = 0, gen1_max = 0, ge0_max = 0;
   for (size_t i = 0; i < len; i++) {
     float err = 0;
@@ -125,7 +125,7 @@ static int check_error(const char *name, const float *in, const float *res,
     if (in[i] >= 0.f && err > ge0_max)
       ge0_max = err;
   }
-  // NOLINTEND(*-signed-bitwise,*-braces-around-statements,*-isolate-declaration)
+  // NOLINTEND(*-signed-bitwise,*-braces-around-statements)
   int ret = spanning_max > spanning_tol || gen2_max > gen2_tol ||
             gen1_max > gen1_tol || ge0_max > ge0_tol;
   // clang-format off

--- a/test/gelu/gelu_f32.c
+++ b/test/gelu/gelu_f32.c
@@ -15,7 +15,7 @@
 #endif
 
 #include "skl-test.h"
-#include "skl.h" // NOLINT(misc-include-cleaner)
+#include "skl.h"
 #include <inttypes.h>
 #if defined(ENABLE_TEST)
 #include <math.h>

--- a/test/gelu/gelu_f32.c
+++ b/test/gelu/gelu_f32.c
@@ -94,7 +94,7 @@ static int check_error(const char *name, const float *in, const float *res,
                        const float *ref, float spanning_tol, float gen2_tol,
                        float gen1_tol, float ge0_tol, uint8_t specials,
                        size_t len) {
-  // NOLINTBEGIN(*-signed-bitwise,*-braces-around-statements)
+  // NOLINTBEGIN(*-signed-bitwise)
   float spanning_max = 0, gen2_max = 0, gen1_max = 0, ge0_max = 0;
   for (size_t i = 0; i < len; i++) {
     float err = 0;
@@ -125,7 +125,7 @@ static int check_error(const char *name, const float *in, const float *res,
     if (in[i] >= 0.f && err > ge0_max)
       ge0_max = err;
   }
-  // NOLINTEND(*-signed-bitwise,*-braces-around-statements)
+  // NOLINTEND(*-signed-bitwise)
   int ret = spanning_max > spanning_tol || gen2_max > gen2_tol ||
             gen1_max > gen1_tol || ge0_max > ge0_tol;
   // clang-format off

--- a/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
+++ b/test/gemm/gemm_bf16rc_bf16rc_f32rc.c
@@ -47,7 +47,6 @@
 #define SKL_TEST_PERF_REPORT report_perf_mpc
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -68,7 +68,6 @@
 #define SKL_TEST_PERF_REPORT report_perf_mpc
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/gemm/gemm_f16rc_f16rc_f16rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f16rc.c
@@ -47,7 +47,6 @@
 #define SKL_TEST_PERF_REPORT report_perf_mpc
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/gemm/gemm_f16rc_f16rc_f32rc.c
+++ b/test/gemm/gemm_f16rc_f16rc_f32rc.c
@@ -47,7 +47,6 @@
 #define SKL_TEST_PERF_REPORT report_perf_mpc
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -68,7 +68,6 @@
 #define SKL_TEST_PERF_REPORT report_perf_mpc
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/gemm/gemm_f64rc_f64rc_f64rc.c
+++ b/test/gemm/gemm_f64rc_f64rc_f64rc.c
@@ -47,7 +47,6 @@
 #define SKL_TEST_PERF_REPORT report_perf_mpc
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
+++ b/test/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.c
@@ -58,7 +58,6 @@
 #define SKL_TEST_PERF_REPORT report_perf_mpc
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -79,7 +79,6 @@
 #define SKL_TEST_PERF_REPORT report_perf_mpc
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
+++ b/test/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.c
@@ -58,7 +58,6 @@
 #define SKL_TEST_PERF_REPORT report_perf_mpc
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
@@ -79,7 +79,6 @@
 #define SKL_TEST_PERF_REPORT report_perf_mpc
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/gemm/gemm_i8_i8pc_i32_xsfvqdotq.c
+++ b/test/gemm/gemm_i8_i8pc_i32_xsfvqdotq.c
@@ -58,7 +58,6 @@
 #define SKL_TEST_PERF_REPORT report_perf_mpc
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/gemm/gemm_i8rc_i8rc_i32rc.c
+++ b/test/gemm/gemm_i8rc_i8rc_i32rc.c
@@ -43,7 +43,6 @@
 #define SKL_TEST_PERF_REPORT report_perf_mpc
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -64,7 +64,6 @@
 #define SKL_TEST_PERF_REPORT report_perf_mpc
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/gemm/pack_b_i8_xsfvqdotq.c
+++ b/test/gemm/pack_b_i8_xsfvqdotq.c
@@ -36,7 +36,7 @@
 #endif
 
 #include "skl-test.h"
-#include "skl.h" // NOLINT(misc-include-cleaner)
+#include "skl.h"
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/test/silu/silu_f16.c
+++ b/test/silu/silu_f16.c
@@ -7,7 +7,6 @@
 #define NUM_ELEMS 1024
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/silu/silu_f32.c
+++ b/test/silu/silu_f32.c
@@ -9,7 +9,6 @@
 #define NUM_ELEMS 1024
 #endif
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
 #include "skl-test.h"
 #include "skl.h"

--- a/test/softmax/softmax_f16.c
+++ b/test/softmax/softmax_f16.c
@@ -16,7 +16,6 @@
 
 #include "skl-ref.h"
 #include "skl-test.h"
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl.h"
 #include <inttypes.h>
 #if defined(ENABLE_TEST)

--- a/test/transpose/transpose_e16.c
+++ b/test/transpose/transpose_e16.c
@@ -7,9 +7,7 @@
 
 #include "skl-test.h"
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl.h"
 
 #include <inttypes.h>

--- a/test/transpose/transpose_e32.c
+++ b/test/transpose/transpose_e32.c
@@ -7,9 +7,7 @@
 
 #include "skl-test.h"
 
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl-ref.h"
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "skl.h"
 
 #include <inttypes.h>

--- a/test/transpose/transpose_e8.c
+++ b/test/transpose/transpose_e8.c
@@ -11,7 +11,7 @@
 #include "transpose_e8.h"
 #include "skl-ref.h"
 #include "skl-test-driver.h"
-#include "skl.h" // NOLINT(misc-include-cleaner)
+#include "skl.h"
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
This set of patches cleans up some of our lint checks that turned out to be either inconvenient or generating many false positives.