### PR TITLE
[CI] Check license headers

### DIFF
--- a/.github/check_license_headers.py
+++ b/.github/check_license_headers.py
@@ -8,7 +8,7 @@
 Script to check for SiFive copyright and MIT license headers in source files.
 This script verifies that each relevant file contains the following header:
 
-    Copyright (c) {year_str} SiFive, Inc. All rights reserved.
+    Copyright (c) (YYYY-)YYYY SiFive, Inc. All rights reserved.
     Licensed under the MIT License.
     See LICENSE file in the project root for full license information.
     SPDX-License-Identifier: MIT
@@ -83,30 +83,22 @@ def get_comment_style(filepath: Path) -> str:
     return ''
 
 
-def get_copyright_year(filepath: Path) -> str:
+def get_year_modified(filepath: Path) -> str:
     current_year = datetime.now().strftime('%Y')
-    date_created = subprocess.check_output(['git', 'log', '--pretty=format:%cI', '--follow', filepath]).decode('utf-8').rsplit('\n', 1)[-1]
     date_modified = subprocess.check_output(['git', 'log', '-1', '--pretty=format:%cI', filepath]).decode('utf-8')
-    year_created = date_created.split('-')[0] or current_year
     year_modified = date_modified.split('-')[0] or current_year
-
-    if year_created != year_modified:
-        year_str = f"{year_created}-{year_modified}"
-    else:
-        year_str = f"{year_modified}"
-
-    return year_str
+    return year_modified
 
 
 def generate_license_pattern(filepath: Path) -> str:
     """Generate the appropriate license header pattern for a file."""
     comment_prefix = get_comment_style(filepath)
-    year_str = get_copyright_year(filepath)
+    year_modified = get_year_modified(filepath)
     header_lines = [
-        f"{comment_prefix} Copyright (c) {year_str} SiFive, Inc. All rights reserved.\n",
-        f"{comment_prefix} Licensed under the MIT License.\n",
-        f"{comment_prefix} See LICENSE file in the project root for full license information.\n",
-        f"{comment_prefix} SPDX-License-Identifier: MIT\n",
+        rf"{comment_prefix} Copyright \(c\) ((\d{{4}})-)?{year_modified} SiFive, Inc\. All rights reserved\.\n",
+        rf"{comment_prefix} Licensed under the MIT License\.\n",
+        rf"{comment_prefix} See LICENSE file in the project root for full license information\.\n",
+        rf"{comment_prefix} SPDX-License-Identifier: MIT\n",
         ""
     ]
     return ''.join(header_lines)
@@ -132,11 +124,17 @@ def check_file_header(filepath: Path) -> List[str]:
             header_text = ''.join(header_lines)
 
             license_pattern = generate_license_pattern(filepath)
-            if not license_pattern in header_text:
+            match = re.search(license_pattern, header_text)
+            if not match:
                 issues.append("Missing or incorrect header. Should be:\n" + license_pattern)
+            else:
+                start_year = match.groups()[1]
+                year_modified = get_year_modified(filepath)
+                if start_year and (int(start_year) < 2025 or int(start_year) >= int(year_modified)):
+                    issues.append(f"Invalid start year. Should be >= 2025 and < {year_modified}.")
 
     except Exception as e:
-        issues.append(f"Error reading file: {e}")
+        issues.append(f"Error: {e}")
 
     return issues
 

--- a/.github/check_license_headers.py
+++ b/.github/check_license_headers.py
@@ -28,10 +28,11 @@ Exit codes:
     1 - One or more files are missing headers
 """
 
-import sys
-import re
 import argparse
+import re
 import subprocess
+import sys
+from datetime import datetime
 from pathlib import Path
 from typing import List, Tuple
 
@@ -83,10 +84,11 @@ def get_comment_style(filepath: Path) -> str:
 
 
 def get_copyright_year(filepath: Path) -> str:
+    current_year = datetime.now().strftime('%Y')
     date_created = subprocess.check_output(['git', 'log', '--pretty=format:%cI', '--follow', filepath]).decode('utf-8').rsplit('\n', 1)[-1]
     date_modified = subprocess.check_output(['git', 'log', '-1', '--pretty=format:%cI', filepath]).decode('utf-8')
-    year_created = date_created.split('-')[0]
-    year_modified = date_modified.split('-')[0]
+    year_created = date_created.split('-')[0] or current_year
+    year_modified = date_modified.split('-')[0] or current_year
 
     if year_created != year_modified:
         year_str = f"{year_created}-{year_modified}"

--- a/.github/check_license_headers.py
+++ b/.github/check_license_headers.py
@@ -34,7 +34,7 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import List, Tuple
+from typing import List
 
 # Comment styles for different file types
 # The script defaults to '' for types not listed here

--- a/.github/check_license_headers.py
+++ b/.github/check_license_headers.py
@@ -57,8 +57,9 @@ EXCLUDE_PATTERNS = [
     r'.*\.md$',
     '.clang-tidy',
     '.clang-format',
+    r'.*CODEOWNERS$',
     r'.*Doxyfile$',
-    '.github/',
+    '.github/workflows/',
     '.gitignore',
     'LICENSE.txt',
 ]
@@ -155,7 +156,7 @@ def main():
     )
     args = parser.parse_args()
 
-    repo_root = Path(__file__).parent.resolve()
+    repo_root = Path(__file__).resolve().parent.parent
 
     files_skipped = 0
     files_ok = []

--- a/.github/check_license_headers.py
+++ b/.github/check_license_headers.py
@@ -32,6 +32,7 @@ import argparse
 import re
 import subprocess
 import sys
+from codecs import decode
 from datetime import datetime
 from pathlib import Path
 from typing import List
@@ -90,18 +91,34 @@ def get_year_modified(filepath: Path) -> str:
     return year_modified
 
 
-def generate_license_pattern(filepath: Path) -> str:
-    """Generate the appropriate license header pattern for a file."""
+def generate_license(filepath: Path, generate_pattern: bool = False) -> str:
+    """
+    Generate the appropriate license header for a file.
+
+    If generate_pattern is True, returns a regex for the license header.
+    Otherwise, returns the license header itself.
+    """
     comment_prefix = get_comment_style(filepath)
     year_modified = get_year_modified(filepath)
+    if generate_pattern:
+        esc = "\\"
+        start_year = r"((\d{4})-)?"
+    else:
+        esc = ""
+        start_year = "(YYYY-)"
+
     header_lines = [
-        rf"{comment_prefix} Copyright \(c\) ((\d{{4}})-)?{year_modified} SiFive, Inc\. All rights reserved\.\n",
-        rf"{comment_prefix} Licensed under the MIT License\.\n",
-        rf"{comment_prefix} See LICENSE file in the project root for full license information\.\n",
+        rf"{comment_prefix} Copyright {esc}(c{esc}) {start_year}{year_modified} SiFive, Inc{esc}. All rights reserved{esc}.\n",
+        rf"{comment_prefix} Licensed under the MIT License{esc}.\n",
+        rf"{comment_prefix} See LICENSE file in the project root for full license information{esc}.\n",
         rf"{comment_prefix} SPDX-License-Identifier: MIT\n",
-        ""
     ]
-    return ''.join(header_lines)
+    header = "".join(header_lines)
+
+    if not generate_pattern:
+        header = decode(header, 'unicode-escape')
+
+    return header
 
 
 def check_file_header(filepath: Path) -> List[str]:
@@ -123,10 +140,10 @@ def check_file_header(filepath: Path) -> List[str]:
                 header_lines.append(line)
             header_text = ''.join(header_lines)
 
-            license_pattern = generate_license_pattern(filepath)
+            license_pattern = generate_license(filepath, True)
             match = re.search(license_pattern, header_text)
             if not match:
-                issues.append("Missing or incorrect header. Should be:\n" + license_pattern)
+                issues.append("Missing or incorrect header. Should be:\n" + generate_license(filepath))
             else:
                 start_year = match.groups()[1]
                 year_modified = get_year_modified(filepath)

--- a/.github/check_license_headers.py
+++ b/.github/check_license_headers.py
@@ -115,7 +115,7 @@ def check_file_header(filepath: Path) -> List[str]:
     Check if a file has the required copyright and license header.
 
     Returns:
-        Tuple of (has_valid_header, list_of_issues)
+        List of issues
     """
     issues = []
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         HEAD_SHA=${{ github.event.pull_request.head.sha }}
         BASE_SHA=${{ github.event.pull_request.base.sha }}
         MERGE_BASE_SHA=$(git merge-base $HEAD_SHA $BASE_SHA)
