### PR TITLE
DepthwiseConv2D: Simplify naming styles of public APIs.

### DIFF
--- a/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
@@ -8,7 +8,7 @@
 
 #include "skl-common.h"
 
-SKL_FUNC void skl_depthwise_conv2d_hwc_f16_f16_f16_ref(
+SKL_FUNC void skl_depthwise_conv2d_f16hwc_f16hwim_f16hwc_ref(
     _Float16 *output, const _Float16 *input, const _Float16 *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t filter_height, size_t filter_width, size_t output_height,

--- a/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.h
@@ -63,7 +63,7 @@ extern "C" {
  * @note This function is for API documentation and test purposes only, and
  * should not be used to obtain good performance.
  */
-void skl_depthwise_conv2d_hwc_f16_f16_f16_ref(
+void skl_depthwise_conv2d_f16hwc_f16hwim_f16hwc_ref(
     _Float16 *output, const _Float16 *input, const _Float16 *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t filter_height, size_t filter_width, size_t output_height,

--- a/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
@@ -8,7 +8,7 @@
 
 #include "skl-common.h"
 
-SKL_FUNC void skl_depthwise_conv2d_hwc_f32_f32_f32_ref(
+SKL_FUNC void skl_depthwise_conv2d_f32hwc_f32hwim_f32hwc_ref(
     float *output, const float *input, const float *filter, size_t input_height,
     size_t input_width, size_t input_channel, size_t filter_height,
     size_t filter_width, size_t output_height, size_t output_width,

--- a/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.h
@@ -63,7 +63,7 @@ extern "C" {
  * @note This function is for API documentation and test purposes only, and
  * should not be used to obtain good performance.
  */
-void skl_depthwise_conv2d_hwc_f32_f32_f32_ref(
+void skl_depthwise_conv2d_f32hwc_f32hwim_f32hwc_ref(
     float *output, const float *input, const float *filter, size_t input_height,
     size_t input_width, size_t input_channel, size_t filter_height,
     size_t filter_width, size_t output_height, size_t output_width,

--- a/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.c
@@ -8,7 +8,7 @@
 
 #include "skl-common.h"
 
-SKL_FUNC void skl_depthwise_conv2d_hwc_f64_f64_f64_ref(
+SKL_FUNC void skl_depthwise_conv2d_f64hwc_f64hwim_f64hwc_ref(
     double *output, const double *input, const double *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t filter_height, size_t filter_width, size_t output_height,

--- a/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_f64_f64_f64.h
@@ -63,7 +63,7 @@ extern "C" {
  * @note This function is for API documentation and test purposes only, and
  * should not be used to obtain good performance.
  */
-void skl_depthwise_conv2d_hwc_f64_f64_f64_ref(
+void skl_depthwise_conv2d_f64hwc_f64hwim_f64hwc_ref(
     double *output, const double *input, const double *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t filter_height, size_t filter_width, size_t output_height,

--- a/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
+++ b/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
@@ -8,7 +8,7 @@
 
 #include "skl-common.h"
 
-SKL_FUNC void skl_depthwise_conv2d_hwc_i8_i8_i32_ref(
+SKL_FUNC void skl_depthwise_conv2d_i8hwc_i8hwim_i32hwc_ref(
     int32_t *output, const int8_t *input, const int8_t *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t filter_height, size_t filter_width, size_t output_height,

--- a/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
+++ b/ref/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.h
@@ -71,7 +71,7 @@ extern "C" {
  * @note This function is for API documentation and test purposes only, and
  * should not be used to obtain good performance.
  */
-void skl_depthwise_conv2d_hwc_i8_i8_i32_ref(
+void skl_depthwise_conv2d_i8hwc_i8hwim_i32hwc_ref(
     int32_t *output, const int8_t *input, const int8_t *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t filter_height, size_t filter_width, size_t output_height,

--- a/src/depthwise_conv2d/README.md
+++ b/src/depthwise_conv2d/README.md
@@ -94,12 +94,12 @@ Below is the format of RVV Kernel name:
 **`skl_depthwise_conv2d_<specialization>_<input_data_type><input_layout>_<filter_data_type><filter_layout>_<output_data_type><output_layout>_<isa>`**
 
 where
-- `specialization` includes the contraints of filter size, strides, and dilations, expressed in f[number]x[number]s[number]d[number]i[number].
+- `specialization` includes the contraints of filter size, strides, and dilations, expressed in `f[number]x[number]s[number]d[number]i[number]`.
 If any of them is not specified, it indiates any positive integer.
- - `f` for filter size. `[number]` should be an exact positive integer
- - `s` for strides
- - `d` for dilations
- - `i` for input channel size
+  - `f` for filter size. `[number]` should be an exact positive integer
+  - `s` for strides
+  - `d` for dilations
+  - `i` for input channel size
 - `layout`: `hwc` or `chw` for input/output data layout. `hwim` for filter data layout.
 - `data_type` for data type of tensors (input, filter, output).
 - `isa` for target architecture, e.g. `zve32x`.

--- a/src/depthwise_conv2d/README.md
+++ b/src/depthwise_conv2d/README.md
@@ -104,6 +104,18 @@ If any of them is not specified, it indicates any positive integer.
 - `data_type` for data type of tensors (input, filter, output).
 - `isa` for target architecture, e.g. `zve32x`.
 
+Below is the description of filter layout:
+```
+Given M = depth multiplier, I = input channel size
+Here are the pairs of input and filter for channel-wise dot-product:
+
+Input channel index:  [0, 0, ..., 0]     [1, 1,     ..., 1]         [I - 1, I - 1,                 ..., I - 1]
+Filter channel index: [0, 1, ..., M - 1] [M, M + 1, ..., 2 * M - 1] [I * (M - 1), I * (M - 1) + 1, ..., I * M - 1]
+
+The pairs will be interated through the height and width of filter tensor.
+Following the order of nested loops, we express filter as `hwim` from the outmost loop to the innermost loop.
+```
+
 ### RVV Implementations (Int8)
 #### **`skl_depthwise_conv2d_i8hwc_i8hwim_i32hwc_zve32x`**
 - Generic RVV implementation

--- a/src/depthwise_conv2d/README.md
+++ b/src/depthwise_conv2d/README.md
@@ -95,7 +95,7 @@ Below is the format of RVV Kernel name:
 
 where
 - `specialization` includes the contraints of filter size, strides, and dilations, expressed in `f[number]x[number]s[number]d[number]i[number]`.
-If any of them is not specified, it indiates any positive integer.
+If any of them is not specified, it indicates any positive integer.
   - `f` for filter size. `[number]` should be an exact positive integer
   - `s` for strides
   - `d` for dilations

--- a/src/depthwise_conv2d/README.md
+++ b/src/depthwise_conv2d/README.md
@@ -20,12 +20,12 @@ Currently supports `int8` input/filter with `int32` output, as well as `float16`
 ## Kernel List
 
 ### Scalar Implementation (Int8)
-#### **`skl_depthwise_conv2d_hwc_i8_i8_i32_ref`**
+#### **`skl_depthwise_conv2d_i8hwc_i8hwim_i32hwc_ref`**
 - Generic implementation
 - Data layout: Input (HWC), Filter (HWIM), Output (HWC)
 
 ```c
-void skl_depthwise_conv2d_hwc_i8_i8_i32_ref(
+void skl_depthwise_conv2d_i8hwc_i8hwim_i32hwc_ref(
     int32_t *output,                   // Output tensor (HWC layout)
     const int8_t *input,               // Input tensor (HWC layout)
     const int8_t *filter,              // Filter tensor (HWIM layout)
@@ -54,12 +54,12 @@ void skl_depthwise_conv2d_hwc_i8_i8_i32_ref(
 
 
 ### Scalar Implementation (Float16)
-#### `skl_depthwise_conv2d_hwc_f16_f16_f16_ref`
+#### `skl_depthwise_conv2d_f16hwc_f16hwim_f16hwc_ref`
 - Generic implementation
 - Data layout: Input (HWC), Filter (HWIM), Output (HWC)
 
 ```c
-void skl_depthwise_conv2d_hwc_f16_f16_f16_ref(
+void skl_depthwise_conv2d_f16hwc_f16hwim_f16hwc_ref(
     _Float16 *output, const _Float16 *input, const _Float16 *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t filter_height, size_t filter_width, size_t output_height,
@@ -71,12 +71,12 @@ void skl_depthwise_conv2d_hwc_f16_f16_f16_ref(
 ```
 
 ### Scalar Implementation (Float32)
-#### `skl_depthwise_conv2d_hwc_f32_f32_f32_ref`
+#### `skl_depthwise_conv2d_f32hwc_f32hwim_f32hwc_ref`
 - Generic implementation
 - Data layout: Input (HWC), Filter (HWIM), Output (HWC)
 
 ```c
-void skl_depthwise_conv2d_hwc_f32_f32_f32_ref(
+void skl_depthwise_conv2d_f32hwc_f32hwim_f32hwc_ref(
     float *output, const float *input, const float *filter, size_t input_height,
     size_t input_width, size_t input_channel, size_t filter_height,
     size_t filter_width, size_t output_height, size_t output_width,
@@ -91,26 +91,26 @@ void skl_depthwise_conv2d_hwc_f32_f32_f32_ref(
 
 Below is the format of RVV Kernel name:
 
-**`skl_depthwise_conv2d_v[dimensions]_f[number]x[number]_s[number]_d[number]_i[number]_[layout]_[data_type]_[architecture]`**
+**`skl_depthwise_conv2d_<specialization>_<input_data_type><input_layout>_<filter_data_type><filter_layout>_<output_data_type><output_layout>_<isa>`**
 
 where
-- `v` for vectorized dimensions. `[dimension]` should be a combination of `h` (height), `w` (width) and `c` (channel)
-- `f` for filter size. `[number]` should be an exact positive integer or `n` for any positive integer
-- `s` for strides
-- `d` for dilations
-- `i` for input channel size
-- `layout` for input/output data layout, `hwc` or `chw`
-- `data_type` for data type of tensors (input, filter, output) and separated by underscores
-- `architecture` for target architecture
+- `specialization` includes the contraints of filter size, strides, and dilations, expressed in f[number]x[number]s[number]d[number]i[number].
+If any of them is not specified, it indiates any positive integer.
+ - `f` for filter size. `[number]` should be an exact positive integer
+ - `s` for strides
+ - `d` for dilations
+ - `i` for input channel size
+- `layout`: `hwc` or `chw` for input/output data layout. `hwim` for filter data layout.
+- `data_type` for data type of tensors (input, filter, output).
+- `isa` for target architecture, e.g. `zve32x`.
 
 ### RVV Implementations (Int8)
-#### **`skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_i8_i8_i32_zve32x`**
+#### **`skl_depthwise_conv2d_i8hwc_i8hwim_i32hwc_zve32x`**
 - Generic RVV implementation
 - Data layout: Input (HWC), Filter (HWIM), Output (HWC)
-- Vectorize along the channel dimension
 
 ```c
-void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_i8_i8_i32_zve32x(
+void skl_depthwise_conv2d_i8hwc_i8hwim_i32hwc_zve32x(
     int32_t *output, const int8_t *input, const int8_t *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t filter_height, size_t filter_width, size_t output_height,
@@ -122,14 +122,13 @@ void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_i8_i8_i32_zve32x(
     int32_t input_zero_point);
 ```
 
-#### **`skl_depthwise_conv2d_vc_f3x3_sn_dn_m1_in_hwc_i8_i8_i32_zve32x`**
+#### **`skl_depthwise_conv2d_f3x3m1_i8hwc_i8hwim_i32hwc_zve32x`**
 - Specialized RVV implementation
 - Data layout: Input (HWC), Filter (HWIM), Output (HWC)
 - Optimized for 3x3 filters and `depth_multiplier` = 1
-- Vectorize along the channel dimension
 
 ```c
-void skl_depthwise_conv2d_vc_f3x3_sn_dn_m1_in_hwc_i8_i8_i32_zve32x(
+void skl_depthwise_conv2d_f3x3m1_i8hwc_i8hwim_i32hwc_zve32x(
     int32_t *output, const int8_t *input, const int8_t *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t output_height, size_t output_width, size_t output_channel,
@@ -141,12 +140,11 @@ void skl_depthwise_conv2d_vc_f3x3_sn_dn_m1_in_hwc_i8_i8_i32_zve32x(
 ```
 
 ### RVV Implementations (Float16)
-#### **`skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f16_f16_f16_zvfh`**
+#### **`skl_depthwise_conv2d_f16hwc_f16hwim_f16hwc_zvfh`**
 - Data layout: Input (HWC), Filter (HWIM), Output (HWC)
-- Vectorize along the channel dimension
 
 ```c
-void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f16_f16_f16_zvfh(
+void skl_depthwise_conv2d_f16hwc_f16hwim_f16hwc_zvfh(
     _Float16 *output, const _Float16 *input, const _Float16 *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t filter_height, size_t filter_width, size_t output_height,
@@ -157,14 +155,13 @@ void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f16_f16_f16_zvfh(
     size_t output_row_stride, size_t output_col_stride);
 ```
 
-#### **`skl_depthwise_conv2d_vc_f3x3_sn_dn_mn_in_hwc_f16_f16_f16_zvfh`**
+#### **`skl_depthwise_conv2d_f3x3_f16hwc_f16hwim_f16hwc_zvfh`**
 - Specialized RVV implementation
 - Data layout: Input (HWC), Filter (HWIM), Output (HWC)
 - Optimized for 3x3 filters
-- Vectorize along the channel dimension
 
 ```c
-void skl_depthwise_conv2d_vc_f3x3_sn_dn_mn_in_hwc_f16_f16_f16_zvfh(
+void skl_depthwise_conv2d_f3x3_f16hwc_f16hwim_f16hwc_zvfh(
     _Float16 *output, const _Float16 *input, const _Float16 *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t output_height, size_t output_width, size_t output_channel,
@@ -175,12 +172,11 @@ void skl_depthwise_conv2d_vc_f3x3_sn_dn_mn_in_hwc_f16_f16_f16_zvfh(
 ```
 
 ### RVV Implementations (Float32)
-#### **`skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f32_f32_f32_zve32f`**
+#### **`skl_depthwise_conv2d_f32hwc_f32hwim_f32hwc_zve32f`**
 - Data layout: Input (HWC), Filter (HWIM), Output (HWC)
-- Vectorize along the channel dimension
 
 ```c
-void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f32_f32_f32_zve32f(
+void skl_depthwise_conv2d_f32hwc_f32hwim_f32hwc_zve32f(
     float *output, const float *input, const float *filter, size_t input_height,
     size_t input_width, size_t input_channel, size_t filter_height,
     size_t filter_width, size_t output_height, size_t output_width,
@@ -191,14 +187,13 @@ void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f32_f32_f32_zve32f(
     size_t output_row_stride, size_t output_col_stride);
 ```
 
-#### **`skl_depthwise_conv2d_vc_f3x3_sn_dn_mn_in_hwc_f32_f32_f32_zve32f`**
+#### **`skl_depthwise_conv2d_f3x3_f32hwc_f32hwim_f32hwc_zve32f`**
 - Specialized RVV implementation
 - Data layout: Input (HWC), Filter (HWIM), Output (HWC)
 - Optimized for 3x3 filters
-- Vectorize along the channel dimension
 
 ```c
-void skl_depthwise_conv2d_vc_f3x3_sn_dn_mn_in_hwc_f32_f32_f32_zve32f(
+void skl_depthwise_conv2d_f3x3_f32hwc_f32hwim_f32hwc_zve32f(
     float *output, const float *input, const float *filter, size_t input_height,
     size_t input_width, size_t input_channel, size_t output_height,
     size_t output_width, size_t output_channel, size_t depth_multiplier,

--- a/src/depthwise_conv2d/README.md
+++ b/src/depthwise_conv2d/README.md
@@ -112,7 +112,7 @@ Here are the pairs of input and filter for channel-wise dot-product:
 Input channel index:  [0, 0, ..., 0]     [1, 1,     ..., 1]         [I - 1, I - 1,                 ..., I - 1]
 Filter channel index: [0, 1, ..., M - 1] [M, M + 1, ..., 2 * M - 1] [I * (M - 1), I * (M - 1) + 1, ..., I * M - 1]
 
-The pairs will be interated through the height and width of filter tensor.
+The pairs will be iterated through the height and width of filter tensor for each output element.
 Following the order of nested loops, we express filter as `hwim` from the outmost loop to the innermost loop.
 ```
 

--- a/src/depthwise_conv2d/README.md
+++ b/src/depthwise_conv2d/README.md
@@ -106,11 +106,15 @@ If any of them is not specified, it indicates any positive integer.
 
 Below is the description of filter layout:
 ```
-Given M = depth multiplier, I = input channel size
-Here are the pairs of input and filter for channel-wise dot-product:
+Given M = depth multiplier > 1, I = input channel size
+In general, filter's channel size is equal to M * input's channel size.
 
-Input channel index:  [0, 0, ..., 0]     [1, 1,     ..., 1]         [I - 1, I - 1,                 ..., I - 1]
-Filter channel index: [0, 1, ..., M - 1] [M, M + 1, ..., 2 * M - 1] [I * (M - 1), I * (M - 1) + 1, ..., I * M - 1]
+Here are the pairs of input and filter for channel-wise dot-product, where input's elements will be repeated M times in each channel group.
+
+Input channel index:  [0, 0, ..., 0]     [1, 1,     ..., 1]         [(I - 1),     (I - 1),         ..., (I - 1)]
+Filter channel index: [0, 1, ..., M - 1] [M, M + 1, ..., 2 * M - 1] [(I - 1) * M, (I - 1) * M + 1, ..., I * M - 1]
+
+In the special case M = 1, filter's channel size is equal to input's channel size.
 
 The pairs will be iterated through the height and width of filter tensor for each output element.
 Following the order of nested loops, we express filter as `hwim` from the outmost loop to the innermost loop.

--- a/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.c
@@ -261,7 +261,7 @@ skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f16_f16_f16_internal_zvfh(
 }
 
 SKL_FUNC
-void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f16_f16_f16_zvfh(
+void skl_depthwise_conv2d_f16hwc_f16hwim_f16hwc_zvfh(
     _Float16 *output, const _Float16 *input, const _Float16 *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t filter_height, size_t filter_width, size_t output_height,
@@ -1209,7 +1209,7 @@ skl_depthwise_conv2d_vc_f3x3_sn_dn_mn_in_hwc_f16_f16_f16_internal_zvfh(
 }
 
 SKL_FUNC
-void skl_depthwise_conv2d_vc_f3x3_sn_dn_mn_in_hwc_f16_f16_f16_zvfh(
+void skl_depthwise_conv2d_f3x3_f16hwc_f16hwim_f16hwc_zvfh(
     _Float16 *output, const _Float16 *input, const _Float16 *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t output_height, size_t output_width, size_t output_channel,

--- a/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_f16_f16_f16_zvfh.h
@@ -67,7 +67,7 @@ extern "C" {
  * float16 depthwise convolution kernels where input and output are in HWC data
  * layout, and vectorizes along the channel dimension.
  */
-void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f16_f16_f16_zvfh(
+void skl_depthwise_conv2d_f16hwc_f16hwim_f16hwc_zvfh(
     _Float16 *output, const _Float16 *input, const _Float16 *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t filter_height, size_t filter_width, size_t output_height,
@@ -111,7 +111,7 @@ void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f16_f16_f16_zvfh(
  *
  * @note Filter dimensions must be exactly 3x3.
  */
-void skl_depthwise_conv2d_vc_f3x3_sn_dn_mn_in_hwc_f16_f16_f16_zvfh(
+void skl_depthwise_conv2d_f3x3_f16hwc_f16hwim_f16hwc_zvfh(
     _Float16 *output, const _Float16 *input, const _Float16 *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t output_height, size_t output_width, size_t output_channel,

--- a/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.c
@@ -260,7 +260,7 @@ skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f32_f32_f32_internal_zve32f(
   }
 }
 
-SKL_FUNC void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f32_f32_f32_zve32f(
+SKL_FUNC void skl_depthwise_conv2d_f32hwc_f32hwim_f32hwc_zve32f(
     float *output, const float *input, const float *filter, size_t input_height,
     size_t input_width, size_t input_channel, size_t filter_height,
     size_t filter_width, size_t output_height, size_t output_width,
@@ -1200,7 +1200,7 @@ skl_depthwise_conv2d_vc_f3x3_sn_dn_mn_in_hwc_f32_f32_f32_internal_zve32f(
   }
 }
 
-SKL_FUNC void skl_depthwise_conv2d_vc_f3x3_sn_dn_mn_in_hwc_f32_f32_f32_zve32f(
+SKL_FUNC void skl_depthwise_conv2d_f3x3_f32hwc_f32hwim_f32hwc_zve32f(
     float *output, const float *input, const float *filter, size_t input_height,
     size_t input_width, size_t input_channel, size_t output_height,
     size_t output_width, size_t output_channel, size_t depth_multiplier,

--- a/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_f32_f32_f32_zve32f.h
@@ -67,7 +67,7 @@ extern "C" {
  * float32 depthwise convolution kernels where input and output are in HWC data
  * layout, and vectorizes along the channel dimension.
  */
-void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f32_f32_f32_zve32f(
+void skl_depthwise_conv2d_f32hwc_f32hwim_f32hwc_zve32f(
     float *output, const float *input, const float *filter, size_t input_height,
     size_t input_width, size_t input_channel, size_t filter_height,
     size_t filter_width, size_t output_height, size_t output_width,
@@ -111,7 +111,7 @@ void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f32_f32_f32_zve32f(
  *
  * @note Filter dimensions must be exactly 3x3.
  */
-void skl_depthwise_conv2d_vc_f3x3_sn_dn_mn_in_hwc_f32_f32_f32_zve32f(
+void skl_depthwise_conv2d_f3x3_f32hwc_f32hwim_f32hwc_zve32f(
     float *output, const float *input, const float *filter, size_t input_height,
     size_t input_width, size_t input_channel, size_t output_height,
     size_t output_width, size_t output_channel, size_t depth_multiplier,

--- a/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.c
+++ b/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.c
@@ -13,7 +13,7 @@
 
 #include "skl-common.h"
 
-SKL_FUNC void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_i8_i8_i32_zve32x(
+SKL_FUNC void skl_depthwise_conv2d_i8hwc_i8hwim_i32hwc_zve32x(
     int32_t *output, const int8_t *input, const int8_t *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t filter_height, size_t filter_width, size_t output_height,
@@ -453,7 +453,7 @@ SKL_FUNC_PRIVATE void skl_depthwise_conv2d_vc_f3x3_apply_input_zp(
   }
 }
 
-SKL_FUNC void skl_depthwise_conv2d_vc_f3x3_sn_dn_m1_in_hwc_i8_i8_i32_zve32x(
+SKL_FUNC void skl_depthwise_conv2d_f3x3m1_i8hwc_i8hwim_i32hwc_zve32x(
     int32_t *output, const int8_t *input, const int8_t *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t output_height, size_t output_width, size_t output_channel,

--- a/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h
+++ b/src/depthwise_conv2d/depthwise_conv2d_i8_i8_i32_zve32x.h
@@ -72,7 +72,7 @@ extern "C" {
  * depthwise convolution kernels with int32 accumulators where input and output
  * are in HWC data layout, and vectorizes along the channel dimension.
  */
-void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_i8_i8_i32_zve32x(
+void skl_depthwise_conv2d_i8hwc_i8hwim_i32hwc_zve32x(
     int32_t *output, const int8_t *input, const int8_t *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t filter_height, size_t filter_width, size_t output_height,
@@ -115,7 +115,7 @@ void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_i8_i8_i32_zve32x(
  *
  * Equivalent to calling the generic function:
  * ```
- * skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_i8_i8_i32_zve32x(
+ * skl_depthwise_conv2d_i8hwc_i8hwim_i32hwc_zve32x(
  *     output, input, filter, input_height, input_width, input_channel,
  *     3, 3, output_height, output_width, output_channel, 1,
  *     stride_height, stride_width, dilation_height_factor,
@@ -127,7 +127,7 @@ void skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_i8_i8_i32_zve32x(
  * @note Filter dimensions must be exactly 3x3.
  * @note Depth multiplier must be exactly 1.
  */
-void skl_depthwise_conv2d_vc_f3x3_sn_dn_m1_in_hwc_i8_i8_i32_zve32x(
+void skl_depthwise_conv2d_f3x3m1_i8hwc_i8hwim_i32hwc_zve32x(
     int32_t *output, const int8_t *input, const int8_t *filter,
     size_t input_height, size_t input_width, size_t input_channel,
     size_t output_height, size_t output_width, size_t output_channel,

--- a/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
@@ -104,7 +104,7 @@ void depthwise_conv2d_f16_f16_f16_verify(skl_test_t *t) {
   }
 
   // Compute the reference result
-  skl_depthwise_conv2d_hwc_f16_f16_f16_ref(
+  skl_depthwise_conv2d_f16hwc_f16hwim_f16hwc_ref(
       h->ctx.ref_output, h->input.data, h->filter.data, h->input_height,
       h->input_width, h->input_channel, h->filter_height, h->filter_width,
       h->output_height, h->output_width, h->output_channel, h->depth_multiplier,

--- a/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
@@ -89,7 +89,7 @@ void depthwise_conv2d_f16_f16_f16_verify(skl_test_t *t) {
 
   // Compute bound = roundoff_scaling * (|input| ⊗ |filter|)
   // where ⊗ denotes depthwise convolution
-  skl_depthwise_conv2d_hwc_f64_f64_f64_ref(
+  skl_depthwise_conv2d_f64hwc_f64hwim_f64hwc_ref(
       h->ctx.bound, h->ctx.input_abs, h->ctx.filter_abs, h->input_height,
       h->input_width, h->input_channel, h->filter_height, h->filter_width,
       h->output_height, h->output_width, h->output_channel, h->depth_multiplier,

--- a/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
@@ -100,7 +100,7 @@ void depthwise_conv2d_f32_f32_f32_verify(skl_test_t *t) {
   }
 
   // Compute the reference result
-  skl_depthwise_conv2d_hwc_f32_f32_f32_ref(
+  skl_depthwise_conv2d_f32hwc_f32hwim_f32hwc_ref(
       h->ctx.ref_output, h->input.data, h->filter.data, h->input_height,
       h->input_width, h->input_channel, h->filter_height, h->filter_width,
       h->output_height, h->output_width, h->output_channel, h->depth_multiplier,

--- a/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
@@ -85,7 +85,7 @@ void depthwise_conv2d_f32_f32_f32_verify(skl_test_t *t) {
 
   // Compute bound = roundoff_scaling * (|input| ⊗ |filter|)
   // where ⊗ denotes depthwise convolution
-  skl_depthwise_conv2d_hwc_f64_f64_f64_ref(
+  skl_depthwise_conv2d_f64hwc_f64hwim_f64hwc_ref(
       h->ctx.bound, h->ctx.input_abs, h->ctx.filter_abs, h->input_height,
       h->input_width, h->input_channel, h->filter_height, h->filter_width,
       h->output_height, h->output_width, h->output_channel, h->depth_multiplier,

--- a/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
@@ -50,7 +50,7 @@ void depthwise_conv2d_i8_i8_i32_verify(skl_test_t *t) {
   int32_t *ref_output = h->ctx.ref_output;
 
   // Compute reference value
-  skl_depthwise_conv2d_hwc_i8_i8_i32_ref(
+  skl_depthwise_conv2d_i8hwc_i8hwim_i32hwc_ref(
       ref_output, input, filter, h->input_height, h->input_width,
       h->input_channel, h->filter_height, h->filter_width, h->output_height,
       h->output_width, h->output_channel, h->depth_multiplier, h->stride_height,

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_f16_f16_f16_zvfh.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_f16_f16_f16_zvfh.c
@@ -226,7 +226,7 @@ static void execute(skl_test_t *t) {
   _Float16 *output = h->output.data;
 
   if (h->use_specialization && h->filter_height == 3 && h->filter_width == 3) {
-    skl_depthwise_conv2d_vc_f3x3_sn_dn_mn_in_hwc_f16_f16_f16_zvfh(
+    skl_depthwise_conv2d_f3x3_f16hwc_f16hwim_f16hwc_zvfh(
         output, input, filter, h->input_height, h->input_width,
         h->input_channel, h->output_height, h->output_width, h->output_channel,
         h->depth_multiplier, h->stride_height, h->stride_width,
@@ -234,7 +234,7 @@ static void execute(skl_test_t *t) {
         h->input_row_stride, h->input_col_stride, h->filter_row_stride,
         h->filter_col_stride, h->output_row_stride, h->output_col_stride);
   } else {
-    skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f16_f16_f16_zvfh(
+    skl_depthwise_conv2d_f16hwc_f16hwim_f16hwc_zvfh(
         output, input, filter, h->input_height, h->input_width,
         h->input_channel, h->filter_height, h->filter_width, h->output_height,
         h->output_width, h->output_channel, h->depth_multiplier,

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_f32_f32_f32_zve32f.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_f32_f32_f32_zve32f.c
@@ -226,7 +226,7 @@ static void execute(skl_test_t *t) {
   float *output = h->output.data;
 
   if (h->use_specialization && h->filter_height == 3 && h->filter_width == 3) {
-    skl_depthwise_conv2d_vc_f3x3_sn_dn_mn_in_hwc_f32_f32_f32_zve32f(
+    skl_depthwise_conv2d_f3x3_f32hwc_f32hwim_f32hwc_zve32f(
         output, input, filter, h->input_height, h->input_width,
         h->input_channel, h->output_height, h->output_width, h->output_channel,
         h->depth_multiplier, h->stride_height, h->stride_width,
@@ -234,7 +234,7 @@ static void execute(skl_test_t *t) {
         h->input_row_stride, h->input_col_stride, h->filter_row_stride,
         h->filter_col_stride, h->output_row_stride, h->output_col_stride);
   } else {
-    skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_f32_f32_f32_zve32f(
+    skl_depthwise_conv2d_f32hwc_f32hwim_f32hwc_zve32f(
         output, input, filter, h->input_height, h->input_width,
         h->input_channel, h->filter_height, h->filter_width, h->output_height,
         h->output_width, h->output_channel, h->depth_multiplier,

--- a/test/depthwise_conv2d/rvv/depthwise_conv2d_i8_i8_i32_zve32x.c
+++ b/test/depthwise_conv2d/rvv/depthwise_conv2d_i8_i8_i32_zve32x.c
@@ -223,7 +223,7 @@ static void execute(skl_test_t *t) {
 
   if (h->use_specialization && h->filter_height == 3 && h->filter_width == 3 &&
       h->depth_multiplier == 1) {
-    skl_depthwise_conv2d_vc_f3x3_sn_dn_m1_in_hwc_i8_i8_i32_zve32x(
+    skl_depthwise_conv2d_f3x3m1_i8hwc_i8hwim_i32hwc_zve32x(
         output, input, filter, h->input_height, h->input_width,
         h->input_channel, h->output_height, h->output_width, h->output_channel,
         h->stride_height, h->stride_width, h->dilation_height_factor,
@@ -231,7 +231,7 @@ static void execute(skl_test_t *t) {
         h->filter_row_stride, h->filter_col_stride, h->output_row_stride,
         h->output_col_stride, h->input_zero_point);
   } else {
-    skl_depthwise_conv2d_vc_fnxn_sn_dn_mn_in_hwc_i8_i8_i32_zve32x(
+    skl_depthwise_conv2d_i8hwc_i8hwim_i32hwc_zve32x(
         output, input, filter, h->input_height, h->input_width,
         h->input_channel, h->filter_height, h->filter_width, h->output_height,
         h->output_width, h->output_channel, h->depth_multiplier,


### PR DESCRIPTION
* Append the layout to the data type, as expressed in gemm and pack APIs.
* Simplify the string of "specialization". Only include the parameters which have contraints.
* Remove the vectorization hint. Making it invisble to the users is more reasonable.