### PR TITLE
Improve and fix CMake infrastructure for cross-compiling and linting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@
 
 cmake_minimum_required(VERSION 3.21)
 
+# This option may affect the call to `project` and thus must come first.
+option(SKL_ENABLE_CLANG_TIDY "Enable linting with clang-tidy" ON)
+
 project(SKL)
 
 set(DEFAULT_CMAKE_BUILD_TYPE "Release")
@@ -14,9 +17,17 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # Set up clang-tidy
-option(SKL_ENABLE_CLANG_TIDY "Enable clang-tidy command" ON)
 if(SKL_ENABLE_CLANG_TIDY)
-    set(CMAKE_C_CLANG_TIDY riscv64-unknown-elf-clang-tidy)
+    find_program(SKL_CLANG_TIDY_EXE NAMES
+        riscv64-unknown-elf-clang-tidy
+        riscv64-unknown-linux-gnu-clang-tidy
+    )
+    set(SKL_CLANG_TIDY_EXE "${SKL_CLANG_TIDY_EXE}" CACHE FILEPATH "Path to clang-tidy")
+    if(SKL_CLANG_TIDY_EXE)
+        set(CMAKE_C_CLANG_TIDY "${SKL_CLANG_TIDY_EXE}" CACHE STRING "clang-tidy command")
+    endif()
+else()
+    unset(CMAKE_C_CLANG_TIDY CACHE)
 endif()
 
 # Build the library itself

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,12 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "${DEFAULT_CMAKE_BUILD_TYPE}" CACHE STRING "Build type (default ${DEFAULT_CMAKE_BUILD_TYPE})" FORCE)
 endif()
 
+# Set up clang-tidy
+option(SKL_ENABLE_CLANG_TIDY "Enable clang-tidy command" ON)
+if(SKL_ENABLE_CLANG_TIDY)
+    set(CMAKE_C_CLANG_TIDY riscv64-unknown-elf-clang-tidy)
+endif()
+
 # Build the library itself
 
 set(SKL_LIBRARY skl)

--- a/cmake/riscv.cmake
+++ b/cmake/riscv.cmake
@@ -3,6 +3,7 @@
 # See LICENSE file in the project root for full license information.
 # SPDX-License-Identifier: MIT
 
+set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR riscv)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")

--- a/cmake/riscv.cmake
+++ b/cmake/riscv.cmake
@@ -9,10 +9,6 @@ set(CMAKE_SYSTEM_PROCESSOR riscv)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
 
 set(CMAKE_C_COMPILER riscv64-unknown-elf-clang)
-option(SKL_ENABLE_CLANG_TIDY "Enable clang-tidy command" ON)
-if(SKL_ENABLE_CLANG_TIDY)
-  set(CMAKE_C_CLANG_TIDY riscv64-unknown-elf-clang-tidy)
-endif()
 
 set(SKL_ARCH_EXTENSIONS
   rv64gcv


### PR DESCRIPTION
This PR fixes minor issues with our build infrastructure:

* `CMAKE_SYSTEM_NAME` was never set when it actually should be set when cross-compiling. I've set it to `Generic` as a first step.
* Move the `SKL_ENABLE_CLANG_TIDY` option and its related setting from the `cmake/riscv.cmake` toolchain file to the project's `CMakeLists.txt`, because it could cause configure-time errors when CMake checks for a working C compiler for two main reasons: either CMake could not find a clang-tidy config file (out-of-tree build scenario), or CMake's own C source files used for the check did not conform to our linter rules.