-        git diff --name-only $MERGE_BASE_SHA $HEAD_SHA | xargs ./check_license_headers.py
+        git diff --name-only $MERGE_BASE_SHA $HEAD_SHA | xargs ./.github/check_license_headers.py
 
     - name: Setup QEMU
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Check license headers 
+      run: |
+        ./check_license_headers.py
+
     - name: Setup QEMU
       run: |
         gh release download $SKL_TAG -p "$QEMU_TARBALL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,12 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Check license headers 
+    - name: Check license headers
       run: |
-        ./check_license_headers.py
+        HEAD_SHA=${{ github.event.pull_request.head.sha }}
+        BASE_SHA=${{ github.event.pull_request.base.sha }}
+        MERGE_BASE_SHA=$(git merge-base $HEAD_SHA $BASE_SHA)
+        git diff --name-only $MERGE_BASE_SHA $HEAD_SHA | xargs ./check_license_headers.py
 
     - name: Setup QEMU
       run: |

--- a/check_license_headers.py
+++ b/check_license_headers.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+# SPDX-License-Identifier: MIT
+
+"""
+Script to check for SiFive copyright and MIT license headers in source files.
+
+This script verifies that each relevant file contains:
+1. A copyright notice with "SiFive, Inc." and years 2025-Present or 2026-Present
+2. MIT License reference
+3. Proper SPDX-License-Identifier
+
+Usage:
+    # Check all files in the repository
+    ./check_license_headers.py
+
+    # Check specific files
+    ./check_license_headers.py file1.c file2.h
+
+    # Show file type summary
+    ./check_license_headers.py --summary
+
+    # Show verbose output (lists all valid files)
+    ./check_license_headers.py --verbose
+
+    # Show example headers
+    ./check_license_headers.py --examples
+
+    # Fix files with missing headers
+    ./check_license_headers.py --fix
+
+    # Fix specific files only
+    ./check_license_headers.py --fix file1.c file2.h
+
+Exit codes:
+    0 - All files have proper headers
+    1 - One or more files are missing headers
+"""
+
+import os
+import sys
+import re
+import argparse
+from pathlib import Path
+from typing import List, Tuple, Set
+
+# Expected copyright patterns (allowing for 2025 or 2026)
+COPYRIGHT_PATTERNS = [
+    r"Copyright\s+\(c\)\s+202[56]-Present\s+SiFive,?\s+Inc\.\s+All\s+rights\s+reserved\.",
+]
+
+# Expected license reference
+LICENSE_REFERENCE = r"Licensed\s+under\s+the\s+MIT\s+License\."
+
+# Expected SPDX identifier
+SPDX_IDENTIFIER = r"SPDX-License-Identifier:\s*MIT"
+
+# File extensions to check and their comment styles
+FILE_TYPES = {
+    # C/C++ style comments
+    '.c': ('//', '//'),
+    '.h': ('//', '//'),
+    '.cpp': ('//', '//'),
+    '.hpp': ('//', '//'),
+    # Python style comments
+    '.py': ('#', '#'),
+    # CMake style comments
+    '.cmake': ('#', '#'),
+    'CMakeLists.txt': ('#', '#'),
+}
+
+# Directories to exclude
+EXCLUDE_DIRS = {
+    '.git',
+    'build',
+    'doc/html',
+    '__pycache__',
+    '.pytest_cache',
+}
+
+# Files to exclude (relative paths from repo root)
+EXCLUDE_FILES = {
+    '.clang-tidy',
+    '.gitignore',
+    'LICENSE.txt',
+    'CHANGELOG.md',
+    'README.md',
+    'CONTRIBUTING.md',
+    'CONTRIBUTORS.md',
+    '.github/CODEOWNERS',
+}
+
+# Exclude files matching these patterns
+EXCLUDE_PATTERNS = [
+    r'.*README\.md$',
+    r'.*\.md$',  # Exclude all markdown files
+]
+
+def should_check_file(filepath: Path, repo_root: Path) -> bool:
+    """Determine if a file should be checked for license headers."""
+    # Check if in excluded directory
+    rel_path = filepath.relative_to(repo_root)
+    for part in rel_path.parts:
+        if part in EXCLUDE_DIRS:
+            return False
+
+    # Check if in excluded files
+    if str(rel_path) in EXCLUDE_FILES:
+        return False
+
+    # Check against exclude patterns
+    rel_path_str = str(rel_path)
+    for pattern in EXCLUDE_PATTERNS:
+        if re.match(pattern, rel_path_str):
+            return False
+
+    # Check file extension or name
+    if filepath.name == 'CMakeLists.txt':
+        return True
+
+    return filepath.suffix in FILE_TYPES
+
+
+def get_comment_style(filepath: Path) -> Tuple[str, str]:
+    """Get the comment style for a file."""
+    if filepath.name == 'CMakeLists.txt':
+        return FILE_TYPES['CMakeLists.txt']
+    return FILE_TYPES.get(filepath.suffix, (None, None))
+
+
+def generate_header(filepath: Path, year: str = "2025") -> str:
+    """
+    Generate the appropriate copyright header for a file.
+
+    Args:
+        filepath: Path to the file
+        year: Starting copyright year (2025 or 2026)
+
+    Returns:
+        String containing the copyright header
+    """
+    comment_prefix, _ = get_comment_style(filepath)
+
+    if comment_prefix is None:
+        return ""
+
+    header_lines = [
+        f"{comment_prefix} Copyright (c) {year}-Present SiFive, Inc. All rights reserved.",
+        f"{comment_prefix} Licensed under the MIT License.",
+        f"{comment_prefix} See LICENSE file in the project root for full license information.",
+        f"{comment_prefix} SPDX-License-Identifier: MIT",
+        ""
+    ]
+
+    return '\n'.join(header_lines)
+
+
+def fix_file_header(filepath: Path, year: str = "2025") -> bool:
+    """
+    Add the copyright header to a file that's missing it.
+
+    Args:
+        filepath: Path to the file to fix
+        year: Starting copyright year (2025 or 2026)
+
+    Returns:
+        True if file was modified, False otherwise
+    """
+    try:
+        with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+            original_content = f.read()
+
+        header = generate_header(filepath, year)
+        if not header:
+            return False
+
+        # Check if file starts with shebang
+        new_content = ""
+        if original_content.startswith('#!'):
+            # Preserve shebang line
+            lines = original_content.split('\n', 1)
+            shebang = lines[0] + '\n'
+            rest = lines[1] if len(lines) > 1 else ""
+            new_content = shebang + header + '\n' + rest
+        else:
+            new_content = header + '\n' + original_content
+
+        # Write the modified content
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+
+        return True
+
+    except Exception as e:
+        print(f"Error fixing file {filepath}: {e}")
+        return False
+
+
+def check_file_header(filepath: Path) -> Tuple[bool, List[str]]:
+    """
+    Check if a file has the required copyright and license header.
+    
+    Returns:
+        Tuple of (has_valid_header, list_of_issues)
+    """
+    issues = []
+    
+    try:
+        with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+            # Read first 20 lines (header should be in this range)
+            header_lines = []
+            for i, line in enumerate(f):
+                if i >= 20:
+                    break
+                header_lines.append(line)
+            
+            header_text = ''.join(header_lines)
+            
+            # Check for copyright notice
+            copyright_found = False
+            for pattern in COPYRIGHT_PATTERNS:
+                if re.search(pattern, header_text, re.IGNORECASE):
+                    copyright_found = True
+                    break
+            
+            if not copyright_found:
+                issues.append("Missing or incorrect SiFive copyright notice (should be '2025-Present' or '2026-Present')")
+            
+            # Check for MIT license reference
+            if not re.search(LICENSE_REFERENCE, header_text, re.IGNORECASE):
+                issues.append("Missing MIT License reference")
+            
+            # Check for SPDX identifier
+            if not re.search(SPDX_IDENTIFIER, header_text):
+                issues.append("Missing SPDX-License-Identifier: MIT")
+            
+    except Exception as e:
+        issues.append(f"Error reading file: {e}")
+    
+    return (len(issues) == 0, issues)
+
+
+def print_example_headers():
+    """Print example headers for different file types."""
+    print("\nEXAMPLE HEADERS:")
+    print("=" * 80)
+
+    print("\nC/C++ files (.c, .h, .cpp, .hpp):")
+    print("-" * 80)
+    print("""// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+""")
+
+    print("\nPython/CMake files (.py, .cmake, CMakeLists.txt):")
+    print("-" * 80)
+    print("""# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+# SPDX-License-Identifier: MIT
+""")
+
+
+def main():
+    """Main function to check all files in the repository."""
+    parser = argparse.ArgumentParser(
+        description="Check for SiFive copyright and MIT license headers in source files.",
+        epilog="Note: Copyright year can be either 2025-Present or 2026-Present"
+    )
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        help='Show verbose output including all checked files'
+    )
+    parser.add_argument(
+        '--summary',
+        action='store_true',
+        help='Show summary of file types checked'
+    )
+    parser.add_argument(
+        '--examples',
+        action='store_true',
+        help='Show example headers and exit'
+    )
+    parser.add_argument(
+        '--fix',
+        action='store_true',
+        help='Automatically add missing headers to files'
+    )
+    parser.add_argument(
+        '--year',
+        choices=['2025', '2026'],
+        default='2025',
+        help='Copyright year to use when fixing files (default: 2025)'
+    )
+    parser.add_argument(
+        'files',
+        nargs='*',
+        help='Specific files to check (if not provided, checks entire repository)'
+    )
+    args = parser.parse_args()
+
+    if args.examples:
+        print_example_headers()
+        return 0
+
+    repo_root = Path(__file__).parent.resolve()
+
+    files_checked = 0
+    files_with_issues = 0
+    all_issues = []
+    file_type_counts = {}
+    files_ok = []
+    files_fixed = []
+
+    # If specific files are provided, check only those
+    if args.files:
+        files_to_check = [Path(f).resolve() for f in args.files]
+        print(f"Checking {len(files_to_check)} specified file(s)")
+        print("=" * 80)
+
+        for filepath in files_to_check:
+            if not filepath.exists():
+                print(f"Warning: File not found: {filepath}")
+                continue
+
+            if not filepath.is_file():
+                print(f"Warning: Not a file: {filepath}")
+                continue
+
+            try:
+                rel_path = filepath.relative_to(repo_root)
+            except ValueError:
+                print(f"Warning: File outside repository: {filepath}")
+                continue
+
+            files_checked += 1
+
+            # Track file types
+            if filepath.name == 'CMakeLists.txt':
+                ext = 'CMakeLists.txt'
+            else:
+                ext = filepath.suffix if filepath.suffix else filepath.name
+            file_type_counts[ext] = file_type_counts.get(ext, 0) + 1
+
+            has_valid_header, issues = check_file_header(filepath)
+
+            if not has_valid_header:
+                if args.fix:
+                    # Try to fix the file
+                    if fix_file_header(filepath, args.year):
+                        files_fixed.append(rel_path)
+                        # Re-check to verify the fix worked
+                        has_valid_header, issues = check_file_header(filepath)
+                        if has_valid_header:
+                            files_ok.append(rel_path)
+                        else:
+                            files_with_issues += 1
+                            all_issues.append((rel_path, issues))
+                    else:
+                        files_with_issues += 1
+                        all_issues.append((rel_path, issues))
+                else:
+                    files_with_issues += 1
+                    all_issues.append((rel_path, issues))
+            else:
+                files_ok.append(rel_path)
+    else:
+        # Check all files in repository
+        print(f"Checking license headers in: {repo_root}")
+        print("=" * 80)
+
+        # Walk through all files
+        for root, dirs, files in os.walk(repo_root):
+            root_path = Path(root)
+
+            # Filter out excluded directories
+            dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
+
+            for filename in files:
+                filepath = root_path / filename
+
+                if not should_check_file(filepath, repo_root):
+                    continue
+
+                files_checked += 1
+                rel_path = filepath.relative_to(repo_root)
+
+                # Track file types (special case for CMakeLists.txt)
+                if filepath.name == 'CMakeLists.txt':
+                    ext = 'CMakeLists.txt'
+                else:
+                    ext = filepath.suffix if filepath.suffix else filepath.name
+                file_type_counts[ext] = file_type_counts.get(ext, 0) + 1
+
+                has_valid_header, issues = check_file_header(filepath)
+
+                if not has_valid_header:
+                    if args.fix:
+                        # Try to fix the file
+                        if fix_file_header(filepath, args.year):
+                            files_fixed.append(rel_path)
+                            # Re-check to verify the fix worked
+                            has_valid_header, issues = check_file_header(filepath)
+                            if has_valid_header:
+                                files_ok.append(rel_path)
+                            else:
+                                files_with_issues += 1
+                                all_issues.append((rel_path, issues))
+                        else:
+                            files_with_issues += 1
+                            all_issues.append((rel_path, issues))
+                    else:
+                        files_with_issues += 1
+                        all_issues.append((rel_path, issues))
+                else:
+                    files_ok.append(rel_path)
+
+    # Print results
+    print(f"\nFiles checked: {files_checked}")
+    if args.fix and files_fixed:
+        print(f"Files fixed: {len(files_fixed)}")
+    print(f"Files with issues: {files_with_issues}")
+    print(f"Files OK: {files_checked - files_with_issues}")
+
+    # Show file type summary if requested
+    if args.summary:
+        print("\n" + "=" * 80)
+        print("FILE TYPE SUMMARY:")
+        print("=" * 80)
+        for ext, count in sorted(file_type_counts.items()):
+            print(f"  {ext:20s}: {count:4d} files")
+
+    # Show fixed files
+    if files_fixed:
+        print("\n" + "=" * 80)
+        print("FILES FIXED:")
+        print("=" * 80)
+        for filepath in sorted(files_fixed):
+            print(f"  ✓ {filepath}")
+
+    # Show verbose output if requested
+    if args.verbose and files_ok:
+        print("\n" + "=" * 80)
+        print("FILES WITH VALID HEADERS:")
+        print("=" * 80)
+        for filepath in sorted(files_ok):
+            print(f"  ✓ {filepath}")
+
+    if all_issues:
+        print("\n" + "=" * 80)
+        print("FILES WITH ISSUES:")
+        print("=" * 80)
+
+        for filepath, issues in sorted(all_issues):
+            print(f"\n{filepath}")
+            for issue in issues:
+                print(f"  ✗ {issue}")
+
+    print("\n" + "=" * 80)
+
+    if files_with_issues == 0:
+        print("✓ All files have proper copyright and license headers!")
+        return 0
+    else:
+        print(f"✗ Found {files_with_issues} file(s) with missing or incorrect headers.")
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/check_license_headers.py
+++ b/check_license_headers.py
@@ -73,9 +73,10 @@ def should_check_file(filepath: Path, repo_root: Path) -> bool:
 
 def get_comment_style(filepath: Path) -> str:
     """Get the comment style for a file."""
-    if filepath.name == 'CMakeLists.txt':
-        return FILE_TYPES[filepath.name]
-    return FILE_TYPES.get(filepath.suffix, '')
+    for suffix in FILE_TYPES:
+        if str(filepath).endswith(suffix):
+            return FILE_TYPES[suffix]
+    return ''
 
 
 def get_copyright_year(filepath: Path) -> str:

--- a/check_license_headers.py
+++ b/check_license_headers.py
@@ -79,9 +79,12 @@ def get_comment_style(filepath: Path) -> str:
     return ''
 
 
-def get_copyright_year(filepath: Path) -> str:
-    year_from_date = lambda date: date.split(b'-')[0].decode('utf-8')
+def year_from_date(date: str) -> str:
+    """Extract the year from a date string in %cI format"""
+    return date.split(b'-')[0].decode('utf-8')
 
+
+def get_copyright_year(filepath: Path) -> str:
     date_created = subprocess.check_output(['git', 'log', '--pretty=format:%cI', '--follow', filepath]).rsplit(b'\n', 1)[-1]
     date_modified = subprocess.check_output(['git', 'log', '-1', '--pretty=format:%cI', filepath])
     year_created = year_from_date(date_created)

--- a/check_license_headers.py
+++ b/check_license_headers.py
@@ -19,9 +19,6 @@ Usage:
     # Check specific files
     ./check_license_headers.py file1.c file2.h
 
-    # Show file type summary
-    ./check_license_headers.py --summary
-
     # Show verbose output (lists all valid files)
     ./check_license_headers.py --verbose
 
@@ -40,6 +37,7 @@ import os
 import sys
 import re
 import argparse
+import subprocess
 from pathlib import Path
 from typing import List, Tuple, Set
 
@@ -220,10 +218,18 @@ def check_file_header(filepath: Path) -> Tuple[bool, List[str]]:
             
             header_text = ''.join(header_lines)
             
+            year_created = subprocess.check_output(['git', 'log', '--pretty=format:%cI', '--follow', filepath]).split(b'\n')[-1].split(b'-')[0].decode('utf-8')
+            year_modified = subprocess.check_output(['git', 'log', '-1', '--pretty=format:%cI', filepath]).split(b'-')[0].decode('utf-8')
+            if year_created != year_modified:
+                year_str = rf"{year_created}-{year_modified}"
+            else:
+                year_str = rf"{year_modified}"
+            COPYRIGHT_PATTERNS = [
+                rf"Copyright\s+\(c\)\s+202[56](-2026)?\s+\SiFive,\s+Inc\.\s+All\s+rights\s+reserved\.",
+            ]
+            
             copyright_license_lines = COPYRIGHT_PATTERNS + LICENSE_REFERENCE + SPDX_IDENTIFIER
-            # copyright_license_lines = LICENSE_REFERENCE
             comment_char, _ = get_comment_style(filepath)
-            print(f"comment char is {comment_char}\n")
             lines = []
             for line in copyright_license_lines:
                 line = comment_char + r"\s+" + line
@@ -235,22 +241,8 @@ def check_file_header(filepath: Path) -> Tuple[bool, List[str]]:
                 copyright_found = True
 
             # Check for copyright notice
-            # copyright_found = False
-            # for pattern in COPYRIGHT_PATTERNS:
-            #     if re.search(pattern, header_text, re.IGNORECASE):
-            #         copyright_found = True
-            #         break
-            
             if not copyright_found:
-                issues.append("Missing or incorrect SiFive copyright notice (should be '2025-Present' or '2026-Present')")
-            
-            # Check for MIT license reference
-            # if not re.search(LICENSE_REFERENCE, header_text, re.IGNORECASE):
-            #     issues.append("Missing MIT License reference")
-            
-            # Check for SPDX identifier
-            # if not re.search(SPDX_IDENTIFIER, header_text):
-            #     issues.append("Missing SPDX-License-Identifier: MIT")
+                issues.append("Missing or incorrect SiFive copyright notice (should be" + copyright_license_pattern + ")")
             
     except Exception as e:
         issues.append(f"Error reading file: {e}")
@@ -268,20 +260,9 @@ def main():
         help='Show verbose output including all checked files'
     )
     parser.add_argument(
-        '--summary',
-        action='store_true',
-        help='Show summary of file types checked'
-    )
-    parser.add_argument(
         '--fix',
         action='store_true',
         help='Automatically add missing headers to files'
-    )
-    parser.add_argument(
-        '--year',
-        choices=['2025', '2026'],
-        default='2025',
-        help='Copyright year to use when fixing files (default: 2025)'
     )
     parser.add_argument(
         'files',
@@ -295,7 +276,6 @@ def main():
     files_checked = 0
     files_with_issues = 0
     all_issues = []
-    file_type_counts = {}
     files_ok = []
     files_fixed = []
 
@@ -327,7 +307,6 @@ def main():
                 ext = 'CMakeLists.txt'
             else:
                 ext = filepath.suffix if filepath.suffix else filepath.name
-            file_type_counts[ext] = file_type_counts.get(ext, 0) + 1
 
             has_valid_header, issues = check_file_header(filepath)
 
@@ -377,7 +356,6 @@ def main():
                     ext = 'CMakeLists.txt'
                 else:
                     ext = filepath.suffix if filepath.suffix else filepath.name
-                file_type_counts[ext] = file_type_counts.get(ext, 0) + 1
 
                 has_valid_header, issues = check_file_header(filepath)
 
@@ -408,14 +386,6 @@ def main():
         print(f"Files fixed: {len(files_fixed)}")
     print(f"Files with issues: {files_with_issues}")
     print(f"Files OK: {files_checked - files_with_issues}")
-
-    # Show file type summary if requested
-    if args.summary:
-        print("\n" + "=" * 80)
-        print("FILE TYPE SUMMARY:")
-        print("=" * 80)
-        for ext, count in sorted(file_type_counts.items()):
-            print(f"  {ext:20s}: {count:4d} files")
 
     # Show fixed files
     if files_fixed:

--- a/check_license_headers.py
+++ b/check_license_headers.py
@@ -25,13 +25,12 @@ Exit codes:
     1 - One or more files are missing headers
 """
 
-import os
 import sys
 import re
 import argparse
 import subprocess
 from pathlib import Path
-from typing import List, Tuple, Set
+from typing import List, Tuple
 
 # Comment styles for different file types
 # The script defaults to '' for types not listed here

--- a/check_license_headers.py
+++ b/check_license_headers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
+# Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 # Licensed under the MIT License.
 # See LICENSE file in the project root for full license information.
 # SPDX-License-Identifier: MIT
@@ -25,9 +25,6 @@ Usage:
     # Show verbose output (lists all valid files)
     ./check_license_headers.py --verbose
 
-    # Show example headers
-    ./check_license_headers.py --examples
-
     # Fix files with missing headers
     ./check_license_headers.py --fix
 
@@ -48,7 +45,7 @@ from typing import List, Tuple, Set
 
 # Expected copyright patterns (allowing for 2025 or 2026)
 COPYRIGHT_PATTERNS = [
-    r"Copyright\s+\(c\)\s+202[56]-Present\s+SiFive,?\s+Inc\.\s+All\s+rights\s+reserved\.",
+    r"Copyright\s+\(c\)\s+202[56](-2026)?\s+SiFive,?\s+Inc\.\s+All\s+rights\s+reserved\.",
 ]
 
 # Expected license reference
@@ -147,7 +144,7 @@ def generate_header(filepath: Path, year: str = "2025") -> str:
         return ""
 
     header_lines = [
-        f"{comment_prefix} Copyright (c) {year}-Present SiFive, Inc. All rights reserved.",
+        f"{comment_prefix} Copyright (c) {year} SiFive, Inc. All rights reserved.",
         f"{comment_prefix} Licensed under the MIT License.",
         f"{comment_prefix} See LICENSE file in the project root for full license information.",
         f"{comment_prefix} SPDX-License-Identifier: MIT",
@@ -241,34 +238,10 @@ def check_file_header(filepath: Path) -> Tuple[bool, List[str]]:
     
     return (len(issues) == 0, issues)
 
-
-def print_example_headers():
-    """Print example headers for different file types."""
-    print("\nEXAMPLE HEADERS:")
-    print("=" * 80)
-
-    print("\nC/C++ files (.c, .h, .cpp, .hpp):")
-    print("-" * 80)
-    print("""// Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
-// Licensed under the MIT License.
-// See LICENSE file in the project root for full license information.
-// SPDX-License-Identifier: MIT
-""")
-
-    print("\nPython/CMake files (.py, .cmake, CMakeLists.txt):")
-    print("-" * 80)
-    print("""# Copyright (c) 2025-Present SiFive, Inc. All rights reserved.
-# Licensed under the MIT License.
-# See LICENSE file in the project root for full license information.
-# SPDX-License-Identifier: MIT
-""")
-
-
 def main():
     """Main function to check all files in the repository."""
     parser = argparse.ArgumentParser(
         description="Check for SiFive copyright and MIT license headers in source files.",
-        epilog="Note: Copyright year can be either 2025-Present or 2026-Present"
     )
     parser.add_argument(
         '-v', '--verbose',
@@ -279,11 +252,6 @@ def main():
         '--summary',
         action='store_true',
         help='Show summary of file types checked'
-    )
-    parser.add_argument(
-        '--examples',
-        action='store_true',
-        help='Show example headers and exit'
     )
     parser.add_argument(
         '--fix',
@@ -302,10 +270,6 @@ def main():
         help='Specific files to check (if not provided, checks entire repository)'
     )
     args = parser.parse_args()
-
-    if args.examples:
-        print_example_headers()
-        return 0
 
     repo_root = Path(__file__).parent.resolve()
 

--- a/check_license_headers.py
+++ b/check_license_headers.py
@@ -90,7 +90,7 @@ def get_copyright_year(filepath: Path) -> str:
         year_str = f"{year_created}-{year_modified}"
     else:
         year_str = f"{year_modified}"
-    
+
     return year_str
 
 
@@ -111,12 +111,12 @@ def generate_copyright_pattern(filepath: Path) -> str:
 def check_file_header(filepath: Path) -> Tuple[bool, List[str]]:
     """
     Check if a file has the required copyright and license header.
-    
+
     Returns:
         Tuple of (has_valid_header, list_of_issues)
     """
     issues = []
-    
+
     try:
         with open(filepath, 'r') as f:
             # Read first 6 lines (header should be in this range)
@@ -130,10 +130,10 @@ def check_file_header(filepath: Path) -> Tuple[bool, List[str]]:
             copyright_pattern = generate_copyright_pattern(filepath)
             if not re.search(copyright_pattern, header_text):
                 issues.append("Missing or incorrect header. Should be: " + copyright_pattern)
-            
+
     except Exception as e:
         issues.append(f"Error reading file: {e}")
-    
+
     return (len(issues) == 0, issues)
 
 

--- a/check_license_headers.py
+++ b/check_license_headers.py
@@ -14,6 +14,9 @@ This script verifies that each relevant file contains the following header:
     SPDX-License-Identifier: MIT
 
 Usage:
+    # Check all git-tracked files
+    ./check_license_headers.py
+
     # Check specific files
     ./check_license_headers.py file1.c file2.h
 
@@ -78,16 +81,11 @@ def get_comment_style(filepath: Path) -> str:
     return ''
 
 
-def year_from_date(date: str) -> str:
-    """Extract the year from a date string in %cI format"""
-    return date.split(b'-')[0].decode('utf-8')
-
-
 def get_copyright_year(filepath: Path) -> str:
-    date_created = subprocess.check_output(['git', 'log', '--pretty=format:%cI', '--follow', filepath]).rsplit(b'\n', 1)[-1]
-    date_modified = subprocess.check_output(['git', 'log', '-1', '--pretty=format:%cI', filepath])
-    year_created = year_from_date(date_created)
-    year_modified = year_from_date(date_modified)
+    date_created = subprocess.check_output(['git', 'log', '--pretty=format:%cI', '--follow', filepath]).decode('utf-8').rsplit('\n', 1)[-1]
+    date_modified = subprocess.check_output(['git', 'log', '-1', '--pretty=format:%cI', filepath]).decode('utf-8')
+    year_created = date_created.split('-')[0]
+    year_modified = date_modified.split('-')[0]
 
     if year_created != year_modified:
         year_str = f"{year_created}-{year_modified}"
@@ -148,7 +146,7 @@ def main():
     parser.add_argument(
         'files',
         nargs='*',
-        help='Files to check'
+        help='Files to check. If none are provided, checks all git-tracked files.'
     )
     parser.add_argument(
         '-v', '--verbose',
@@ -163,7 +161,12 @@ def main():
     files_ok = []
     all_issues = []
 
-    files_to_check = [Path(f).resolve() for f in args.files]
+    if args.files:
+        files_to_check = [Path(f).resolve() for f in args.files]
+    else:
+        tracked_files = subprocess.check_output(['git', 'ls-files']).decode('utf-8').rstrip().split('\n')
+        files_to_check = [Path(f).resolve() for f in tracked_files]
+
     print(f"Checking {len(files_to_check)} specified file(s)")
     print("=" * 80)
 

--- a/check_license_headers.py
+++ b/check_license_headers.py
@@ -111,7 +111,7 @@ def generate_license_pattern(filepath: Path) -> str:
     return ''.join(header_lines)
 
 
-def check_file_header(filepath: Path) -> Tuple[bool, List[str]]:
+def check_file_header(filepath: Path) -> List[str]:
     """
     Check if a file has the required copyright and license header.
 
@@ -137,7 +137,7 @@ def check_file_header(filepath: Path) -> Tuple[bool, List[str]]:
     except Exception as e:
         issues.append(f"Error reading file: {e}")
 
-    return (len(issues) == 0, issues)
+    return issues
 
 
 def main():
@@ -159,9 +159,7 @@ def main():
 
     repo_root = Path(__file__).parent.resolve()
 
-    files_checked = 0
     files_skipped = 0
-    files_with_issues = 0
     files_ok = []
     all_issues = []
 
@@ -189,21 +187,17 @@ def main():
             print(f"Skipping {filepath}")
             continue
 
-        files_checked += 1
+        issues = check_file_header(filepath)
 
-        has_valid_header, issues = check_file_header(filepath)
-
-        if has_valid_header:
-            files_ok.append(rel_path)
-        else:
-            files_with_issues += 1
+        if issues:
             all_issues.append((rel_path, issues))
+        else:
+            files_ok.append(rel_path)
 
     # Print results
-    print(f"\nFiles checked: {files_checked}")
     print(f"Files skipped: {files_skipped}")
     print(f"Files OK: {len(files_ok)}")
-    print(f"Files with issues: {files_with_issues}")
+    print(f"Files with issues: {len(all_issues)}")
 
     # Show verbose output if requested
     if args.verbose and files_ok:
@@ -225,12 +219,12 @@ def main():
 
     print("\n" + "=" * 80)
 
-    if files_with_issues == 0:
+    if all_issues:
+        print(f"✗ Found {len(all_issues)} file(s) with missing or incorrect headers.")
+        return 1
+    else:
         print("✓ All files have proper copyright and license headers!")
         return 0
-    else:
-        print(f"✗ Found {files_with_issues} file(s) with missing or incorrect headers.")
-        return 1
 
 
 if __name__ == '__main__':

--- a/check_license_headers.py
+++ b/check_license_headers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
+# Copyright (c) 2026 SiFive, Inc. All rights reserved.
 # Licensed under the MIT License.
 # See LICENSE file in the project root for full license information.
 # SPDX-License-Identifier: MIT
@@ -60,15 +60,15 @@ SPDX_IDENTIFIER = [
 # File extensions to check and their comment styles
 FILE_TYPES = {
     # C/C++ style comments
-    '.c': ('//', '//'),
-    '.h': ('//', '//'),
-    '.cpp': ('//', '//'),
-    '.hpp': ('//', '//'),
+    '.c': '//',
+    '.h': '//',
+    '.cpp': '//',
+    '.hpp': '//',
     # Python style comments
-    '.py': ('#', '#'),
+    '.py': '#',
     # CMake style comments
-    '.cmake': ('#', '#'),
-    'CMakeLists.txt': ('#', '#'),
+    '.cmake': '#',
+    'CMakeLists.txt': '#',
 }
 
 # Directories to exclude
@@ -80,9 +80,11 @@ EXCLUDE_DIRS = {
     '.pytest_cache',
 }
 
-# Files to exclude (relative paths from repo root)
-EXCLUDE_FILES = {
+# Exclude files matching these patterns
+EXCLUDE_PATTERNS = [
+    r'.*\.md$',  # Exclude all markdown files
     '.clang-tidy',
+    '.clang-format',
     '.gitignore',
     'LICENSE.txt',
     'CHANGELOG.md',
@@ -90,12 +92,6 @@ EXCLUDE_FILES = {
     'CONTRIBUTING.md',
     'CONTRIBUTORS.md',
     '.github/CODEOWNERS',
-}
-
-# Exclude files matching these patterns
-EXCLUDE_PATTERNS = [
-    r'.*README\.md$',
-    r'.*\.md$',  # Exclude all markdown files
 ]
 
 def should_check_file(filepath: Path, repo_root: Path) -> bool:
@@ -105,10 +101,6 @@ def should_check_file(filepath: Path, repo_root: Path) -> bool:
     for part in rel_path.parts:
         if part in EXCLUDE_DIRS:
             return False
-
-    # Check if in excluded files
-    if str(rel_path) in EXCLUDE_FILES:
-        return False
 
     # Check against exclude patterns
     rel_path_str = str(rel_path)
@@ -127,10 +119,10 @@ def get_comment_style(filepath: Path) -> Tuple[str, str]:
     """Get the comment style for a file."""
     if filepath.name == 'CMakeLists.txt':
         return FILE_TYPES['CMakeLists.txt']
-    return FILE_TYPES.get(filepath.suffix, (None, None))
+    return FILE_TYPES.get(filepath.suffix)
 
 
-def generate_header(filepath: Path, year: str = "2025") -> str:
+def generate_header(filepath: Path) -> str:
     """
     Generate the appropriate copyright header for a file.
 
@@ -141,23 +133,40 @@ def generate_header(filepath: Path, year: str = "2025") -> str:
     Returns:
         String containing the copyright header
     """
-    comment_prefix, _ = get_comment_style(filepath)
+    comment_prefix = get_comment_style(filepath)
 
     if comment_prefix is None:
         return ""
 
+    year_created = subprocess.check_output(['git', 'log', '--pretty=format:%cI', '--follow', filepath]).split(b'\n')[-1].split(b'-')[0].decode('utf-8')
+    year_modified = subprocess.check_output(['git', 'log', '-1', '--pretty=format:%cI', filepath]).split(b'-')[0].decode('utf-8')
+    if year_created != year_modified:
+        year_str = rf"{year_created}-{year_modified}"
+    else:
+        year_str = rf"{year_modified}"
     header_lines = [
-        f"{comment_prefix} Copyright (c) {year} SiFive, Inc. All rights reserved.",
+    #     rf"Copyright\s+\(c\)\s+202[56](-2026)?\s+\SiFive,\s+Inc\.\s+All\s+rights\s+reserved\.",
+        f"{comment_prefix} Copyright (c) {year_str} SiFive, Inc. All rights reserved.",
         f"{comment_prefix} Licensed under the MIT License.",
         f"{comment_prefix} See LICENSE file in the project root for full license information.",
         f"{comment_prefix} SPDX-License-Identifier: MIT",
         ""
     ]
+    
+    # copyright_license_lines = COPYRIGHT_PATTERNS + LICENSE_REFERENCE + SPDX_IDENTIFIER
+
+    # header_lines = [
+    #     f"{comment_prefix} Copyright (c) {year} SiFive, Inc. All rights reserved.",
+    #     f"{comment_prefix} Licensed under the MIT License.",
+    #     f"{comment_prefix} See LICENSE file in the project root for full license information.",
+    #     f"{comment_prefix} SPDX-License-Identifier: MIT",
+    #     ""
+    # ]
 
     return '\n'.join(header_lines)
 
 
-def fix_file_header(filepath: Path, year: str = "2025") -> bool:
+def fix_file_header(filepath: Path) -> bool:
     """
     Add the copyright header to a file that's missing it.
 
@@ -169,12 +178,14 @@ def fix_file_header(filepath: Path, year: str = "2025") -> bool:
         True if file was modified, False otherwise
     """
     try:
-        with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+        with open(filepath, 'r', encoding='utf-8') as f:
             original_content = f.read()
 
-        header = generate_header(filepath, year)
+        header = generate_header(filepath)
         if not header:
             return False
+
+        print(header)
 
         # Check if file starts with shebang
         new_content = ""
@@ -188,8 +199,11 @@ def fix_file_header(filepath: Path, year: str = "2025") -> bool:
             new_content = header + '\n' + original_content
 
         # Write the modified content
+        with open(filepath, 'r', encoding='utf-8') as f:
+            lines = f.readlines()
         with open(filepath, 'w', encoding='utf-8') as f:
-            f.write(new_content)
+            lines = header + ''.join(lines[4:])
+            f.write(lines)
 
         return True
 
@@ -225,11 +239,12 @@ def check_file_header(filepath: Path) -> Tuple[bool, List[str]]:
             else:
                 year_str = rf"{year_modified}"
             COPYRIGHT_PATTERNS = [
-                rf"Copyright\s+\(c\)\s+202[56](-2026)?\s+\SiFive,\s+Inc\.\s+All\s+rights\s+reserved\.",
+            #     rf"Copyright\s+\(c\)\s+202[56](-2026)?\s+\SiFive,\s+Inc\.\s+All\s+rights\s+reserved\.",
+                rf"Copyright\s+\(c\)\s+{year_str}?\s+\SiFive,\s+Inc\.\s+All\s+rights\s+reserved\.",
             ]
             
             copyright_license_lines = COPYRIGHT_PATTERNS + LICENSE_REFERENCE + SPDX_IDENTIFIER
-            comment_char, _ = get_comment_style(filepath)
+            comment_char = get_comment_style(filepath)
             lines = []
             for line in copyright_license_lines:
                 line = comment_char + r"\s+" + line
@@ -302,18 +317,12 @@ def main():
 
             files_checked += 1
 
-            # Track file types
-            if filepath.name == 'CMakeLists.txt':
-                ext = 'CMakeLists.txt'
-            else:
-                ext = filepath.suffix if filepath.suffix else filepath.name
-
             has_valid_header, issues = check_file_header(filepath)
 
             if not has_valid_header:
                 if args.fix:
                     # Try to fix the file
-                    if fix_file_header(filepath, args.year):
+                    if fix_file_header(filepath):
                         files_fixed.append(rel_path)
                         # Re-check to verify the fix worked
                         has_valid_header, issues = check_file_header(filepath)
@@ -351,18 +360,12 @@ def main():
                 files_checked += 1
                 rel_path = filepath.relative_to(repo_root)
 
-                # Track file types (special case for CMakeLists.txt)
-                if filepath.name == 'CMakeLists.txt':
-                    ext = 'CMakeLists.txt'
-                else:
-                    ext = filepath.suffix if filepath.suffix else filepath.name
-
                 has_valid_header, issues = check_file_header(filepath)
 
                 if not has_valid_header:
                     if args.fix:
                         # Try to fix the file
-                        if fix_file_header(filepath, args.year):
+                        if fix_file_header(filepath):
                             files_fixed.append(rel_path)
                             # Re-check to verify the fix worked
                             has_valid_header, issues = check_file_header(filepath)

--- a/check_license_headers.py
+++ b/check_license_headers.py
@@ -6,27 +6,19 @@
 
 """
 Script to check for SiFive copyright and MIT license headers in source files.
+This script verifies that each relevant file contains the following header:
 
-This script verifies that each relevant file contains:
-1. A copyright notice with "SiFive, Inc." and years 2025-Present or 2026-Present
-2. MIT License reference
-3. Proper SPDX-License-Identifier
+    Copyright (c) {year_str} SiFive, Inc. All rights reserved.
+    Licensed under the MIT License.
+    See LICENSE file in the project root for full license information.
+    SPDX-License-Identifier: MIT
 
 Usage:
-    # Check all files in the repository
-    ./check_license_headers.py
-
     # Check specific files
     ./check_license_headers.py file1.c file2.h
 
     # Show verbose output (lists all valid files)
     ./check_license_headers.py --verbose
-
-    # Fix files with missing headers
-    ./check_license_headers.py --fix
-
-    # Fix specific files only
-    ./check_license_headers.py --fix file1.c file2.h
 
 Exit codes:
     0 - All files have proper headers
@@ -41,23 +33,8 @@ import subprocess
 from pathlib import Path
 from typing import List, Tuple, Set
 
-# Expected copyright patterns (allowing for 2025 or 2026)
-COPYRIGHT_PATTERNS = [
-    r"Copyright\s+\(c\)\s+202[56](-2026)?\s+SiFive,?\s+Inc\.\s+All\s+rights\s+reserved\.",
-]
-
-# Expected license reference
-LICENSE_REFERENCE = [
-    r"Licensed under the MIT License\.",
-    r"See LICENSE file in the project root for full license information\."
-]
-
-# Expected SPDX identifier
-SPDX_IDENTIFIER = [
-    r"SPDX-License-Identifier:\s*MIT"
-]
-
-# File extensions to check and their comment styles
+# Comment styles for different file types
+# The script defaults to '' for types not listed here
 FILE_TYPES = {
     # C/C++ style comments
     '.c': '//',
@@ -71,145 +48,64 @@ FILE_TYPES = {
     'CMakeLists.txt': '#',
 }
 
-# Directories to exclude
-EXCLUDE_DIRS = {
-    '.git',
-    'build',
-    'doc/html',
-    '__pycache__',
-    '.pytest_cache',
-}
-
 # Exclude files matching these patterns
+# The script looks for a match at the beginning of a file's path relative to
+# the root of the repo.
 EXCLUDE_PATTERNS = [
-    r'.*\.md$',  # Exclude all markdown files
+    r'.*\.md$',
     '.clang-tidy',
     '.clang-format',
+    r'.*Doxyfile$',
+    '.github/',
     '.gitignore',
     'LICENSE.txt',
-    'CHANGELOG.md',
-    'README.md',
-    'CONTRIBUTING.md',
-    'CONTRIBUTORS.md',
-    '.github/CODEOWNERS',
 ]
 
 def should_check_file(filepath: Path, repo_root: Path) -> bool:
-    """Determine if a file should be checked for license headers."""
-    # Check if in excluded directory
+    """Determine if a file should be checked."""
     rel_path = filepath.relative_to(repo_root)
-    for part in rel_path.parts:
-        if part in EXCLUDE_DIRS:
-            return False
-
-    # Check against exclude patterns
     rel_path_str = str(rel_path)
     for pattern in EXCLUDE_PATTERNS:
         if re.match(pattern, rel_path_str):
             return False
-
-    # Check file extension or name
-    if filepath.name == 'CMakeLists.txt':
-        return True
-
-    return filepath.suffix in FILE_TYPES
+    return True
 
 
-def get_comment_style(filepath: Path) -> Tuple[str, str]:
+def get_comment_style(filepath: Path) -> str:
     """Get the comment style for a file."""
     if filepath.name == 'CMakeLists.txt':
-        return FILE_TYPES['CMakeLists.txt']
-    return FILE_TYPES.get(filepath.suffix)
+        return FILE_TYPES[filepath.name]
+    return FILE_TYPES.get(filepath.suffix, '')
 
 
-def generate_header(filepath: Path) -> str:
-    """
-    Generate the appropriate copyright header for a file.
+def get_copyright_year(filepath: Path) -> str:
+    year_from_date = lambda date: date.split(b'-')[0].decode('utf-8')
 
-    Args:
-        filepath: Path to the file
-        year: Starting copyright year (2025 or 2026)
+    date_created = subprocess.check_output(['git', 'log', '--pretty=format:%cI', '--follow', filepath]).rsplit(b'\n', 1)[-1]
+    date_modified = subprocess.check_output(['git', 'log', '-1', '--pretty=format:%cI', filepath])
+    year_created = year_from_date(date_created)
+    year_modified = year_from_date(date_modified)
 
-    Returns:
-        String containing the copyright header
-    """
-    comment_prefix = get_comment_style(filepath)
-
-    if comment_prefix is None:
-        return ""
-
-    year_created = subprocess.check_output(['git', 'log', '--pretty=format:%cI', '--follow', filepath]).split(b'\n')[-1].split(b'-')[0].decode('utf-8')
-    year_modified = subprocess.check_output(['git', 'log', '-1', '--pretty=format:%cI', filepath]).split(b'-')[0].decode('utf-8')
     if year_created != year_modified:
-        year_str = rf"{year_created}-{year_modified}"
+        year_str = f"{year_created}-{year_modified}"
     else:
-        year_str = rf"{year_modified}"
+        year_str = f"{year_modified}"
+    
+    return year_str
+
+
+def generate_copyright_pattern(filepath: Path) -> str:
+    """Generate the appropriate copyright header pattern for a file."""
+    comment_prefix = get_comment_style(filepath)
+    year_str = get_copyright_year(filepath)
     header_lines = [
-    #     rf"Copyright\s+\(c\)\s+202[56](-2026)?\s+\SiFive,\s+Inc\.\s+All\s+rights\s+reserved\.",
-        f"{comment_prefix} Copyright (c) {year_str} SiFive, Inc. All rights reserved.",
-        f"{comment_prefix} Licensed under the MIT License.",
-        f"{comment_prefix} See LICENSE file in the project root for full license information.",
-        f"{comment_prefix} SPDX-License-Identifier: MIT",
+        rf"{comment_prefix} Copyright \(c\) {year_str} SiFive, Inc\. All rights reserved\.(\r)?\n",
+        rf"{comment_prefix} Licensed under the MIT License\.(\r)?\n",
+        rf"{comment_prefix} See LICENSE file in the project root for full license information\.(\r)?\n",
+        rf"{comment_prefix} SPDX-License-Identifier: MIT(\r)?\n",
         ""
     ]
-    
-    # copyright_license_lines = COPYRIGHT_PATTERNS + LICENSE_REFERENCE + SPDX_IDENTIFIER
-
-    # header_lines = [
-    #     f"{comment_prefix} Copyright (c) {year} SiFive, Inc. All rights reserved.",
-    #     f"{comment_prefix} Licensed under the MIT License.",
-    #     f"{comment_prefix} See LICENSE file in the project root for full license information.",
-    #     f"{comment_prefix} SPDX-License-Identifier: MIT",
-    #     ""
-    # ]
-
-    return '\n'.join(header_lines)
-
-
-def fix_file_header(filepath: Path) -> bool:
-    """
-    Add the copyright header to a file that's missing it.
-
-    Args:
-        filepath: Path to the file to fix
-        year: Starting copyright year (2025 or 2026)
-
-    Returns:
-        True if file was modified, False otherwise
-    """
-    try:
-        with open(filepath, 'r', encoding='utf-8') as f:
-            original_content = f.read()
-
-        header = generate_header(filepath)
-        if not header:
-            return False
-
-        print(header)
-
-        # Check if file starts with shebang
-        new_content = ""
-        if original_content.startswith('#!'):
-            # Preserve shebang line
-            lines = original_content.split('\n', 1)
-            shebang = lines[0] + '\n'
-            rest = lines[1] if len(lines) > 1 else ""
-            new_content = shebang + header + '\n' + rest
-        else:
-            new_content = header + '\n' + original_content
-
-        # Write the modified content
-        with open(filepath, 'r', encoding='utf-8') as f:
-            lines = f.readlines()
-        with open(filepath, 'w', encoding='utf-8') as f:
-            lines = header + ''.join(lines[4:])
-            f.write(lines)
-
-        return True
-
-    except Exception as e:
-        print(f"Error fixing file {filepath}: {e}")
-        return False
+    return ''.join(header_lines)
 
 
 def check_file_header(filepath: Path) -> Tuple[bool, List[str]]:
@@ -223,180 +119,88 @@ def check_file_header(filepath: Path) -> Tuple[bool, List[str]]:
     
     try:
         with open(filepath, 'r') as f:
-            # Read first 20 lines (header should be in this range)
+            # Read first 6 lines (header should be in this range)
             header_lines = []
             for i, line in enumerate(f):
-                if i >= 20:
+                if i >= 6:
                     break
                 header_lines.append(line)
-            
             header_text = ''.join(header_lines)
-            
-            year_created = subprocess.check_output(['git', 'log', '--pretty=format:%cI', '--follow', filepath]).split(b'\n')[-1].split(b'-')[0].decode('utf-8')
-            year_modified = subprocess.check_output(['git', 'log', '-1', '--pretty=format:%cI', filepath]).split(b'-')[0].decode('utf-8')
-            if year_created != year_modified:
-                year_str = rf"{year_created}-{year_modified}"
-            else:
-                year_str = rf"{year_modified}"
-            COPYRIGHT_PATTERNS = [
-            #     rf"Copyright\s+\(c\)\s+202[56](-2026)?\s+\SiFive,\s+Inc\.\s+All\s+rights\s+reserved\.",
-                rf"Copyright\s+\(c\)\s+{year_str}?\s+\SiFive,\s+Inc\.\s+All\s+rights\s+reserved\.",
-            ]
-            
-            copyright_license_lines = COPYRIGHT_PATTERNS + LICENSE_REFERENCE + SPDX_IDENTIFIER
-            comment_char = get_comment_style(filepath)
-            lines = []
-            for line in copyright_license_lines:
-                line = comment_char + r"\s+" + line
-                lines.append(line)
-            copyright_license_pattern = r"(\r)?\n".join(lines)
 
-            copyright_found = False
-            if re.search(copyright_license_pattern, header_text):
-                copyright_found = True
-
-            # Check for copyright notice
-            if not copyright_found:
-                issues.append("Missing or incorrect SiFive copyright notice (should be" + copyright_license_pattern + ")")
+            copyright_pattern = generate_copyright_pattern(filepath)
+            if not re.search(copyright_pattern, header_text):
+                issues.append("Missing or incorrect header. Should be: " + copyright_pattern)
             
     except Exception as e:
         issues.append(f"Error reading file: {e}")
     
     return (len(issues) == 0, issues)
 
+
 def main():
-    """Main function to check all files in the repository."""
+    """Main function to check given files in the repository."""
     parser = argparse.ArgumentParser(
         description="Check for SiFive copyright and MIT license headers in source files.",
+    )
+    parser.add_argument(
+        'files',
+        nargs='*',
+        help='Files to check'
     )
     parser.add_argument(
         '-v', '--verbose',
         action='store_true',
         help='Show verbose output including all checked files'
     )
-    parser.add_argument(
-        '--fix',
-        action='store_true',
-        help='Automatically add missing headers to files'
-    )
-    parser.add_argument(
-        'files',
-        nargs='*',
-        help='Specific files to check (if not provided, checks entire repository)'
-    )
     args = parser.parse_args()
 
     repo_root = Path(__file__).parent.resolve()
 
     files_checked = 0
+    files_skipped = 0
     files_with_issues = 0
-    all_issues = []
     files_ok = []
-    files_fixed = []
+    all_issues = []
 
-    # If specific files are provided, check only those
-    if args.files:
-        files_to_check = [Path(f).resolve() for f in args.files]
-        print(f"Checking {len(files_to_check)} specified file(s)")
-        print("=" * 80)
+    files_to_check = [Path(f).resolve() for f in args.files]
+    print(f"Checking {len(files_to_check)} specified file(s)")
+    print("=" * 80)
 
-        for filepath in files_to_check:
-            if not filepath.exists():
-                print(f"Warning: File not found: {filepath}")
-                continue
+    for filepath in files_to_check:
+        if not filepath.exists():
+            print(f"Warning: File not found: {filepath}")
+            continue
 
-            if not filepath.is_file():
-                print(f"Warning: Not a file: {filepath}")
-                continue
+        if not filepath.is_file():
+            print(f"Warning: Not a file: {filepath}")
+            continue
 
-            try:
-                rel_path = filepath.relative_to(repo_root)
-            except ValueError:
-                print(f"Warning: File outside repository: {filepath}")
-                continue
+        try:
+            rel_path = filepath.relative_to(repo_root)
+        except ValueError:
+            print(f"Warning: File outside repository: {filepath}")
+            continue
 
-            files_checked += 1
+        if not should_check_file(filepath, repo_root):
+            files_skipped += 1
+            print(f"Skipping {filepath}")
+            continue
 
-            has_valid_header, issues = check_file_header(filepath)
+        files_checked += 1
 
-            if not has_valid_header:
-                if args.fix:
-                    # Try to fix the file
-                    if fix_file_header(filepath):
-                        files_fixed.append(rel_path)
-                        # Re-check to verify the fix worked
-                        has_valid_header, issues = check_file_header(filepath)
-                        if has_valid_header:
-                            files_ok.append(rel_path)
-                        else:
-                            files_with_issues += 1
-                            all_issues.append((rel_path, issues))
-                    else:
-                        files_with_issues += 1
-                        all_issues.append((rel_path, issues))
-                else:
-                    files_with_issues += 1
-                    all_issues.append((rel_path, issues))
-            else:
-                files_ok.append(rel_path)
-    else:
-        # Check all files in repository
-        print(f"Checking license headers in: {repo_root}")
-        print("=" * 80)
+        has_valid_header, issues = check_file_header(filepath)
 
-        # Walk through all files
-        for root, dirs, files in os.walk(repo_root):
-            root_path = Path(root)
-
-            # Filter out excluded directories
-            dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
-
-            for filename in files:
-                filepath = root_path / filename
-
-                if not should_check_file(filepath, repo_root):
-                    continue
-
-                files_checked += 1
-                rel_path = filepath.relative_to(repo_root)
-
-                has_valid_header, issues = check_file_header(filepath)
-
-                if not has_valid_header:
-                    if args.fix:
-                        # Try to fix the file
-                        if fix_file_header(filepath):
-                            files_fixed.append(rel_path)
-                            # Re-check to verify the fix worked
-                            has_valid_header, issues = check_file_header(filepath)
-                            if has_valid_header:
-                                files_ok.append(rel_path)
-                            else:
-                                files_with_issues += 1
-                                all_issues.append((rel_path, issues))
-                        else:
-                            files_with_issues += 1
-                            all_issues.append((rel_path, issues))
-                    else:
-                        files_with_issues += 1
-                        all_issues.append((rel_path, issues))
-                else:
-                    files_ok.append(rel_path)
+        if has_valid_header:
+            files_ok.append(rel_path)
+        else:
+            files_with_issues += 1
+            all_issues.append((rel_path, issues))
 
     # Print results
     print(f"\nFiles checked: {files_checked}")
-    if args.fix and files_fixed:
-        print(f"Files fixed: {len(files_fixed)}")
+    print(f"Files skipped: {files_skipped}")
+    print(f"Files OK: {len(files_ok)}")
     print(f"Files with issues: {files_with_issues}")
-    print(f"Files OK: {files_checked - files_with_issues}")
-
-    # Show fixed files
-    if files_fixed:
-        print("\n" + "=" * 80)
-        print("FILES FIXED:")
-        print("=" * 80)
-        for filepath in sorted(files_fixed):
-            print(f"  ✓ {filepath}")
 
     # Show verbose output if requested
     if args.verbose and files_ok:

--- a/check_license_headers.py
+++ b/check_license_headers.py
@@ -94,8 +94,8 @@ def get_copyright_year(filepath: Path) -> str:
     return year_str
 
 
-def generate_copyright_pattern(filepath: Path) -> str:
-    """Generate the appropriate copyright header pattern for a file."""
+def generate_license_pattern(filepath: Path) -> str:
+    """Generate the appropriate license header pattern for a file."""
     comment_prefix = get_comment_style(filepath)
     year_str = get_copyright_year(filepath)
     header_lines = [
@@ -127,9 +127,9 @@ def check_file_header(filepath: Path) -> Tuple[bool, List[str]]:
                 header_lines.append(line)
             header_text = ''.join(header_lines)
 
-            copyright_pattern = generate_copyright_pattern(filepath)
-            if not re.search(copyright_pattern, header_text):
-                issues.append("Missing or incorrect header. Should be: " + copyright_pattern)
+            license_pattern = generate_license_pattern(filepath)
+            if not re.search(license_pattern, header_text):
+                issues.append("Missing or incorrect header. Should be: " + license_pattern)
 
     except Exception as e:
         issues.append(f"Error reading file: {e}")

--- a/check_license_headers.py
+++ b/check_license_headers.py
@@ -102,10 +102,10 @@ def generate_license_pattern(filepath: Path) -> str:
     comment_prefix = get_comment_style(filepath)
     year_str = get_copyright_year(filepath)
     header_lines = [
-        rf"{comment_prefix} Copyright \(c\) {year_str} SiFive, Inc\. All rights reserved\.(\r)?\n",
-        rf"{comment_prefix} Licensed under the MIT License\.(\r)?\n",
-        rf"{comment_prefix} See LICENSE file in the project root for full license information\.(\r)?\n",
-        rf"{comment_prefix} SPDX-License-Identifier: MIT(\r)?\n",
+        f"{comment_prefix} Copyright (c) {year_str} SiFive, Inc. All rights reserved.\n",
+        f"{comment_prefix} Licensed under the MIT License.\n",
+        f"{comment_prefix} See LICENSE file in the project root for full license information.\n",
+        f"{comment_prefix} SPDX-License-Identifier: MIT\n",
         ""
     ]
     return ''.join(header_lines)
@@ -131,8 +131,8 @@ def check_file_header(filepath: Path) -> List[str]:
             header_text = ''.join(header_lines)
 
             license_pattern = generate_license_pattern(filepath)
-            if not re.search(license_pattern, header_text):
-                issues.append("Missing or incorrect header. Should be: " + license_pattern)
+            if not license_pattern in header_text:
+                issues.append("Missing or incorrect header. Should be:\n" + license_pattern)
 
     except Exception as e:
         issues.append(f"Error reading file: {e}")

--- a/check_license_headers.py
+++ b/check_license_headers.py
@@ -49,10 +49,15 @@ COPYRIGHT_PATTERNS = [
 ]
 
 # Expected license reference
-LICENSE_REFERENCE = r"Licensed\s+under\s+the\s+MIT\s+License\."
+LICENSE_REFERENCE = [
+    r"Licensed under the MIT License\.",
+    r"See LICENSE file in the project root for full license information\."
+]
 
 # Expected SPDX identifier
-SPDX_IDENTIFIER = r"SPDX-License-Identifier:\s*MIT"
+SPDX_IDENTIFIER = [
+    r"SPDX-License-Identifier:\s*MIT"
+]
 
 # File extensions to check and their comment styles
 FILE_TYPES = {
@@ -205,7 +210,7 @@ def check_file_header(filepath: Path) -> Tuple[bool, List[str]]:
     issues = []
     
     try:
-        with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+        with open(filepath, 'r') as f:
             # Read first 20 lines (header should be in this range)
             header_lines = []
             for i, line in enumerate(f):
@@ -215,23 +220,37 @@ def check_file_header(filepath: Path) -> Tuple[bool, List[str]]:
             
             header_text = ''.join(header_lines)
             
-            # Check for copyright notice
+            copyright_license_lines = COPYRIGHT_PATTERNS + LICENSE_REFERENCE + SPDX_IDENTIFIER
+            # copyright_license_lines = LICENSE_REFERENCE
+            comment_char, _ = get_comment_style(filepath)
+            print(f"comment char is {comment_char}\n")
+            lines = []
+            for line in copyright_license_lines:
+                line = comment_char + r"\s+" + line
+                lines.append(line)
+            copyright_license_pattern = r"(\r)?\n".join(lines)
+
             copyright_found = False
-            for pattern in COPYRIGHT_PATTERNS:
-                if re.search(pattern, header_text, re.IGNORECASE):
-                    copyright_found = True
-                    break
+            if re.search(copyright_license_pattern, header_text):
+                copyright_found = True
+
+            # Check for copyright notice
+            # copyright_found = False
+            # for pattern in COPYRIGHT_PATTERNS:
+            #     if re.search(pattern, header_text, re.IGNORECASE):
+            #         copyright_found = True
+            #         break
             
             if not copyright_found:
                 issues.append("Missing or incorrect SiFive copyright notice (should be '2025-Present' or '2026-Present')")
             
             # Check for MIT license reference
-            if not re.search(LICENSE_REFERENCE, header_text, re.IGNORECASE):
-                issues.append("Missing MIT License reference")
+            # if not re.search(LICENSE_REFERENCE, header_text, re.IGNORECASE):
+            #     issues.append("Missing MIT License reference")
             
             # Check for SPDX identifier
-            if not re.search(SPDX_IDENTIFIER, header_text):
-                issues.append("Missing SPDX-License-Identifier: MIT")
+            # if not re.search(SPDX_IDENTIFIER, header_text):
+            #     issues.append("Missing SPDX-License-Identifier: MIT")
             
     except Exception as e:
         issues.append(f"Error reading file: {e}")


### PR DESCRIPTION
This PR adds a script by @ericlove to check each file in the repo for a correct license header if needed and adds this check to CI.

Currently based on #88, but will rebase after it merges.