### PR TITLE
[GEMM] Update API specs for proposed change to packed GEMM & packing kernel names

### DIFF
--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -340,7 +340,7 @@ void example_blocked_gemm(size_t m, size_t n, size_t k, const int8_t *a,
         size_t kt = min(k_tile, k - kk_tile);
 
         size_t k0 = 4;
-        size_t k1 = (k0 + 3) / 4;
+        size_t k1 = (kt + 3) / 4;
         uint8_t pad = 0; // Padding value
 
         // Pack and pad B tile:

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -14,9 +14,9 @@ It also describes the packing and unpacking routines that convert matrices betwe
    - [Naming Convention](#naming-convention)
 3. [APIs for Packing & Unpacking Kernels](#apis-for-packing--unpacking-kernels)
 4. [Application to Specific ISAs and Frameworks](#application-to-specific-isas-and-frameworks)
-   - [Xsfvqdotq: Pack B-Matrix K-Dimension (4 x N)](#xsfvqdotq-pack-b-matrix-k-dimension-4xn)
-   - [Xsfmm + IREE Framework: Pack M- & N-Dimensions (TE x TE)](#xsfmm--iree-framework-pack-m---n-dimensions-texte)
-   - [Xsfvqmaccqoq: Packed (M=4)x(K=8)x(N=4) Block-Matrix Products](#xsfvqmaccqoq-packed-m4xk8xn4-block-matrix-products)
+   - [Xsfvqdotq: Pack B-Matrix K-Dimension (4 x N)](#xsfvqdotq-pack-b-matrix-k-dimension-4-x-n)
+   - [Xsfmm + IREE Framework: Pack M- & N-Dimensions (TE x TE)](#xsfmm--iree-framework-pack-m---n-dimensions-te-x-te)
+   - [Xsfvqmaccqoq: Packed (M = 4)x(K = 8)x(N = 4) Block-Matrix Products](#xsfvqmaccqoq-packed-m--4xk--8xn--4-block-matrix-products)
 5. [Cache Tiling with Packing](#cache-tiling-with-packing)
 
 ## Packing and Padding

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -7,7 +7,7 @@ It also describes the packing and unpacking routines that convert matrices betwe
 
 ## Table of Contents
 1. [Packing and Padding](#packing-and-padding)
-   - [Example: Matrix A Packing with Padding](#example-matrix-a-packing-with-padding)
+   - [Example: Matrix Packing with Padding](#example-matrix-packing-with-padding)
    - [Stride Parameters](#stride-parameters)
 2. [APIs for Packed GEMM Kernels](#apis-for-packed-gemm-kernels)
    - [Generic Packed GEMM Semantics (Reference Implementation)](#generic-packed-gemm-semantics-reference-implementation)

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -283,11 +283,11 @@ void skl_gemm_a1b01_i8p4x8_i8p8x4_i32p4x4_xsfvqmaccqoq(
   size_t n1,       // Num. block-columns in B and C
   size_t k1,       // Num. block-columns in A, block-rows in B
   const int8_t* a, // Packed input matrix A [m1 x k1 x (4 x 8)]
-  size_t rsa1,     // Stride between block-rows of packed A
+  size_t rsa1,     // Row stride between blocks of A
   const int8_t* b, // Packed input matrix B [k1 x n1 x (8 x 4)]
-  size_t rsb1,     // Stride between block-rows of packed B
+  size_t rsb1,     // Row stride between blocks of B
   int32_t* c,      // Packed output matrix C [m1 x n1 x (4 x 4)]
-  size_t rsc1,     // Stride between block-rows of packed C
+  size_t rsc1,     // Row stride between blocks of C
   bool accum       // Whether to accumulate into C
 );
 ```

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -166,8 +166,6 @@ When one dimension is not packed, its specifier dimension is set to `1`: `p4x1` 
 For block-row-major layouts (no `c` or `rc` before the `p`), if the last dimension is `1`, then it is followed by `c` to emphasize that elements within the block are in column-major order (although this is only vacuously true); when the first dimension is `1`, then its only difference from a non-packed matrix is that it is padded to a multiple of the block length along the packed dimension.
 For block-column-major, an inverted but analogous logic applies.
 
-The block dimensions are not included in the name, as they are target-specific and implied by the `<isa>` field.
-
 ## APIs for Packing & Unpacking Kernels
 Packing and unpacking must be performed by the user, and is not automatically applied by the GEMM functions for a variety of reasons:
 - The packing may be impossible to perform in-place, requiring a separate buffer that the caller must allocate

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -239,7 +239,7 @@ However, in the case of the dot product dimension, we simply set the SKL GEMM `k
 
 In theory, it should be possible to avoid exposing this packing to the GEMM kernel itself.
 If all matrices were packed into `TE` x `TE` blocks, then the kernel could be called in a loop nest over the packed blocks, applying one `sf.mm` instruction per block.
-However, to obtain peak performance it is often necessary for the kernel to use `2 * TE` x `2 * TE` register tiles, so the strides between blocks must necessarily be exposed to the implementation, motivating the provision of a packed API for this target:
+However, to obtain peak performance it is often necessary for the kernel to use `2*TE` x `2*TE` register tiles, so the strides between blocks must necessarily be exposed to the implementation, motivating the provision of a packed API for this target:
 
 ```c
 void skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f(
@@ -266,16 +266,16 @@ In this case, the packing is performed by the IREE framework itself, and the SKL
 
 ### Xsfvqmaccqoq: Packed (M = 4)x(K = 8)x(N = 4) Block-Matrix Products
 
-The `sf.vqmacc.4x8x4` instruction computes a fat dot product:
+The `sf.vqmacc.4x8x4` instruction computes multiple fat dot products:
 ```
 C[j] += A * B[j], 0 <= j < VL / 32
 ```
 where `A` is a 4 x 8 `int8_t` matrix, each `B[j]` is an 8 x 4 `int8_t` matrix, and each `C[j]` is a 4 x 4 `int32_t` matrix.
 As in the `sf.vqdot.vx`, `VL` is the vector length.
 
-All of the matrices `C[j]` are collectively held in a single vector register group; `C[j]` is stored in row-major order in bytes `[j * 64, (j + 1) * 64)`.
+All of the matrices `C[j]` are collectively held in a single vector register group; `C[j]` is stored in row-major order in bytes `[j*64, (j+1)*64)`.
 `A` is stored in row-major order in a single vector register group.
-Similar to the `C[j]`, all of the matrices `B[j]` are collectively held in a single vector register group, and `B[j]` is stored in row-major order in bytes `[j * 32, (j + 1) * 32)`.
+And similarly to the `C[j]`, all of the matrices `B[j]` are in a single vector register group, with `B[j]` stored in row-major order in bytes `[j*32, (j+1)*32)`.
 
 Thus, the block dimensions must be `m0 = 4`, `n0 = 4`, and `k0 = 8`; the intra-block row strides must be `rsa0 = 8`, `rsb0 = 4`, `rsc0 = 4`; and all three intra-block column strides must be 1.
 Due to this instruction's operand layout, it is also natural to use a block-row-major layout for `B` and `C`.
@@ -363,7 +363,7 @@ void example_blocked_gemm(size_t m, size_t n, size_t k, const int8_t *a,
 
         // Multiply A and B tiles, accumulate into un-tiled C
         skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
-            mt, nt, k1, 1 /* alpha */, a_tile, rsa1, csa1, b_tile, rsb1, csb1,
+            mt, nt, k1, 1 /* alpha */, a_tile, rsa1, csa1, b_tile, rsb1,
             kk_tile ? 1 : 0 /* beta */, c + ii_tile * rsc + jj_tile, rsc);
       }
     }

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -15,7 +15,7 @@ It also describes the packing and unpacking routines that convert matrices betwe
 3. [APIs for Packing & Unpacking Kernels](#apis-for-packing--unpacking-kernels)
 4. [Application to Specific ISAs and Frameworks](#application-to-specific-isas-and-frameworks)
    - [Xsfvqdotq: Pack B-Matrix K-Dimension (4 x N)](#xsfvqdotq-pack-b-matrix-k-dimension-4-x-n)
-   - [Xsfmm + IREE Framework: Pack M- & N-Dimensions (ETE x ETE)](#xsfmm--iree-framework-pack-m---n-dimensions-ete-x-ete)
+   - [Xsfmm + IREE Framework: Pack M- & N-Dimensions (TE x TE)](#xsfmm--iree-framework-pack-m---n-dimensions-te-x-te)
    - [Xsfvqmaccqoq: Packed (M = 4)x(K = 8)x(N = 4) Block-Matrix Products](#xsfvqmaccqoq-packed-m--4xk--8xn--4-block-matrix-products)
 5. [Cache Tiling with Packing](#cache-tiling-with-packing)
 
@@ -218,37 +218,37 @@ void skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
 }
 ```
 
-### Xsfmm + IREE Framework: Pack M- & N-Dimensions (ETE x ETE)
+### Xsfmm + IREE Framework: Pack M- & N-Dimensions (TE x TE)
 
 The SiFive matrix engine (Xsfmm) provides a transposed fat outer-product instruction `sf.mm` to compute:
 ```
 C[i:i+TM, j:j+TN] += A[k:k+TK, i:i+TM]^T * B[k:k+TK, j:j+TN]
 ```
-The types of the matrices may vary, but the output matrix is held in matrix register tiles of size `ETE` x `ETE`, while each of the `TK` rows of each input operand is held in vector register groups of size `ETE`.
-The accumulator dimensions `TM` and `TN` are set by the application, and must be <= `ETE`, the machine tile size.
+The types of the matrices may vary, but the output matrix is held in matrix register tiles of size `TE` x `TE`, while each of the `TK` rows of each input operand is held in vector register groups of size `TE`.
+The accumulator dimensions `TM` and `TN` are set by the application, and must be <= `TE`, the machine tile size.
 The dot product length `TK` is either 1, 2, or 4 depending on the datatype and the application `K` dimension.
 
 __To use the Xsfmm instructions, the `A` matrix must be transposed, but it is not otherwise necessary to pack any matrix into blocks.__
-However, integration with the IREE framework imposes additional requirements that motivate a `ETE` x `ETE` packed layout for this target.
+However, integration with the IREE framework imposes additional requirements that motivate a `TE` x `TE` packed layout for this target.
 
 Since the `A` matrix must be transposed, it is sensible to integrate SKL kernels via the 4D matrix matrix-transpose [MMT4D interface](https://iree.dev/community/blog/2021-10-13-matrix-multiplication-with-mmt4d/) of [the `linalg` dialect](https://iree.dev/community/blog/2021-10-13-matrix-multiplication-with-mmt4d/) (**warning**: the `M` vs `M0` notation in MMT4D is different from the above, and `M` is equivalent to `m1` here).
 The 4D layout of MMT4D requires all three matrices be packed into `M0` x `N0`, `M0` x `K0`, or `K0` x `N0` blocks.
 However, in the case of the dot product dimension, we simply set the SKL GEMM `k0 = 1` and `k1` to MMT4D's `K * K0`, meaning that a single call to the GEMM kernel processes a full _panel_ of the `A`/`B` matrices, covering the full `K` dimension as if it were a single block.
 
 In theory, it should be possible to avoid exposing this packing to the GEMM kernel itself.
-If all matrices were packed into `ETE` x `ETE` blocks, then the kernel could be called in a loop nest over the packed blocks, applying one `sf.mm` instruction per block.
-However, to obtain peak performance it is often necessary for the kernel to use `2*ETE` x `2*ETE` register tiles, so the strides between blocks must necessarily be exposed to the implementation, motivating the provision of a packed API for this target:
+If all matrices were packed into `TE` x `TE` blocks, then the kernel could be called in a loop nest over the packed blocks, applying one `sf.mm` instruction per block.
+However, to obtain peak performance it is often necessary for the kernel to use `2*TE` x `2*TE` register tiles, so the strides between blocks must necessarily be exposed to the implementation, motivating the provision of a packed API for this target:
 
 ```c
-void skl_gemm_a1b01_f32petex1c_f32cp1xete_f32rcpetexete_xsfmm32a32f(
+void skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f(
   size_t m1,       // Num. block-rows in A and C
   size_t n1,       // Num. block-columns in B and C
   size_t k,        // Num. columns in A, rows in B
-  const float* a,  // Packed input matrix A [m1 x k x (ETE x 1)]
+  const float* a,  // Packed input matrix A [m1 x k x (TE x 1)]
   size_t rsa1,     // Row stride between panels of A
-  const float* b,  // Packed input matrix B [k x n1 x (1 x ETE)]
+  const float* b,  // Packed input matrix B [k x n1 x (1 x TE)]
   size_t csb1,     // Column stride between panels of B
-  float* c,        // Packed output matrix C [m1 x n1 x (ETE x ETE)]
+  float* c,        // Packed output matrix C [m1 x n1 x (TE x TE)]
   size_t rsc1,     // Row stride between blocks of C
   size_t csc1,     // Column stride between blocks of C
   bool accum       // Whether to accumulate into C
@@ -256,9 +256,9 @@ void skl_gemm_a1b01_f32petex1c_f32cp1xete_f32rcpetexete_xsfmm32a32f(
 ```
 
 The matrix specifiers should be interpreted as:
-- `A`: `f32petex1c` `ETE` x 1 column vectors of `A` packed in block-row-major order
-- `B`: `f32cp1xete` 1 x `ETE` row vectors of `B` packed in block-column-major order
-- `C`: `f32rcpetexete` `ETE` x `ETE` blocks of `C` packed in either block-row- or block-column-major order, depending on `rsc1` and `csc1`
+- `A`: `f32ptex1c` `TE` x 1 column vectors of `A` packed in block-row-major order
+- `B`: `f32cp1xte` 1 x `TE` row vectors of `B` packed in block-column-major order
+- `C`: `f32rcptexte` `TE` x `TE` blocks of `C` packed in either block-row- or block-column-major order, depending on `rsc1` and `csc1`
 
 In this case, the packing is performed by the IREE framework itself, and the SKL kernel is called directly with the packed matrices; because of the arbitrary inter-block strides of `C`, it is up to the framework how the individual blocks are arranged with respect to one another.
 

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -111,7 +111,7 @@ void skl_gemm_<specialization>_<datatypes>_<isa>_<cpu>(
 
 The general form assumes all three matrices have already been packed and are stored in packed format in memory.
 Usually, all arguments ending in `0` are fixed by the target--and thus omitted from a specific kernel's API--while those ending in `1` are determined by the problem size.
-However, in some cases not every dimension will be packed, in which case the original `m`, `n`, or `k` will be passed (see the [Xsfvqdotq](#xsfvqdotq-pack-b-matrix-k-dimension-4xn) example below).
+However, in some cases not every dimension will be packed, in which case the original `m`, `n`, or `k` will be passed (see the [Xsfvqdotq](#xsfvqdotq-pack-b-matrix-k-dimension-4-x-n) example below).
 
 As in the case of basic GEMM, the various stride parameters suffice to describe arbitrary transpositions (row- and column-major) both of blocks and within them.
 

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -163,7 +163,7 @@ On either side of `p`, transposition specifiers are used as usual:
 - `f32rcp<...>` for a packed matrix in either block-row-major or block-column-major format, but whose blocks are themselves row-major
 
 When one dimension is not packed, its specifier dimension is set to `1`: `p4x1` for instance.
-For block-row-major layouts (no `c` or `rc` before the `p`), if the last dimension is `1`, then it is followed by `c` to emphasize that elements within the block are in column-major order (although this is only vacuously true); when the first dimension is `1`, then its only difference from a non-packed matrix is that the it is padded to a multiple of the block length along the packed dimension.
+For block-row-major layouts (no `c` or `rc` before the `p`), if the last dimension is `1`, then it is followed by `c` to emphasize that elements within the block are in column-major order (although this is only vacuously true); when the first dimension is `1`, then its only difference from a non-packed matrix is that it is padded to a multiple of the block length along the packed dimension.
 For block-column-major, an inverted but analogous logic applies.
 
 The block dimensions are not included in the name, as they are target-specific and implied by the `<isa>` field.
@@ -267,7 +267,7 @@ void skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f(
 The matrix specifiers should be interpreted as:
 - A: `f32ptex1c` TE x 1 column vectors of A packed in block-row-major order
 - B: `f32cp1xte` 1 x TE row vectors of B packed in block-column-major order
-- C; `f32rcptexte` TE x TE blocks of C packed in either block-row- or block-column-major order, depending `rsc1` and `csc1`
+- C: `f32rcptexte` TE x TE blocks of C packed in either block-row- or block-column-major order, depending on `rsc1` and `csc1`
 
 In this case, the packing is performed by the IREE framework itself, and the SKL kernel is called directly with the packed matrices; because of the arbitrary inter-block strides of `C`, it is up to the framework how the individual blocks are arranged with respect to one another.
 
@@ -278,7 +278,7 @@ The `sf.vqmacc.4x8x4` instruction computes a fat dot product:
 C[i:i+4, j:j+4] += A[i:i+4, k:k+8] * B[k:k+8, j:j+4]
 ```
 Where the element types of `A` and `B` are `int8_t` and `C` is accumulated as `int32_t`.
-As in the `sf.vqdot.vx` example, `VL` is the vector length, but here the `C` matrix operands is a 4x4 sub-matrix, while `A` and `B` are 4x8 and 8x4 sub-matrices, respectively.
+As in the `sf.vqdot.vx` example, `VL` is the vector length, but here the `C` matrix operand is a 4x4 sub-matrix, while `A` and `B` are 4x8 and 8x4 sub-matrices, respectively.
 
 In order to make use of this instruction, all matrices must be packed such that `m0=4`, `n0=4`, and `k0=8`.
 Within each block, the `sf.vqmacc.4x8x4` instruction requires a row-major layout, so `rsa0=8`, `rsb0=4`, `rsc0=4`, and all three column strides are `1`.
@@ -296,7 +296,7 @@ void skl_gemm_a1b01_i8p4x8_i8p8x4_i32p4x4_xsfvqmaccqoq(
   const int8_t* b_pack, // Packed matrix B [k1 x n1 x (8 x 4)]
   size_t rsb1,          // Stride between block-rows of packed B
   int32_t* c_pack,      // Packed matrix C [m1 x n1 x (4 x 4)]
-  size_t rsc1           // Stride between block rows of packed C
+  size_t rsc1,          // Stride between block rows of packed C
   bool accum            // Whether to accumulate into C
 );
 ```
@@ -337,7 +337,7 @@ void example_blocked_gemm(size_t m, size_t n, size_t k, const int8_t *a,
         // Pack and compute tile
         skl_pack_b_i8_xsfvqdotq(k0, n0, b + kk_tile * rsb + jj_tile, rsb, b_pack, 4 * n0);
         skl_gemm_a1b01_i8p1x4_i8p4x1c_i32_xsfvqdotq(
-            m0, n0, k0, a + ii_tile * rsa + kk_tile, rsa, b_pack,
+            m0, n0, (k0 + 3) / 4, a + ii_tile * rsa + kk_tile, rsa, b_pack,
             4 * n0, c + ii_tile * rsc + jj_tile, rsc, kk_tile > 0 /* accum */);
       }
     }

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -266,19 +266,16 @@ In this case, the packing is performed by the IREE framework itself, and the SKL
 
 ### Xsfvqmaccqoq: Packed (M = 4)x(K = 8)x(N = 4) Block-Matrix Products
 
-The `sf.vqmacc.4x8x4` instruction computes multiple fat dot products:
+The `sf.vqmacc.4x8x4` instruction computes a fat dot product:
 ```
-C[j] += A * B[j], 0 <= j < VL / 32
+C[i:i+4, j:j+4] += A[i:i+4, k:k+8] * B[k:k+8, j:j+4]
 ```
-where `A` is a 4 x 8 `int8_t` matrix, each `B[j]` is an 8 x 4 `int8_t` matrix, and each `C[j]` is a 4 x 4 `int32_t` matrix.
-As in the `sf.vqdot.vx`, `VL` is the vector length.
+where `A` and `B` are `int8_t` matrices and `C` is an `int32_t` matrix.
+Each of the three operands is held contiguously in row-major order in its own vector register group.
+Packed GEMM kernels using this instruction would have block dimensions `m0 = 4`, `n0 = 4`, and `k0 = 8`; intra-block row strides `rsa0 = 8`, `rsb0 = 4`, `rsc0 = 4`; and all intra-block column strides equal to 1.
 
-All of the matrices `C[j]` are collectively held in a single vector register group; `C[j]` is stored in row-major order in bytes `[j*64, (j+1)*64)`.
-`A` is stored in row-major order in a single vector register group.
-And similarly to the `C[j]`, all of the matrices `B[j]` are in a single vector register group, with `B[j]` stored in row-major order in bytes `[j*32, (j+1)*32)`.
-
-Thus, the block dimensions must be `m0 = 4`, `n0 = 4`, and `k0 = 8`; the intra-block row strides must be `rsa0 = 8`, `rsb0 = 4`, `rsc0 = 4`; and all three intra-block column strides must be 1.
-Due to this instruction's operand layout, it is also natural to use a block-row-major layout for `B` and `C`.
+For a fixed `A`, `sf.vqmacc.4x8x4` can compute multiple such fat dot products at once provided that the `B` blocks are stored together contiguously in a vector register group and likewise for the `C` blocks.
+Because of this, it is natural to use a block-row-major layout for `B` and `C`.
 The specific kernel provided by SKL assumes this layout for `A` as well, so `csa1 = 32`, `csb1 = 32`, and `csc1 = 16`.
 
 The packed kernel's API is thus:

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -22,90 +22,88 @@ It also describes the packing and unpacking routines that convert matrices betwe
 ## Packing and Padding
 
 A _packed_ matrix has one or both dimensions partitioned into fixed-size blocks.
-For example, if we have a matrix `A` of size `m` x `k`, we might need to partition it into blocks of size `m0` x `k0`, where these dimensions are usually determined by the target hardware instruction.
+For example, if we have a matrix of size `m` x `n`, we might need to partition it into blocks of size `m0` x `n0`, where these dimensions are usually determined by the target hardware instruction.
 
 Since the original matrix dimensions might not be exact multiples of the block size, we must pad the matrix so that they are.
 Typically, matrices are padded with zeroes, but other values are possible.
-The resulting packed matrix `A_pack` will consist of `m1` x `k1` blocks, where `m1 = ceil(m/m0)` and `k1 = ceil(k/k0)`, with each block having size `m0` x `k0` elements.
+The resulting packed matrix will consist of `m1` x `n1` blocks, where `m1 = ceil(m/m0)` and `n1 = ceil(n/n0)`, with each block having size `m0` x `n0` elements.
 While it might be possible to construct packed formats that avoid padding, we exclude this possibility from the API for simplicity, as it is unlikely to be useful in practice.
 
-### Example: Matrix A Packing with Padding
+### Example: Matrix Packing with Padding
 
-Consider a 7 x 6 matrix `A` with block size `m0 = 3`, `k0 = 4` (admittedly an unlikely layout, but useful for illustration):
+Consider a 7 x 6 matrix with block size `m0 = 3`, `n0 = 4` (admittedly an unlikely layout, but useful for illustration):
 
 ```
-Original Matrix A (7 x 6):               Conceptual Blocking:
+Original Matrix (7 x 6):               Conceptual Blocking:
 ┌─────────────────────────────────┐    ┌───────────┬───────────┐
-│ a00 a01 a02 a03 a04 a05  0   0  │    │ Block     │ Block     │
-│ a10 a11 a12 a13 a14 a15  0   0  │    │ (0,0)     │ (0,1)     │
-│ a20 a21 a22 a23 a24 a25  0   0  │    │ 3×4       │ 3×2+pad   │
+│ c00 c01 c02 c03 c04 c05  0   0  │    │ Block     │ Block     │
+│ c10 c11 c12 c13 c14 c15  0   0  │    │ (0,0)     │ (0,1)     │
+│ c20 c21 c22 c23 c24 c25  0   0  │    │ 3×4       │ 3×2+pad   │
 │                                 |    ├───────────┼───────────┤
-│ a30 a31 a32 a33 a34 a35  0   0  │    │ Block     │ Block     │
-│ a40 a41 a42 a43 a44 a45  0   0  │    │ (1,0)     │ (1,1)     │
-│ a50 a51 a52 a53 a54 a55  0   0  │    │ 3×4       │ 3×2+pad   │
+│ c30 c31 c32 c33 c34 c35  0   0  │    │ Block     │ Block     │
+│ c40 c41 c42 c43 c44 c45  0   0  │    │ (1,0)     │ (1,1)     │
+│ c50 c51 c52 c53 c54 c55  0   0  │    │ 3×4       │ 3×2+pad   │
 │                                 |    ├───────────┼───────────┤
-│ a60 a61 a62 a63 a64 a65  0   0  │    │ Block     │ Block     │
+│ c60 c61 c62 c63 c64 c65  0   0  │    │ Block     │ Block     │
 │  0   0   0   0   0   0   0   0  │    │ (2,0)     │ (2,1)     │
 │  0   0   0   0   0   0   0   0  │    │1+pad×4    │1+pad×2+pad│
 └─────────────────────────────────┘    └───────────┴───────────┘
         (padded to 9 x 8)                m1 = 3, k1 = 2 blocks
 
 Packed Layout in Memory (row-major blocks):
-Block(0,0): [a00 a01 a02 a03] [a10 a11 a12 a13] [a20 a21 a22 a23]
-Block(0,1): [a04 a05  0   0 ] [a14 a15  0   0 ] [a24 a25  0   0 ]
-Block(1,0): [a30 a31 a32 a33] [a40 a41 a42 a43] [a50 a51 a52 a53]
-Block(1,1): [a34 a35  0   0 ] [a44 a45  0   0 ] [a54 a55  0   0 ]
-Block(2,0): [a60 a61 a62 a63] [ 0   0   0   0 ] [ 0   0   0   0 ]
-Block(2,1): [a64 a65  0   0 ] [ 0   0   0   0 ] [ 0   0   0   0 ]
+Block(0,0): [c00 c01 c02 c03] [c10 c11 c12 c13] [c20 c21 c22 c23]
+Block(0,1): [c04 c05  0   0 ] [c14 c15  0   0 ] [c24 c25  0   0 ]
+Block(1,0): [c30 c31 c32 c33] [c40 c41 c42 c43] [c50 c51 c52 c53]
+Block(1,1): [c34 c35  0   0 ] [c44 c45  0   0 ] [c54 c55  0   0 ]
+Block(2,0): [c60 c61 c62 c63] [ 0   0   0   0 ] [ 0   0   0   0 ]
+Block(2,1): [c64 c65  0   0 ] [ 0   0   0   0 ] [ 0   0   0   0 ]
 ```
 
 #### Stride Parameters
 
-For a matrix `A` with packed storage, the following stride parameters are defined:
-- `rsa0`: row stride within a block, i.e. distance in memory from element `(i, j)` to `(i + 1, j)` in the same block, in units of elements. Example above: `rsa0 = k0 = 4`.
-- `csa0`: column stride within a block, i.e. distance in memory from element `(i, j)` to `(i, j + 1)` in the same block, in units of elements. Example above: `csa0 = 1`.
-- `rsa1`: row stride between blocks, i.e. distance in memory from the start of block `(bi, bj)` to the start of block `(bi + 1, bj)`, in units of elements. Example above: `rsa1 = m0 * k0 * k1 = 24`.
-- `csa1`: column stride between blocks, i.e. distance in memory from the start of block `(bi, bj)` to the start of block `(bi, bj + 1)`, in units of elements. Example above: `csa1 = m0 * k0 = 12`.
+For a matrix `C` with packed storage, the following stride parameters are defined:
+- `rsc0`: row stride within a block, i.e. distance in memory from element `(i, j)` to `(i + 1, j)` in the same block, in units of elements. Example above: `rsc0 = n0 = 4`.
+- `csc0`: column stride within a block, i.e. distance in memory from element `(i, j)` to `(i, j + 1)` in the same block, in units of elements. Example above: `csc0 = 1`.
+- `rsc1`: row stride between blocks, i.e. distance in memory from the start of block `(bi, bj)` to the start of block `(bi + 1, bj)`, in units of elements. Example above: `rsc1 = m0 * n0 * n1 = 24`.
+- `csc1`: column stride between blocks, i.e. distance in memory from the start of block `(bi, bj)` to the start of block `(bi, bj + 1)`, in units of elements. Example above: `csc1 = m0 * n0 = 12`.
 
 Generally the naming scheme for these parameters follows the format `{r,c}s{buffer}{layer}`, where `buffer` is the buffer the parameter applies to and `layer` is the blocking layer the parameter describes.
 
 The memory address (in units of elements) for the element at position `(i, j)` in block `(bi, bj)` is:
 ```
-address = base + bi * rsa1 + bj * csa1 + i * rsa0 + j * csa0
+address = base + bi * rsc1 + bj * csc1 + i * rsc0 + j * csc0
 ```
 
-Thus, the standard row- and column-major layouts are simply special cases of this packed storage, where the block size is 1 x 1 and `csa1` or `rsa1` is 1, respectively.
+Thus, the standard row- and column-major layouts are simply special cases of this packed storage, where the block size is 1 x 1 and `csc1` or `rsc1` is 1, respectively.
 
 ## APIs for Packed GEMM Kernels
 
 The general form of the packed GEMM API is:
 ```c
 void skl_gemm_<specialization>_<datatypes>_<isa>_<cpu>(
-    size_t m0,              // Num. rows in a block of A_pack and C_pack
-    size_t n0,              // Num. columns in a block of B_pack and C_pack
-    size_t k0,              // Num. columns in a block of A_pack,
-                            // rows in a block of B_pack
-    size_t m1,              // Num. block-rows in A_pack and C_pack
-    size_t n1,              // Num. block-columns in B_pack and C_pack
-    size_t k1,              // Num. block-columns in A_pack,
-                            // block-rows in B_pack
-    <type_c> alpha,         // Scaling factor for A_pack * B_pack
-    const <type_a>* a_pack, // Input matrix A_pack
-    size_t rsa0,            // Row stride within a block of A_pack
-    size_t csa0,            // Column stride within a block of A_pack
-    size_t rsa1,            // Row stride between blocks of A_pack
-    size_t csa1,            // Column stride between blocks of A_pack
-    const <type_b>* b_pack, // Input matrix B_pack
-    size_t rsb0,            // Row stride within a block of B_pack
-    size_t csb0,            // Column stride within a block of B_pack
-    size_t rsb1,            // Row stride between blocks of B_pack
-    size_t csb1,            // Column stride between blocks of B_pack
-    <type_c> beta,          // Scaling factor for C_pack
-    <type_c>* c_pack,       // Output matrix C_pack
-    size_t rsc0,            // Row stride within a block of C_pack
-    size_t csc0,            // Column stride within a block of C_pack
-    size_t rsc1,            // Row stride between blocks of C_pack
-    size_t csc1             // Column stride between blocks of C_pack
+    size_t m0,         // Num. rows in a block of A and C
+    size_t n0,         // Num. columns in a block of B and C
+    size_t k0,         // Num. columns in a block of A, rows in a block of B
+    size_t m1,         // Num. block-rows in A and C
+    size_t n1,         // Num. block-columns in B and C
+    size_t k1,         // Num. block-columns in A, block-rows in B
+    <type_c> alpha,    // Scaling factor for A * B
+    const <type_a>* a, // Packed input matrix A
+    size_t rsa0,       // Row stride within a block of A
+    size_t csa0,       // Column stride within a block of A
+    size_t rsa1,       // Row stride between blocks of A
+    size_t csa1,       // Column stride between blocks of A
+    const <type_b>* b, // Packed input matrix B
+    size_t rsb0,       // Row stride within a block of B
+    size_t csb0,       // Column stride within a block of B
+    size_t rsb1,       // Row stride between blocks of B
+    size_t csb1,       // Column stride between blocks of B
+    <type_c> beta,     // Scaling factor for C
+    <type_c>* c,       // Packed output matrix C
+    size_t rsc0,       // Row stride within a block of C
+    size_t csc0,       // Column stride within a block of C
+    size_t rsc1,       // Row stride between blocks of C
+    size_t csc1        // Column stride between blocks of C
 );
 ```
 
@@ -125,8 +123,8 @@ for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t idx = 0; idx < m0 * n0; ++idx)
       acc[idx] = 0;
     for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-      const <type_a>* ap_block = a_pack + ii1 * rsa1 + kk1 * csa1;
-      const <type_b>* bp_block = b_pack + kk1 * rsb1 + jj1 * csb1;
+      const <type_a>* ap_block = a + ii1 * rsa1 + kk1 * csa1;
+      const <type_b>* bp_block = b + kk1 * rsb1 + jj1 * csb1;
       // Compute block product (loops usually map to 1 instruction)
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
@@ -139,7 +137,7 @@ for (size_t ii1 = 0; ii1 < m1; ++ii1) {
       }
     }
     // Update C matrix block (sometimes by specialized stores)
-    <type_c>* c_block = c_pack + ii1 * rsc1 + jj1 * csc1;
+    <type_c>* c_block = c + ii1 * rsc1 + jj1 * csc1;
     for (size_t ii0 = 0; ii0 < m0; ++ii0) {
       for (size_t jj0 = 0; jj0 < n0; ++jj0) {
         size_t c_idx = ii0 * rsc0 + jj0 * csc0;
@@ -196,26 +194,26 @@ As a special case, if `K` is already a multiple of 4, then `A` can be used witho
 The packed kernel could be depicted as implemented by the following wrapper for the general packed GEMM API:
 ```c
 void skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
-  size_t m,             // Num. rows in A_pack and C
-  size_t n,             // Num. columns in B_pack and C
-  size_t k1,            // Num. block-columns in A_pack, block-rows in B_pack
-  int32_t alpha,        // Scaling factor for A_pack * B_pack
-  const int8_t* a_pack, // Packed matrix A_pack [m x k1 x (1 x 4)].
-  size_t rsa1,          // Row stride between blocks of A_pack
-  size_t csa1,          // Column stride between blocks of A_pack
-  const int8_t* b_pack, // Packed matrix B_pack [k1 x n x (4 x 1)]
-  size_t rsb1,          // Row stride between blocks of B_pack
-  int32_t beta,         // Scaling factor for C
-  int32_t* c,           // Output matrix C [m x n]
-  size_t rsc,           // Row stride of C
+  size_t m,        // Num. rows in A and C
+  size_t n,        // Num. columns in B and C
+  size_t k1,       // Num. block-columns in A, block-rows in B
+  int32_t alpha,   // Scaling factor for A * B
+  const int8_t* a, // Packed input matrix A [m x k1 x (1 x 4)].
+  size_t rsa1,     // Row stride between blocks of A
+  size_t csa1,     // Column stride between blocks of A
+  const int8_t* b, // Packed input matrix B [k1 x n x (4 x 1)]
+  size_t rsb1,     // Row stride between blocks of B
+  int32_t beta,    // Scaling factor for C
+  int32_t* c,      // Output matrix C [m x n]
+  size_t rsc,      // Row stride of C
 ) {
   skl_gemm_i8rcprc_i8rcprc_i32rcprc_ref(
-    1, 1, 4, m, n, k1,        // m0, n0, k0, m1, n1, k1
-    alpha,                    // alpha
-    a_pack, 0, 1, rsa1, csa1, // a_pack, rsa0, csa0, rsa1, csa1
-    b_pack, 1, 0, rsb1, 4,    // b_pack, rsb0, csb0, rsb1, csb1
-    beta,                     // beta
-    c, 0, 0, rsc, 1           // c_pack, rsc0, csc0, rsc1, csc1
+    1, 1, 4, m, n, k1,   // m0, n0, k0, m1, n1, k1
+    alpha,               // alpha
+    a, 0, 1, rsa1, csa1, // a, rsa0, csa0, rsa1, csa1
+    b, 1, 0, rsb1, 4,    // b, rsb0, csb0, rsb1, csb1
+    beta,                // beta
+    c, 0, 0, rsc, 1      // c, rsc0, csc0, rsc1, csc1
   );
 }
 ```
@@ -243,17 +241,17 @@ However, to obtain peak performance it is often necessary for the kernel to use 
 
 ```c
 void skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f(
-  size_t m1,            // Num. block-rows in A_pack and C_pack
-  size_t n1,            // Num. block-columns in B_pack and C_pack
-  size_t k,             // Num. columns in A_pack, rows in B_pack
-  const float* a_pack,  // Input matrix A_pack [m1 x k x (TE x 1)]
-  size_t rsa1,          // Row stride between panels of A_pack
-  const float* b_pack,  // Input matrix B_pack [k x n1 x (1 x TE)]
-  size_t csb1,          // Column stride between panels of B_pack
-  float* c_pack,        // Output matrix C_pack [m1 x n1 x (TE x TE)]
-  size_t rsc1,          // Row stride between blocks of C_pack
-  size_t csc1,          // Column stride between blocks of C_pack
-  bool accum            // Whether to accumulate into C_pack
+  size_t m1,       // Num. block-rows in A and C
+  size_t n1,       // Num. block-columns in B and C
+  size_t k,        // Num. columns in A, rows in B
+  const float* a,  // Packed input matrix A [m1 x k x (TE x 1)]
+  size_t rsa1,     // Row stride between panels of A
+  const float* b,  // Packed input matrix B [k x n1 x (1 x TE)]
+  size_t csb1,     // Column stride between panels of B
+  float* c,        // Packed output matrix C [m1 x n1 x (TE x TE)]
+  size_t rsc1,     // Row stride between blocks of C
+  size_t csc1,     // Column stride between blocks of C
+  bool accum       // Whether to accumulate into C
 );
 ```
 
@@ -281,16 +279,16 @@ The specific kernel provided by SKL assumes this layout for `A` as well, so `csa
 The packed kernel's API is thus:
 ```c
 void skl_gemm_a1b01_i8p4x8_i8p8x4_i32p4x4_xsfvqmaccqoq(
-  size_t m1,            // Num. block-rows in A_pack and C_pack
-  size_t n1,            // Num. block-columns in B_pack and C_pack
-  size_t k1,            // Num. block-columns in A_pack, block-rows in B_pack
-  const int8_t* a_pack, // Packed matrix A_pack [m1 x k1 x (4 x 8)]
-  size_t rsa1,          // Stride between block-rows of packed A_pack
-  const int8_t* b_pack, // Packed matrix B_pack [k1 x n1 x (8 x 4)]
-  size_t rsb1,          // Stride between block-rows of packed B_pack
-  int32_t* c_pack,      // Packed matrix C_pack [m1 x n1 x (4 x 4)]
-  size_t rsc1,          // Stride between block-rows of packed C_pack
-  bool accum            // Whether to accumulate into C_pack
+  size_t m1,       // Num. block-rows in A and C
+  size_t n1,       // Num. block-columns in B and C
+  size_t k1,       // Num. block-columns in A, block-rows in B
+  const int8_t* a, // Packed input matrix A [m1 x k1 x (4 x 8)]
+  size_t rsa1,     // Stride between block-rows of packed A
+  const int8_t* b, // Packed input matrix B [k1 x n1 x (8 x 4)]
+  size_t rsb1,     // Stride between block-rows of packed B
+  int32_t* c,      // Packed output matrix C [m1 x n1 x (4 x 4)]
+  size_t rsc1,     // Stride between block-rows of packed C
+  bool accum       // Whether to accumulate into C
 );
 ```
 

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -14,14 +14,14 @@ It also describes the packing and unpacking routines that convert matrices betwe
    - [Naming Convention](#naming-convention)
 3. [APIs for Packing & Unpacking Kernels](#apis-for-packing--unpacking-kernels)
 4. [Application to Specific ISAs and Frameworks](#application-to-specific-isas-and-frameworks)
-   - [Xsfvqdotq: Pack B-Matrix K-Dimension (4xN)](#xsfvqdotq-pack-b-matrix-k-dimension-4xn)
-   - [Xsfmm + IREE Framework: Pack M- & N-Dimensions (TExTE)](#xsfmm--iree-framework-pack-m---n-dimensions-texte)
+   - [Xsfvqdotq: Pack B-Matrix K-Dimension (4 x N)](#xsfvqdotq-pack-b-matrix-k-dimension-4xn)
+   - [Xsfmm + IREE Framework: Pack M- & N-Dimensions (TE x TE)](#xsfmm--iree-framework-pack-m---n-dimensions-texte)
    - [Xsfvqmaccqoq: Packed (M=4)x(K=8)x(N=4) Block-Matrix Products](#xsfvqmaccqoq-packed-m4xk8xn4-block-matrix-products)
 5. [Cache Tiling with Packing](#cache-tiling-with-packing)
 
 ## Packing and Padding
 
-A "packed" matrix has one or both dimensions partitioned into fixed-size blocks.
+A _packed_ matrix has one or both dimensions partitioned into fixed-size blocks.
 For example, if we have a matrix `A` of size `m` x `k`, we might need to partition it into blocks of size `m0` x `k0`, where these dimensions are usually determined by the target hardware instruction.
 
 Since the original matrix dimensions might not be exact multiples of the block size, we must pad the matrix so that they are.
@@ -31,10 +31,10 @@ While it might be possible to construct packed formats that avoid padding, we ex
 
 ### Example: Matrix A Packing with Padding
 
-Consider a 7×6 matrix A with block size `m0=3`, `k0=4` (admittedly an unlikely layout, but useful for illustration):
+Consider a 7 x 6 matrix `A` with block size `m0 = 3`, `k0 = 4` (admittedly an unlikely layout, but useful for illustration):
 
 ```
-Original Matrix A (7×6):               Conceptual Blocking:
+Original Matrix A (7 x 6):               Conceptual Blocking:
 ┌─────────────────────────────────┐    ┌───────────┬───────────┐
 │ a00 a01 a02 a03 a04 a05  0   0  │    │ Block     │ Block     │
 │ a10 a11 a12 a13 a14 a15  0   0  │    │ (0,0)     │ (0,1)     │
@@ -48,7 +48,7 @@ Original Matrix A (7×6):               Conceptual Blocking:
 │  0   0   0   0   0   0   0   0  │    │ (2,0)     │ (2,1)     │
 │  0   0   0   0   0   0   0   0  │    │1+pad×4    │1+pad×2+pad│
 └─────────────────────────────────┘    └───────────┴───────────┘
-        (padded to 9×8)                    m1=3, k1=2 blocks
+        (padded to 9 x 8)                m1 = 3, k1 = 2 blocks
 
 Packed Layout in Memory (row-major blocks):
 Block(0,0): [a00 a01 a02 a03] [a10 a11 a12 a13] [a20 a21 a22 a23]
@@ -61,51 +61,51 @@ Block(2,1): [a64 a65  0   0 ] [ 0   0   0   0 ] [ 0   0   0   0 ]
 
 #### Stride Parameters
 
-For a matrix `A` with packed storage the following stride parameters are defined:
-- `rsa0`: row stride within a block, i.e. distance in memory between rows in the same block, in units of elements. (Example above: `rsa0 = k0 = 4`)
-- `csa0`: column stride within a block, i.e. distance in memory between columns in the same block, in units of elements. (Example above: `csa0 = 1`)
-- `rsa1`: row stride between blocks, i.e. distance in memory from the start of block (bi, bj) to the start of block (bi + 1, bj), in units of elements. (Example above: `rsa1 = m0 * k0 * k1 = 24`)
-- `csa1`: column stride between blocks, i.e. distance in memory from the start of block (bi, bj) to the start of block (bi, bj + 1), in units of elements. (Example above: `csa1 = m0 * k0 = 12`)
+For a matrix `A` with packed storage, the following stride parameters are defined:
+- `rsa0`: row stride within a block, i.e. distance in memory from element `(i, j)` to `(i + 1, j)` in the same block, in units of elements. Example above: `rsa0 = k0 = 4`.
+- `csa0`: column stride within a block, i.e. distance in memory from element `(i, j)` to `(i, j + 1)` in the same block, in units of elements. Example above: `csa0 = 1`.
+- `rsa1`: row stride between blocks, i.e. distance in memory from the start of block `(bi, bj)` to the start of block `(bi + 1, bj)`, in units of elements. Example above: `rsa1 = m0 * k0 * k1 = 24`.
+- `csa1`: column stride between blocks, i.e. distance in memory from the start of block `(bi, bj)` to the start of block `(bi, bj + 1)`, in units of elements. Example above: `csa1 = m0 * k0 = 12`.
 
 Generally the naming scheme for these parameters follows the format `{r,c}s{buffer}{layer}`, where `buffer` is the buffer the parameter applies to and `layer` is the blocking layer the parameter describes.
 
-The memory address (in units of elements) for the element at position (i,j) in block (bi, bj) is:
+The memory address (in units of elements) for the element at position `(i, j)` in block `(bi, bj)` is:
 ```
 address = base + bi * rsa1 + bj * csa1 + i * rsa0 + j * csa0
 ```
 
-Thus, the standard row- and column-major layouts are simply special cases of this packed storage, where the block size is 1x1 and csa1 or rsa1 is 1, respectively.
+Thus, the standard row- and column-major layouts are simply special cases of this packed storage, where the block size is 1 x 1 and `csa1` or `rsa1` is 1, respectively.
 
 ## APIs for Packed GEMM Kernels
 
 The general form of the packed GEMM API is:
 ```c
-void skl_gemm_packed_<specialization>_<datatypes>_<isa>_<cpu>(
-    size_t m0,              // Num. rows in a block of A and C
-    size_t n0,              // Num. columns in a block of B and C
-    size_t k0,              // Num. columns in a block of A,
-                            // rows in a block of B
-    size_t m1,              // Num. block-rows in A and C
-    size_t n1,              // Num. block-columns in B and C
-    size_t k1,              // Num. block-columns in A,
-                            // block-rows in B
-    <type_c> alpha,         // Scaling factor for A*B
-    const <type_a>* a_pack, // Input matrix A
-    size_t rsa0,            // Row stride within a block of A
-    size_t csa0,            // Column stride within a block of A
-    size_t rsa1,            // Row stride between blocks of A
-    size_t csa1,            // Column stride between blocks of A
-    const <type_b>* b_pack, // Input matrix B
-    size_t rsb0,            // Row stride within a block of B
-    size_t csb0,            // Column stride within a block of B
-    size_t rsb1,            // Row stride between blocks of B
-    size_t csb1,            // Column stride between blocks of B
-    <type_c> beta,          // Scaling factor for C
-    <type_c>* c_pack,       // Output matrix C
-    size_t rsc0,            // Row stride within a block of C
-    size_t csc0,            // Column stride within a block of C
-    size_t rsc1,            // Row stride between blocks of C
-    size_t csc1             // Column stride between blocks of C
+void skl_gemm_<specialization>_<datatypes>_<isa>_<cpu>(
+    size_t m0,              // Num. rows in a block of A_pack and C_pack
+    size_t n0,              // Num. columns in a block of B_pack and C_pack
+    size_t k0,              // Num. columns in a block of A_pack,
+                            // rows in a block of B_pack
+    size_t m1,              // Num. block-rows in A_pack and C_pack
+    size_t n1,              // Num. block-columns in B_pack and C_pack
+    size_t k1,              // Num. block-columns in A_pack,
+                            // block-rows in B_pack
+    <type_c> alpha,         // Scaling factor for A_pack * B_pack
+    const <type_a>* a_pack, // Input matrix A_pack
+    size_t rsa0,            // Row stride within a block of A_pack
+    size_t csa0,            // Column stride within a block of A_pack
+    size_t rsa1,            // Row stride between blocks of A_pack
+    size_t csa1,            // Column stride between blocks of A_pack
+    const <type_b>* b_pack, // Input matrix B_pack
+    size_t rsb0,            // Row stride within a block of B_pack
+    size_t csb0,            // Column stride within a block of B_pack
+    size_t rsb1,            // Row stride between blocks of B_pack
+    size_t csb1,            // Column stride between blocks of B_pack
+    <type_c> beta,          // Scaling factor for C_pack
+    <type_c>* c_pack,       // Output matrix C_pack
+    size_t rsc0,            // Row stride within a block of C_pack
+    size_t csc0,            // Column stride within a block of C_pack
+    size_t rsc1,            // Row stride between blocks of C_pack
+    size_t csc1             // Column stride between blocks of C_pack
 );
 ```
 
@@ -124,7 +124,6 @@ for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     <type_c> acc[m0 * n0]; // (Usually a register in practice)
     for (size_t idx = 0; idx < m0 * n0; ++idx)
       acc[idx] = 0;
-    <type_c>* c_block = c_pack + ii1 * rsc1 + jj1 * csc1;
     for (size_t kk1 = 0; kk1 < k1; ++kk1) {
       const <type_a>* ap_block = a_pack + ii1 * rsa1 + kk1 * csa1;
       const <type_b>* bp_block = b_pack + kk1 * rsb1 + jj1 * csb1;
@@ -140,6 +139,7 @@ for (size_t ii1 = 0; ii1 < m1; ++ii1) {
       }
     }
     // Update C matrix block (sometimes by specialized stores)
+    <type_c>* c_block = c_pack + ii1 * rsc1 + jj1 * csc1;
     for (size_t ii0 = 0; ii0 < m0; ++ii0) {
       for (size_t jj0 = 0; jj0 < n0; ++jj0) {
         size_t c_idx = ii0 * rsc0 + jj0 * csc0;
@@ -162,7 +162,7 @@ On either side of `p`, transposition specifiers are used as usual:
 - `f32cp<...>c` for a packed matrix in block-column-major format whose blocks are column-major
 - `f32rcp<...>` for a packed matrix in either block-row-major or block-column-major format, but whose blocks are themselves row-major
 
-When one dimension is not packed, the corresponding block dimension is set to `1`: `p4x1` for instance.
+When one dimension is not packed, the corresponding block dimension is set to 1: `p4x1` for instance.
 
 ## APIs for Packing & Unpacking Kernels
 Packing and unpacking must be performed by the user, and is not automatically applied by the GEMM functions for a variety of reasons:
@@ -177,7 +177,7 @@ For more details, see the [SKL Matrix Packing Kernels](../pack/README.md) docume
 We present three different specializations of the packed GEMM API below, corresponding to different ISAs and frameworks.
 In order, they demonstrate packing of 1, 2, and 3 dimensions, respectively.
 
-### Xsfvqdotq: Pack B-Matrix K-Dimension (4xN)
+### Xsfvqdotq: Pack B-Matrix K-Dimension (4 x N)
 
 The `sf.vqdot.vx` instruction computes a partial dot product:
 ```
@@ -186,25 +186,24 @@ C[i, j:j+VL] += A[i, k:k+4] * B[k:k+4, j:j+VL]
 where `A` and `B` are `int8_t` matrices and `C` is an `int32_t` matrix.
 `VL` is the vector length, `A[i, k:k+4]` is held in a single 32-bit scalar register, and `B[k:k+4, j:j+VL]` is held contiguously in a vector register group in column-major order.
 
-To use this instruction to compute a matrix product, it is therefore natural to pack the `A` matrix into `1x4` blocks; pack the `B` matrix into `4xN` column-major panels, each stored in contiguous memory; and leave `C` in row-major order.
-Thus, only the `K` dimension is packed; it is divided into `k0=4` and `k1=ceil(K/4)`.
-Since the `N` dimension is not packed, we set `n0=1`.
-Similarly, we set `m0=1`.
+To use this instruction to compute a matrix product, it is natural to pack the `A` matrix into 1 x 4 blocks; pack the `B` matrix into 4 x `N` column-major panels, each stored in contiguous memory; and leave `C` in row-major order.
+Thus, only the `K` dimension is packed; it is divided into `k0 = 4` and `k1 = ceil(K/4)`.
+Since the `N` dimension is not packed, we set `n0 = 1`, and similarly, we set `m0 = 1`.
 
-The simplest way to "pack" the `A` matrix is to pad the rows to a multiple of 4.
+Due to its block shape, the simplest way to "pack" the `A` matrix is to just pad the rows to a multiple of 4.
 As a special case, if `K` is already a multiple of 4, then `A` can be used without modification.
 
 The packed kernel could be depicted as implemented by the following wrapper for the general packed GEMM API:
 ```c
-void skl_gemm_a1b01_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
+void skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
   size_t m,             // Num. rows in A_pack and C
   size_t n,             // Num. columns in B_pack and C
-  size_t k1,            // Num. block-columns in A_pack and block-rows in B_pack
+  size_t k1,            // Num. block-columns in A_pack, block-rows in B_pack
   int32_t alpha,        // Scaling factor for A_pack * B_pack
-  const int8_t* a_pack, // Packed matrix A_pack [m x ceil(k/4) x (1 x 4)].
+  const int8_t* a_pack, // Packed matrix A_pack [m x k1 x (1 x 4)].
   size_t rsa1,          // Row stride between blocks of A_pack
   size_t csa1,          // Column stride between blocks of A_pack
-  const int8_t* b_pack, // Packed matrix B_pack [ceil(k/4) x n x (4 x 1)]
+  const int8_t* b_pack, // Packed matrix B_pack [k1 x n x (4 x 1)]
   size_t rsb1,          // Row stride between blocks of B_pack
   int32_t beta,         // Scaling factor for C
   int32_t* c,           // Output matrix C [m x n]
@@ -221,26 +220,26 @@ void skl_gemm_a1b01_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
 }
 ```
 
-### Xsfmm + IREE Framework: Pack M- & N-Dimensions (TExTE)
+### Xsfmm + IREE Framework: Pack M- & N-Dimensions (TE x TE)
 
 The SiFive matrix engine (Xsfmm) provides a transposed fat outer-product instruction `sf.mm` to compute:
 ```
 C[i:i+TM, j:j+TN] += A[k:k+TK, i:i+TM]^T * B[k:k+TK, j:j+TN]
 ```
-The types of the matrices may vary, but the output matrix is held in matrix register tiles of size `TE` x `TE`, while each of the `TK` rows of the input operands are held in vector register groups of size `TE`.
+The types of the matrices may vary, but the output matrix is held in matrix register tiles of size `TE` x `TE`, while each of the `TK` rows of each input operand is held in vector register groups of size `TE`.
 The accumulator dimensions `TM` and `TN` are set by the application, and must be <= `TE`, the machine tile size.
 The dot product length `TK` is either 1, 2, or 4 depending on the datatype and the application `K` dimension.
 
 __To use the Xsfmm instructions, the `A` matrix must be transposed, but it is not otherwise necessary to pack any matrix into blocks.__
-However, integration with the IREE framework imposes additional requirements that motivate a `TExTE` packed layout for this target.
+However, integration with the IREE framework imposes additional requirements that motivate a `TE` x `TE` packed layout for this target.
 
-Since the A matrix must be transposed, it is sensible to integrate SKL kernels via the 4D matrix matrix-transpose [MMT4D interface](https://iree.dev/community/blog/2021-10-13-matrix-multiplication-with-mmt4d/) of [the `linalg` dialect](https://iree.dev/community/blog/2021-10-13-matrix-multiplication-with-mmt4d/) (**warning**: the `M` vs `M0` notation in MMT4D is different from the above, and `M` is equivalent to `m1` here).
+Since the `A` matrix must be transposed, it is sensible to integrate SKL kernels via the 4D matrix matrix-transpose [MMT4D interface](https://iree.dev/community/blog/2021-10-13-matrix-multiplication-with-mmt4d/) of [the `linalg` dialect](https://iree.dev/community/blog/2021-10-13-matrix-multiplication-with-mmt4d/) (**warning**: the `M` vs `M0` notation in MMT4D is different from the above, and `M` is equivalent to `m1` here).
 The 4D layout of MMT4D requires all three matrices be packed into `M0` x `N0`, `M0` x `K0`, or `K0` x `N0` blocks.
-However, in the case of the dot product dimension, we simply set the SKL GEMM `k0=1` and `k1` to MMT4D's `K * K0`, meaning that a single call to the GEMM kernel processes a full _panel_ of the A/B matrices, covering the full `K` dimension as if it were a single block.
+However, in the case of the dot product dimension, we simply set the SKL GEMM `k0 = 1` and `k1` to MMT4D's `K * K0`, meaning that a single call to the GEMM kernel processes a full _panel_ of the `A`/`B` matrices, covering the full `K` dimension as if it were a single block.
 
 In theory, it should be possible to avoid exposing this packing to the GEMM kernel itself.
 If all matrices were packed into `TE` x `TE` blocks, then the kernel could be called in a loop nest over the packed blocks, applying one `sf.mm` instruction per block.
-However, to obtain peak performance it is often necessary for the kernel to use `2*TE` x `2*TE` register tiles, so the strides between blocks must necessarily be exposed to the implementation, motivating the provision of a packed API for this target:
+However, to obtain peak performance it is often necessary for the kernel to use `2 * TE` x `2 * TE` register tiles, so the strides between blocks must necessarily be exposed to the implementation, motivating the provision of a packed API for this target:
 
 ```c
 void skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f(
@@ -259,24 +258,28 @@ void skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f(
 ```
 
 The matrix specifiers should be interpreted as:
-- `A`: `f32ptex1c` TE x 1 column vectors of `A` packed in block-row-major order
-- `B`: `f32cp1xte` 1 x TE row vectors of `B` packed in block-column-major order
-- `C`: `f32rcptexte` TE x TE blocks of `C` packed in either block-row- or block-column-major order, depending on `rsc1` and `csc1`
+- `A`: `f32ptex1c` `TE` x 1 column vectors of `A` packed in block-row-major order
+- `B`: `f32cp1xte` 1 x `TE` row vectors of `B` packed in block-column-major order
+- `C`: `f32rcptexte` `TE` x `TE` blocks of `C` packed in either block-row- or block-column-major order, depending on `rsc1` and `csc1`
 
 In this case, the packing is performed by the IREE framework itself, and the SKL kernel is called directly with the packed matrices; because of the arbitrary inter-block strides of `C`, it is up to the framework how the individual blocks are arranged with respect to one another.
 
-### Xsfvqmaccqoq: Packed (M=4)x(K=8)x(N=4) Block-Matrix Products
+### Xsfvqmaccqoq: Packed (M = 4)x(K = 8)x(N = 4) Block-Matrix Products
 
 The `sf.vqmacc.4x8x4` instruction computes a fat dot product:
 ```
-C[i:i+4, j:j+4] += A[i:i+4, k:k+8] * B[k:k+8, j:j+4]
+C[j] += A * B[j], 0 <= j < VL / 32
 ```
-where `A` and `B` are `int8_t` matrices and `C` is an `int32_t` matrix.
-As in the `sf.vqdot.vx` example, `VL` is the vector length, but here the `C` matrix operand is a 4x4 sub-matrix, while `A` and `B` are 4x8 and 8x4 sub-matrices, respectively.
-Each of the three operands is held contiguously in a vector register group in row-major order.
-Thus, the block dimensions must be `m0=4`, `n0=4`, and `k0=8`; the intra-block row strides must be `rsa0=8`, `rsb0=4`, `rsc0=4`; and all three intra-block column strides must be `1`.
+where `A` is a 4 x 8 `int8_t` matrix, each `B[j]` is an 8 x 4 `int8_t` matrix, and each `C[j]` is a 4 x 4 `int32_t` matrix.
+As in the `sf.vqdot.vx`, `VL` is the vector length.
 
-The specific kernel provided by SKL also assumes a block-row-major layout for the packed matrices, meaning that `csa1=32`, `csb1=32`, and `csc1=16`.
+All of the matrices `C[j]` are collectively held in a single vector register group; `C[j]` is stored in row-major order in bytes `[j * 64, (j + 1) * 64)`.
+`A` is stored in row-major order in a single vector register group.
+Similar to the `C[j]`, all of the matrices `B[j]` are collectively held in a single vector register group, and `B[j]` is stored in row-major order in bytes `[j * 32, (j + 1) * 32)`.
+
+Thus, the block dimensions must be `m0 = 4`, `n0 = 4`, and `k0 = 8`; the intra-block row strides must be `rsa0 = 8`, `rsb0 = 4`, `rsc0 = 4`; and all three intra-block column strides must be 1.
+Due to this instruction's operand layout, it is also natural to use a block-row-major layout for `B` and `C`.
+The specific kernel provided by SKL assumes this layout for `A` as well, so `csa1 = 32`, `csb1 = 32`, and `csc1 = 16`.
 
 The packed kernel's API is thus:
 ```c

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -48,7 +48,7 @@ Original Matrix (7 x 6):               Conceptual Blocking:
 │  0   0   0   0   0   0   0   0  │    │ (2,0)     │ (2,1)     │
 │  0   0   0   0   0   0   0   0  │    │1+pad×4    │1+pad×2+pad│
 └─────────────────────────────────┘    └───────────┴───────────┘
-        (padded to 9 x 8)                m1 = 3, k1 = 2 blocks
+        (padded to 9 x 8)                m1 = 3, n1 = 2 blocks
 
 Packed Layout in Memory (row-major blocks):
 Block(0,0): [c00 c01 c02 c03] [c10 c11 c12 c13] [c20 c21 c22 c23]

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -154,12 +154,17 @@ However, in practice, these innermost loops (`ii0`, `jj0`, and `kk0`) correspond
 
 ### Naming Convention
 The naming convention for packed GEMM APIs is similar to that of the basic GEMM APIs, but uses the `<datatypes>` field to indicate packing.
-Specifically, a `p` is inserted after each matrix type to indicate that it is packed.
+Specifically, a `p<m0xn0>` specifier is inserted after each matrix type to indicate that it is packed in blocks of size `m0` by `n0` (or `k0` and `n0` etc.).
 
 On either side of `p`, transposition specifiers are used as usual:
-- `f32p` for a packed, row-major matrix
-- `f32pc` for a packed matrix with blocks in column-major format
-- `f32cpc` for a packed matrix with blocks in column-major format and columns of blocks in column-major format
+- `f32p<...>` for a packed, row-major matrix
+- `f32p<...>c` for a packed matrix with blocks in column-major format
+- `f32cp<...>c` for a packed matrix with blocks in column-major format and columns of blocks in column-major format
+- `f32rcp<...>` for a packed matrix in either block-row-major or block-column-major format, but whose blocks are themselves row-major
+
+When one dimension is not packed, its specifier dimension is set to `1`: `p4x1` for instance.
+For block-row-major layouts (no `c` or `rc` before the `p`), if the last dimension is `1`, then it is followed by `c` to emphasize that elements within the block are in column-major order (although this is only vacuously true); when the first dimension is `1`, then its only difference from a non-packed matrix is that the it is padded to a multiple of the block length along the packed dimension.
+For block-column-major, an inverted but analogous logic applies.
 
 The block dimensions are not included in the name, as they are target-specific and implied by the `<isa>` field.
 
@@ -194,13 +199,16 @@ Each column of the `4xN` blocks of B can be thought of as one of these `4x1` blo
 And since each `4xN` block of B is column-major and stored contiguously in memory, we find that `rsb0=1` and `csb1=k0*n0`.
 Note that `csb0` is unused since each `4x1` block has only one column.
 
+In the A matrix, the "packed" dimension in `p1x4` simply indicates that the row length has been _padded_ to a multiple of 4.
+Ideally, if the original `k` was a multiple of 4 or the A matrix was already padded, it can be used without modification.
+
 The packed kernel could be depicted as implemented by the following wrapper for the general packed GEMM API:
 ```c
-void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(
+void skl_gemm_a1b01_i8p1x4_i8p4x1c_i32_xsfvqdotq(
   size_t m,             // Num. rows in A and C
   size_t n,             // Num. columns in B and C
-  size_t k,             // Num. columns in A and rows in B
-  const int8_t* a,      // Input matrix A [m x k]
+  size_t k1,            // Num. 1x4 k blocks in A and 4x1 blocks in B
+  const int8_t* a_pack, // Padded  matrix A [m x ceil(k/4) x 4].
   size_t rsa,           // Row stride of A
   const int8_t* b_pack, // Packed matrix B [ceil(k/4) x n x (4 x 1)]
   size_t rsb1,          // Row stride between blocks of B
@@ -208,36 +216,16 @@ void skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(
   size_t rsc,           // Row stride of C
   bool accum            // Whether to accumulate into C
 ) {
-  // NOTE: in the real implementation, the optimized kernel handles all the
-  // K-fringe elements; this is just for illustration
-  size_t k1 = k / 4;
-  size_t kfix = k % 4;
   skl_gemm_i8rcprc_i8rcprc_i32rcprc_ref(
     1, 1, 4, m, n, k1,      // m0, n0, k0, m1, n1, k1
     1,                      // alpha
-    a, 0, 1, rsa, 4,        // a_pack, rsa0, csa0, rsa1, csa1
+    a_pack, 0, 1, rsa, 4,   // a_pack, rsa0, csa0, rsa1, csa1
     b_pack, 1, 0, rsb1, 4,  // b_pack, rsb0, csb0, rsb1, csb1
     accum ? 1 : 0,          // beta
     c, 0, 0, rsc, 1         // c_pack, rsc0, csc0, rsc1, csc1
   );
-  if (kfix != 0) {
-    // Handle the dot-product fringe manually
-    for (size_t ii = 0; ii < m; ++ii) {
-      for (size_t jj = 0; jj < n; ++jj) {
-        int32_t acc = 0;
-        size_t kstart = k1 * 4;
-        for (size_t kk = kstart; kk < k; ++kk) {
-          acc += a[ii * rsa + kk] * b_pack[k1 * rsb1 + jj * 4 + (kk % 4)];
-        }
-        c[ii * rsc + jj] += acc;
-      }
-    }
-  }
 }
 ```
-
-Note that the `k` dimension provided is the original value, not its padded multiple of 4.
-This allows only the `B` matrix to be packed, while `A` and `C` remain in their original format, as the specialized kernel simply substitutes `0` for any elements of `A` that lie beyond the original `k` boundary.
 
 ### Xsfmm + IREE Framework: Pack M- & N-Dimensions (TExTE)
 
@@ -261,7 +249,7 @@ If all matrices were packed into `TE` x `TE` blocks, then the kernel could be ca
 However, to obtain peak performance it is often necessary for the kernel to use `2*TE` x `2*TE` register tiles, so the strides between blocks must necessarily be exposed to the implementation, motivating the provision of a packed API for this target:
 
 ```c
-void skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f(
+void skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f(
   size_t m1,            // Num. row blocks in A and C
   size_t n1,            // Num. column blocks in B and C
   size_t k,             // Num. columns in A, rows in B
@@ -275,6 +263,11 @@ void skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f(
   bool accum            // Whether to accumulate into C
 );
 ```
+
+The matrix specifiers should be interpreted as:
+- A: `f32ptex1c` TE x 1 column vectors of A packed in block-row-major order
+- B: `f32cp1xte` 1 x TE row vectors of B packed in block-column-major order
+- C; `f32rcptexte` TE x TE blocks of C packed in either block-row- or block-column-major order, depending `rsc1` and `csc1`
 
 In this case, the packing is performed by the IREE framework itself, and the SKL kernel is called directly with the packed matrices; because of the arbitrary inter-block strides of `C`, it is up to the framework how the individual blocks are arranged with respect to one another.
 
@@ -294,16 +287,22 @@ The specific kernel provided by SKL also assumes a block-row-major layout for th
 
 The packed kernel's API is thus:
 ```c
-void skl_gemm_a1b01_i8p_i8p_i32p_xsfvqmaccqoq(
+void skl_gemm_a1b01_i8p4x8_i8p8x4_i32p4x4_xsfvqmaccqoq(
   size_t m1,            // Num. row blocks in A and C
   size_t n1,            // Num. column blocks in B and C
   size_t k1,            // Num. column blocks in A, row blocks in B
   const int8_t* a_pack, // Packed matrix A [m1 x k1 x (4 x 8)]
+  size_t rsa1,          // Stride between block-rows of packed A
   const int8_t* b_pack, // Packed matrix B [k1 x n1 x (8 x 4)]
+  size_t rsb1,          // Stride between block-rows of packed B
   int32_t* c_pack,      // Packed matrix C [m1 x n1 x (4 x 4)]
+  size_t rsc1           // Stride between block rows of packed C
   bool accum            // Whether to accumulate into C
 );
 ```
+
+The block row strides `rs{a,b,c}1` allow this kernel to perform a partial multiplication on some portion of a larger problem size.
+
 ## Cache Tiling with Packing
 
 It may sometimes be desirable to combine explicit cache blocking with packing.
@@ -337,7 +336,7 @@ void example_blocked_gemm(size_t m, size_t n, size_t k, const int8_t *a,
         size_t k0 = min(k_tile, k - kk_tile);
         // Pack and compute tile
         skl_pack_b_i8_xsfvqdotq(k0, n0, b + kk_tile * rsb + jj_tile, rsb, b_pack, 4 * n0);
-        skl_gemm_a1b01_i8_i8pc_i32_xsfvqdotq(
+        skl_gemm_a1b01_i8p1x4_i8p4x1c_i32_xsfvqdotq(
             m0, n0, k0, a + ii_tile * rsa + kk_tile, rsa, b_pack,
             4 * n0, c + ii_tile * rsc + jj_tile, rsc, kk_tile > 0 /* accum */);
       }

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -1,6 +1,6 @@
 # SKL Packed GEMM kernels
 The general matrix multiplication (GEMM) kernels in SKL sometimes constrain the memory layout of the input matrices by requiring particular transpositions (as described in the [SKL GEMM README](README.md)).
-In some cases, the use of specialized instructions or integration into certain software frameworks requires more complex memory layouts, where fixed-size 2-D sub-matrices--blocks--of each matrix are packed into contiguous memory.
+In some cases, the use of specialized instructions or integration into certain software frameworks requires more complex memory layouts, where fixed-size 2D sub-matrices--blocks--of each matrix are packed into contiguous memory.
 
 This document describes a generic API for such kernels, and how it is specialized for each target.
 It also describes the packing and unpacking routines that convert matrices between row-major layout and the packed formats.
@@ -24,7 +24,8 @@ It also describes the packing and unpacking routines that convert matrices betwe
 A "packed" matrix has one or both dimensions partitioned into fixed-size blocks.
 For example, if we have a matrix `A` of size `m` x `k`, we might need to partition it into blocks of size `m0` x `k0`, where these dimensions are usually determined by the target hardware instruction.
 
-Since the original matrix dimensions might not be exact multiples of the block size, we must pad the matrix with zeros to make the dimensions match.
+Since the original matrix dimensions might not be exact multiples of the block size, we must pad the matrix so that they are.
+Typically, matrices are padded with zeroes, but other values are possible.
 The resulting packed matrix `A_pack` will consist of `m1` x `k1` blocks, where `m1 = ceil(m/m0)` and `k1 = ceil(k/k0)`, with each block having size `m0` x `k0` elements.
 (While it might be possible to construct packed formats that avoid padding, we exclude this possibility from the API for simplicity, as it is unlikely to be useful in practice.)
 
@@ -62,19 +63,19 @@ Block(2,1): [a64 a65  0   0 ] [ 0   0   0   0 ] [ 0   0   0   0 ]
 #### Stride Relationships
 
 For a matrix `A` with packed storage the following stride parameters are defined:
-- `rsa0`: row stride within a block: distance in memory between rows in the same block, in units of elements. (Example above: `rsa0 = k0 = 4`)
-- `csa0`: column stride within a block: distance in memory between columns in the same block, in units of elements. (Example above: `csa0 = 1`)
-- `rsa1`: row stride between blocks: distance in memory between the start of consecutive blocks in the same block column, in units of elements. (Example above: `rsa1 = m0 * k0 * k1 = 24`)
-- `csa1`: column stride between blocks: distance in memory between the start of consecutive blocks in the same block row, in units of elements. (Example above: `csa1 = m0 * k0 = 12`)
+- `rsa0`: row stride within a block, i.e. distance in memory between rows in the same block, in units of elements. (Example above: `rsa0 = k0 = 4`)
+- `csa0`: column stride within a block, i.e. distance in memory between columns in the same block, in units of elements. (Example above: `csa0 = 1`)
+- `rsa1`: row stride between blocks, i.e. distance in memory between the start of block (bi, bj) and the start of block (bi + 1, bj), in units of elements. (Example above: `rsa1 = m0 * k0 * k1 = 24`)
+- `csa1`: column stride between blocks, i.e. distance in memory between the start of block (bi, bj) and the start of block (bi, bj + 1), in units of elements. (Example above: `csa1 = m0 * k0 = 12`)
 
 Generally the naming scheme for these parameters follows the format `{r,c}s{buffer}{layer}`, where `buffer` is the buffer the parameter applies to and `layer` is the blocking layer the parameter describes.
 
-The memory address (in units of elements) for element at block (bi, bj), position (i, j) is:
+The memory address (in units of elements) for the element at position (i,j) in block (bi, bj) is:
 ```
 address = base + bi * rsa1 + bj * csa1 + i * rsa0 + j * csa0
 ```
 
-Thus, the standard row- and column-major layouts are simply special cases of this packed storage, where the block size is 1x1 and inter-block strides are 1.
+Thus, the standard row- and column-major layouts are simply special cases of this packed storage, where the block size is 1x1 and csa1 or rsa1 is 1, respectively.
 
 ## APIs for Packed GEMM Kernels
 
@@ -85,10 +86,10 @@ void skl_gemm_packed_<specialization>_<datatypes>_<isa>_<cpu>(
     size_t n0,              // Num. columns in a block of B and C
     size_t k0,              // Num. columns in a block of A,
                             // rows in a block of B
-    size_t m1,              // Num. row blocks in A and C
-    size_t n1,              // Num. column blocks in B and C
-    size_t k1,              // Num. column blocks in A,
-                            // row blocks in B
+    size_t m1,              // Num. block-rows in A and C
+    size_t n1,              // Num. block-columns in B and C
+    size_t k1,              // Num. block-columns in A,
+                            // block-rows in B
     <type_c> alpha,         // Scaling factor for A*B
     const <type_a>* a_pack, // Input matrix A
     size_t rsa0,            // Row stride within a block of A
@@ -157,14 +158,12 @@ The naming convention for packed GEMM APIs is similar to that of the basic GEMM 
 Specifically, a `p<m0xn0>` specifier is inserted after each matrix type to indicate that it is packed in blocks of size `m0` by `n0` (or `k0` and `n0` etc.).
 
 On either side of `p`, transposition specifiers are used as usual:
-- `f32p<...>` for a packed, row-major matrix
-- `f32p<...>c` for a packed matrix with blocks in column-major format
-- `f32cp<...>c` for a packed matrix with blocks in column-major format and columns of blocks in column-major format
+- `f32p<...>` for a packed matrix in block-row-major format whose blocks are row-major
+- `f32p<...>c` for a packed matrix in block-rowm-major format whose blocks are column-major
+- `f32cp<...>c` for a packed matrix in block-column-major format whose blocks are column-major
 - `f32rcp<...>` for a packed matrix in either block-row-major or block-column-major format, but whose blocks are themselves row-major
 
-When one dimension is not packed, its specifier dimension is set to `1`: `p4x1` for instance.
-For block-row-major layouts (no `c` or `rc` before the `p`), if the last dimension is `1`, then it is followed by `c` to emphasize that elements within the block are in column-major order (although this is only vacuously true); when the first dimension is `1`, then its only difference from a non-packed matrix is that it is padded to a multiple of the block length along the packed dimension.
-For block-column-major, an inverted but analogous logic applies.
+When one dimension is not packed, the corresponding block dimension is set to `1`: `p4x1` for instance.
 
 ## APIs for Packing & Unpacking Kernels
 Packing and unpacking must be performed by the user, and is not automatically applied by the GEMM functions for a variety of reasons:

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -15,7 +15,7 @@ It also describes the packing and unpacking routines that convert matrices betwe
 3. [APIs for Packing & Unpacking Kernels](#apis-for-packing--unpacking-kernels)
 4. [Application to Specific ISAs and Frameworks](#application-to-specific-isas-and-frameworks)
    - [Xsfvqdotq: Pack B-Matrix K-Dimension (4 x N)](#xsfvqdotq-pack-b-matrix-k-dimension-4-x-n)
-   - [Xsfmm + IREE Framework: Pack M- & N-Dimensions (TE x TE)](#xsfmm--iree-framework-pack-m---n-dimensions-te-x-te)
+   - [Xsfmm + IREE Framework: Pack M- & N-Dimensions (ETE x ETE)](#xsfmm--iree-framework-pack-m---n-dimensions-ete-x-ete)
    - [Xsfvqmaccqoq: Packed (M = 4)x(K = 8)x(N = 4) Block-Matrix Products](#xsfvqmaccqoq-packed-m--4xk--8xn--4-block-matrix-products)
 5. [Cache Tiling with Packing](#cache-tiling-with-packing)
 
@@ -218,37 +218,37 @@ void skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
 }
 ```
 
-### Xsfmm + IREE Framework: Pack M- & N-Dimensions (TE x TE)
+### Xsfmm + IREE Framework: Pack M- & N-Dimensions (ETE x ETE)
 
 The SiFive matrix engine (Xsfmm) provides a transposed fat outer-product instruction `sf.mm` to compute:
 ```
 C[i:i+TM, j:j+TN] += A[k:k+TK, i:i+TM]^T * B[k:k+TK, j:j+TN]
 ```
-The types of the matrices may vary, but the output matrix is held in matrix register tiles of size `TE` x `TE`, while each of the `TK` rows of each input operand is held in vector register groups of size `TE`.
-The accumulator dimensions `TM` and `TN` are set by the application, and must be <= `TE`, the machine tile size.
+The types of the matrices may vary, but the output matrix is held in matrix register tiles of size `ETE` x `ETE`, while each of the `TK` rows of each input operand is held in vector register groups of size `ETE`.
+The accumulator dimensions `TM` and `TN` are set by the application, and must be <= `ETE`, the machine tile size.
 The dot product length `TK` is either 1, 2, or 4 depending on the datatype and the application `K` dimension.
 
 __To use the Xsfmm instructions, the `A` matrix must be transposed, but it is not otherwise necessary to pack any matrix into blocks.__
-However, integration with the IREE framework imposes additional requirements that motivate a `TE` x `TE` packed layout for this target.
+However, integration with the IREE framework imposes additional requirements that motivate a `ETE` x `ETE` packed layout for this target.
 
 Since the `A` matrix must be transposed, it is sensible to integrate SKL kernels via the 4D matrix matrix-transpose [MMT4D interface](https://iree.dev/community/blog/2021-10-13-matrix-multiplication-with-mmt4d/) of [the `linalg` dialect](https://iree.dev/community/blog/2021-10-13-matrix-multiplication-with-mmt4d/) (**warning**: the `M` vs `M0` notation in MMT4D is different from the above, and `M` is equivalent to `m1` here).
 The 4D layout of MMT4D requires all three matrices be packed into `M0` x `N0`, `M0` x `K0`, or `K0` x `N0` blocks.
 However, in the case of the dot product dimension, we simply set the SKL GEMM `k0 = 1` and `k1` to MMT4D's `K * K0`, meaning that a single call to the GEMM kernel processes a full _panel_ of the `A`/`B` matrices, covering the full `K` dimension as if it were a single block.
 
 In theory, it should be possible to avoid exposing this packing to the GEMM kernel itself.
-If all matrices were packed into `TE` x `TE` blocks, then the kernel could be called in a loop nest over the packed blocks, applying one `sf.mm` instruction per block.
-However, to obtain peak performance it is often necessary for the kernel to use `2*TE` x `2*TE` register tiles, so the strides between blocks must necessarily be exposed to the implementation, motivating the provision of a packed API for this target:
+If all matrices were packed into `ETE` x `ETE` blocks, then the kernel could be called in a loop nest over the packed blocks, applying one `sf.mm` instruction per block.
+However, to obtain peak performance it is often necessary for the kernel to use `2*ETE` x `2*ETE` register tiles, so the strides between blocks must necessarily be exposed to the implementation, motivating the provision of a packed API for this target:
 
 ```c
-void skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f(
+void skl_gemm_a1b01_f32petex1c_f32cp1xete_f32rcpetexete_xsfmm32a32f(
   size_t m1,       // Num. block-rows in A and C
   size_t n1,       // Num. block-columns in B and C
   size_t k,        // Num. columns in A, rows in B
-  const float* a,  // Packed input matrix A [m1 x k x (TE x 1)]
+  const float* a,  // Packed input matrix A [m1 x k x (ETE x 1)]
   size_t rsa1,     // Row stride between panels of A
-  const float* b,  // Packed input matrix B [k x n1 x (1 x TE)]
+  const float* b,  // Packed input matrix B [k x n1 x (1 x ETE)]
   size_t csb1,     // Column stride between panels of B
-  float* c,        // Packed output matrix C [m1 x n1 x (TE x TE)]
+  float* c,        // Packed output matrix C [m1 x n1 x (ETE x ETE)]
   size_t rsc1,     // Row stride between blocks of C
   size_t csc1,     // Column stride between blocks of C
   bool accum       // Whether to accumulate into C
@@ -256,9 +256,9 @@ void skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f(
 ```
 
 The matrix specifiers should be interpreted as:
-- `A`: `f32ptex1c` `TE` x 1 column vectors of `A` packed in block-row-major order
-- `B`: `f32cp1xte` 1 x `TE` row vectors of `B` packed in block-column-major order
-- `C`: `f32rcptexte` `TE` x `TE` blocks of `C` packed in either block-row- or block-column-major order, depending on `rsc1` and `csc1`
+- `A`: `f32petex1c` `ETE` x 1 column vectors of `A` packed in block-row-major order
+- `B`: `f32cp1xete` 1 x `ETE` row vectors of `B` packed in block-column-major order
+- `C`: `f32rcpetexete` `ETE` x `ETE` blocks of `C` packed in either block-row- or block-column-major order, depending on `rsc1` and `csc1`
 
 In this case, the packing is performed by the IREE framework itself, and the SKL kernel is called directly with the packed matrices; because of the arbitrary inter-block strides of `C`, it is up to the framework how the individual blocks are arranged with respect to one another.
 

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -316,7 +316,12 @@ const size_t m_tile = 256; // Application-chosen tile sizes
 const size_t n_tile = 128;
 const size_t k_tile = 128;
 
-static int8_t b_pack[k_tile * n_tile]; // Workspace for packed B
+// Need to ensure A-matrix is at least 4-byte aligned,
+// so just used 64-byte alignment for both.
+#define ALIGN _Alignas(64)
+
+ALIGN static int8_t b_tile[k_tile * n_tile];  // Workspace for packed B
+ALIGN static int8_t a_tile[k_tile * m_tile];  // Workspace for padded A
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
@@ -328,16 +333,42 @@ void example_blocked_gemm(size_t m, size_t n, size_t k, const int8_t *a,
                           size_t rsa, const int8_t *b, size_t rsb, int32_t *c,
                           size_t rsc) {
   for (size_t ii_tile = 0; ii_tile < m; ii_tile += m_tile) {
-    size_t m0 = min(m_tile, m - ii_tile);
+    size_t mt = min(m_tile, m - ii_tile);
     for (size_t jj_tile = 0; jj_tile < n; jj_tile += n_tile) {
-      size_t n0 = min(n_tile, n - jj_tile);
+      size_t nt = min(n_tile, n - jj_tile);
       for (size_t kk_tile = 0; kk_tile < k; kk_tile += k_tile) {
-        size_t k0 = min(k_tile, k - kk_tile);
-        // Pack and compute tile
-        skl_pack_b_i8_xsfvqdotq(k0, n0, b + kk_tile * rsb + jj_tile, rsb, b_pack, 4 * n0);
+        size_t kt = min(k_tile, k - kk_tile);
+
+        size_t k0 = 4;
+        size_t k1 = (k0 + 3) / 4;
+        uint8_t pad = 0; // Padding value
+
+        // Pack and pad B tile:
+        // Pack into [k1 x nt] x [ 4 x  1] col-major, block-row-major layout
+        //        =  [k1 x n1] x [k0 x n0]
+        size_t rsb1 = 4 * nt;
+        size_t csb1 = 4;
+        // Use specialized packing function for Xsfvqdot ISA
+        skl_pack_e8_e8rcp4x1c_zve32x(kt, nt, b + kk_tile * rsb + jj_tile, rsb,
+                                     b_tile, rsb_1, pad);
+
+        // Pad A tile to ensure k0 * k1 width (multiple of 4):
+        // "Pack" into [mt x k1] x [ 1 x  4] block-row-major layout
+        //           = [m1 x k1] x [m0 x k0]
+        size_t m0 = 1;
+        size_t rsa0 = 0; // Unused: only one row in block
+        size_t csa0 = 1;
+        size_t rsa1 = k0 * k1;
+        size_t csa1 = k0;
+        // Use generic "packing" function to tile/pad A
+        skl_pack_e8_e8rcprc_zve32x(mt, kt, a + ii_tile * rsa + kk_tile, rsa, 1,
+                                   m0, k0, a_tile, rsa0, csa0, rsa1, csa1, pad);
+
+        // Multiply A and B tiles, accumulate into un-tiled C
         skl_gemm_a1b01_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
-            m0, n0, (k0 + 3) / 4, a + ii_tile * rsa + kk_tile, rsa, 4, b_pack,
-            4 * n0, c + ii_tile * rsc + jj_tile, rsc, kk_tile > 0 /* accum */);
+            mt, nt, k1, a_tile, rsa1, csa1, b_tile,
+            rsb1, csb1, c + ii_tile * rsc + jj_tile, rsc,
+            kk_tile > 0 /* accum */);
       }
     }
   }

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -8,7 +8,7 @@ It also describes the packing and unpacking routines that convert matrices betwe
 ## Table of Contents
 1. [Packing and Padding](#packing-and-padding)
    - [Example: Matrix A Packing with Padding](#example-matrix-a-packing-with-padding)
-   - [Stride Relationships](#stride-relationships)
+   - [Stride Parameters](#stride-parameters)
 2. [APIs for Packed GEMM Kernels](#apis-for-packed-gemm-kernels)
    - [Generic Packed GEMM Semantics (Reference Implementation)](#generic-packed-gemm-semantics-reference-implementation)
    - [Naming Convention](#naming-convention)
@@ -27,7 +27,7 @@ For example, if we have a matrix `A` of size `m` x `k`, we might need to partiti
 Since the original matrix dimensions might not be exact multiples of the block size, we must pad the matrix so that they are.
 Typically, matrices are padded with zeroes, but other values are possible.
 The resulting packed matrix `A_pack` will consist of `m1` x `k1` blocks, where `m1 = ceil(m/m0)` and `k1 = ceil(k/k0)`, with each block having size `m0` x `k0` elements.
-(While it might be possible to construct packed formats that avoid padding, we exclude this possibility from the API for simplicity, as it is unlikely to be useful in practice.)
+While it might be possible to construct packed formats that avoid padding, we exclude this possibility from the API for simplicity, as it is unlikely to be useful in practice.
 
 ### Example: Matrix A Packing with Padding
 
@@ -59,14 +59,13 @@ Block(2,0): [a60 a61 a62 a63] [ 0   0   0   0 ] [ 0   0   0   0 ]
 Block(2,1): [a64 a65  0   0 ] [ 0   0   0   0 ] [ 0   0   0   0 ]
 ```
 
-
-#### Stride Relationships
+#### Stride Parameters
 
 For a matrix `A` with packed storage the following stride parameters are defined:
 - `rsa0`: row stride within a block, i.e. distance in memory between rows in the same block, in units of elements. (Example above: `rsa0 = k0 = 4`)
 - `csa0`: column stride within a block, i.e. distance in memory between columns in the same block, in units of elements. (Example above: `csa0 = 1`)
-- `rsa1`: row stride between blocks, i.e. distance in memory between the start of block (bi, bj) and the start of block (bi + 1, bj), in units of elements. (Example above: `rsa1 = m0 * k0 * k1 = 24`)
-- `csa1`: column stride between blocks, i.e. distance in memory between the start of block (bi, bj) and the start of block (bi, bj + 1), in units of elements. (Example above: `csa1 = m0 * k0 = 12`)
+- `rsa1`: row stride between blocks, i.e. distance in memory from the start of block (bi, bj) to the start of block (bi + 1, bj), in units of elements. (Example above: `rsa1 = m0 * k0 * k1 = 24`)
+- `csa1`: column stride between blocks, i.e. distance in memory from the start of block (bi, bj) to the start of block (bi, bj + 1), in units of elements. (Example above: `csa1 = m0 * k0 = 12`)
 
 Generally the naming scheme for these parameters follows the format `{r,c}s{buffer}{layer}`, where `buffer` is the buffer the parameter applies to and `layer` is the blocking layer the parameter describes.
 
@@ -159,7 +158,7 @@ Specifically, a `p<m0xn0>` specifier is inserted after each matrix type to indic
 
 On either side of `p`, transposition specifiers are used as usual:
 - `f32p<...>` for a packed matrix in block-row-major format whose blocks are row-major
-- `f32p<...>c` for a packed matrix in block-rowm-major format whose blocks are column-major
+- `f32p<...>c` for a packed matrix in block-row-major format whose blocks are column-major
 - `f32cp<...>c` for a packed matrix in block-column-major format whose blocks are column-major
 - `f32rcp<...>` for a packed matrix in either block-row-major or block-column-major format, but whose blocks are themselves row-major
 
@@ -184,43 +183,40 @@ The `sf.vqdot.vx` instruction computes a partial dot product:
 ```
 C[i, j:j+VL] += A[i, k:k+4] * B[k:k+4, j:j+VL]
 ```
-Where the element types of `A` and `B` are `int8_t` and `C` is accumulated as `int32_t`.
-Here, `VL` is the vector length, and the value `A[i, k:k+4]` is held in a single 32-bit scalar register.
+where `A` and `B` are `int8_t` matrices and `C` is an `int32_t` matrix.
+`VL` is the vector length, `A[i, k:k+4]` is held in a single 32-bit scalar register, and `B[k:k+4, j:j+VL]` is held contiguously in a vector register group in column-major order.
 
-In order to make use of this instruction with accumulator as a row vector across the output matrix `C`, we must pack the `B` matrix such that each block has dimensions `4xN`, where `N` is the input matrix width.
-This is done by dividing the `k` dimension into `k0=4` and `k1=ceil(k/4)`, while keeping the `n` dimension unchanged.
-Moreover, since the dot product is performed along the `k` dimension, it must be contiguous in memory, resulting in a column-major layout within each block.
+To use this instruction to compute a matrix product, it is therefore natural to pack the `A` matrix into `1x4` blocks; pack the `B` matrix into `4xN` column-major panels, each stored in contiguous memory; and leave `C` in row-major order.
+Thus, only the `K` dimension is packed; it is divided into `k0=4` and `k1=ceil(K/4)`.
+Since the `N` dimension is not packed, we set `n0=1`.
+Similarly, we set `m0=1`.
 
-In the actual implementation, we think of blocks as having fixed dimensions `4x1` (`n0=1`) instead of `4xN`.
-Each column of the `4xN` blocks of B can be thought of as one of these `4x1` blocks, so `n1 = N`.
-And since each `4xN` block of B is column-major and stored contiguously in memory, we find that `rsb0=1` and `csb1=k0*n0`.
-Note that `csb0` is unused since each `4x1` block has only one column.
-
-In the A matrix, the "packed" dimension in `p1x4` simply indicates that the row length has been _padded_ to a multiple of 4.
-Ideally, if the original `k` was a multiple of 4 or the A matrix was already padded, it can be used without modification.
+The simplest way to "pack" the `A` matrix is to pad the rows to a multiple of 4.
+As a special case, if `K` is already a multiple of 4, then `A` can be used without modification.
 
 The packed kernel could be depicted as implemented by the following wrapper for the general packed GEMM API:
 ```c
 void skl_gemm_a1b01_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
-  size_t m,             // Num. rows in A and C
-  size_t n,             // Num. columns in B and C
-  size_t k1,            // Num. 1x4 k blocks in A and 4x1 blocks in B
-  const int8_t* a_pack, // Padded  matrix A [m x ceil(k/4) x 4].
-  size_t rsa1,           // Row stride between blocks of A
-  size_t csa1,           // Column stride between blocks of A
-  const int8_t* b_pack, // Packed matrix B [ceil(k/4) x n x (4 x 1)]
-  size_t rsb1,          // Row stride between blocks of B
+  size_t m,             // Num. rows in A_pack and C
+  size_t n,             // Num. columns in B_pack and C
+  size_t k1,            // Num. block-columns in A_pack and block-rows in B_pack
+  int32_t alpha,        // Scaling factor for A_pack * B_pack
+  const int8_t* a_pack, // Packed matrix A_pack [m x ceil(k/4) x (1 x 4)].
+  size_t rsa1,          // Row stride between blocks of A_pack
+  size_t csa1,          // Column stride between blocks of A_pack
+  const int8_t* b_pack, // Packed matrix B_pack [ceil(k/4) x n x (4 x 1)]
+  size_t rsb1,          // Row stride between blocks of B_pack
+  int32_t beta,         // Scaling factor for C
   int32_t* c,           // Output matrix C [m x n]
   size_t rsc,           // Row stride of C
-  bool accum            // Whether to accumulate into C
 ) {
   skl_gemm_i8rcprc_i8rcprc_i32rcprc_ref(
-    1, 1, 4, m, n, k1,      // m0, n0, k0, m1, n1, k1
-    1,                      // alpha
-    a_pack, 0, 1, rsa1, csa1,   // a_pack, rsa0, csa0, rsa1, csa1
-    b_pack, 1, 0, rsb1, 4,  // b_pack, rsb0, csb0, rsb1, csb1
-    accum ? 1 : 0,          // beta
-    c, 0, 0, rsc, 1         // c_pack, rsc0, csc0, rsc1, csc1
+    1, 1, 4, m, n, k1,        // m0, n0, k0, m1, n1, k1
+    alpha,                    // alpha
+    a_pack, 0, 1, rsa1, csa1, // a_pack, rsa0, csa0, rsa1, csa1
+    b_pack, 1, 0, rsb1, 4,    // b_pack, rsb0, csb0, rsb1, csb1
+    beta,                     // beta
+    c, 0, 0, rsc, 1           // c_pack, rsc0, csc0, rsc1, csc1
   );
 }
 ```
@@ -231,7 +227,7 @@ The SiFive matrix engine (Xsfmm) provides a transposed fat outer-product instruc
 ```
 C[i:i+TM, j:j+TN] += A[k:k+TK, i:i+TM]^T * B[k:k+TK, j:j+TN]
 ```
-The types of the matrices may vary, but the output matrix is held in matrix register tiles of size `TE` x `TE`, while the input operands are held in vector register groups of size `TK` x `TE`.
+The types of the matrices may vary, but the output matrix is held in matrix register tiles of size `TE` x `TE`, while each of the `TK` rows of the input operands are held in vector register groups of size `TE`.
 The accumulator dimensions `TM` and `TN` are set by the application, and must be <= `TE`, the machine tile size.
 The dot product length `TK` is either 1, 2, or 4 depending on the datatype and the application `K` dimension.
 
@@ -248,24 +244,24 @@ However, to obtain peak performance it is often necessary for the kernel to use 
 
 ```c
 void skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f(
-  size_t m1,            // Num. row blocks in A and C
-  size_t n1,            // Num. column blocks in B and C
-  size_t k,             // Num. columns in A, rows in B
-  const float* a_pack,  // Input matrix A [m1 x k x (TE x 1)]
-  size_t rsa1,          // Row stride between panels of A
-  const float* b_pack,  // Input matrix B [k x n1 x (1 x TE)]
-  size_t csb1,          // Column stride between panels of B
-  float* c_pack,        // Output matrix C [m1 x n1 x (TE x TE)]
-  size_t rsc1,          // Row stride between blocks of C
-  size_t csc1,          // Column stride between blocks of C
-  bool accum            // Whether to accumulate into C
+  size_t m1,            // Num. block-rows in A_pack and C_pack
+  size_t n1,            // Num. block-columns in B_pack and C_pack
+  size_t k,             // Num. columns in A_pack, rows in B_pack
+  const float* a_pack,  // Input matrix A_pack [m1 x k x (TE x 1)]
+  size_t rsa1,          // Row stride between panels of A_pack
+  const float* b_pack,  // Input matrix B_pack [k x n1 x (1 x TE)]
+  size_t csb1,          // Column stride between panels of B_pack
+  float* c_pack,        // Output matrix C_pack [m1 x n1 x (TE x TE)]
+  size_t rsc1,          // Row stride between blocks of C_pack
+  size_t csc1,          // Column stride between blocks of C_pack
+  bool accum            // Whether to accumulate into C_pack
 );
 ```
 
 The matrix specifiers should be interpreted as:
-- A: `f32ptex1c` TE x 1 column vectors of A packed in block-row-major order
-- B: `f32cp1xte` 1 x TE row vectors of B packed in block-column-major order
-- C: `f32rcptexte` TE x TE blocks of C packed in either block-row- or block-column-major order, depending on `rsc1` and `csc1`
+- `A`: `f32ptex1c` TE x 1 column vectors of `A` packed in block-row-major order
+- `B`: `f32cp1xte` 1 x TE row vectors of `B` packed in block-column-major order
+- `C`: `f32rcptexte` TE x TE blocks of `C` packed in either block-row- or block-column-major order, depending on `rsc1` and `csc1`
 
 In this case, the packing is performed by the IREE framework itself, and the SKL kernel is called directly with the packed matrices; because of the arbitrary inter-block strides of `C`, it is up to the framework how the individual blocks are arranged with respect to one another.
 
@@ -275,27 +271,26 @@ The `sf.vqmacc.4x8x4` instruction computes a fat dot product:
 ```
 C[i:i+4, j:j+4] += A[i:i+4, k:k+8] * B[k:k+8, j:j+4]
 ```
-Where the element types of `A` and `B` are `int8_t` and `C` is accumulated as `int32_t`.
+where `A` and `B` are `int8_t` matrices and `C` is an `int32_t` matrix.
 As in the `sf.vqdot.vx` example, `VL` is the vector length, but here the `C` matrix operand is a 4x4 sub-matrix, while `A` and `B` are 4x8 and 8x4 sub-matrices, respectively.
+Each of the three operands is held contiguously in a vector register group in row-major order.
+Thus, the block dimensions must be `m0=4`, `n0=4`, and `k0=8`; the intra-block row strides must be `rsa0=8`, `rsb0=4`, `rsc0=4`; and all three intra-block column strides must be `1`.
 
-In order to make use of this instruction, all matrices must be packed such that `m0=4`, `n0=4`, and `k0=8`.
-Within each block, the `sf.vqmacc.4x8x4` instruction requires a row-major layout, so `rsa0=8`, `rsb0=4`, `rsc0=4`, and all three column strides are `1`.
-
-The specific kernel provided by SKL also assumes a block-row-major layout for the packed matrices, meaning that `rsa1=(k1 * 32)`, `csa1=32`, `rsb1=(n1 * 32)`, `csb1=32`, `rsc1=(n1 * 16)`, and `csc1=16`.
+The specific kernel provided by SKL also assumes a block-row-major layout for the packed matrices, meaning that `csa1=32`, `csb1=32`, and `csc1=16`.
 
 The packed kernel's API is thus:
 ```c
 void skl_gemm_a1b01_i8p4x8_i8p8x4_i32p4x4_xsfvqmaccqoq(
-  size_t m1,            // Num. row blocks in A and C
-  size_t n1,            // Num. column blocks in B and C
-  size_t k1,            // Num. column blocks in A, row blocks in B
-  const int8_t* a_pack, // Packed matrix A [m1 x k1 x (4 x 8)]
-  size_t rsa1,          // Stride between block-rows of packed A
-  const int8_t* b_pack, // Packed matrix B [k1 x n1 x (8 x 4)]
-  size_t rsb1,          // Stride between block-rows of packed B
-  int32_t* c_pack,      // Packed matrix C [m1 x n1 x (4 x 4)]
-  size_t rsc1,          // Stride between block rows of packed C
-  bool accum            // Whether to accumulate into C
+  size_t m1,            // Num. block-rows in A_pack and C_pack
+  size_t n1,            // Num. block-columns in B_pack and C_pack
+  size_t k1,            // Num. block-columns in A_pack, block-rows in B_pack
+  const int8_t* a_pack, // Packed matrix A_pack [m1 x k1 x (4 x 8)]
+  size_t rsa1,          // Stride between block-rows of packed A_pack
+  const int8_t* b_pack, // Packed matrix B_pack [k1 x n1 x (8 x 4)]
+  size_t rsb1,          // Stride between block-rows of packed B_pack
+  int32_t* c_pack,      // Packed matrix C_pack [m1 x n1 x (4 x 4)]
+  size_t rsc1,          // Stride between block-rows of packed C_pack
+  bool accum            // Whether to accumulate into C_pack
 );
 ```
 
@@ -309,18 +304,18 @@ Instead, the combination of calls to packing, GEMM, and unpacking kernels can be
 This allows tiling to be tuned to the geometry of the cache hierarchy, rather than being constrained to matrix instruction or register tile sizes, although optimal performance may require them to be multiples to avoid excessive fringe-case handling and padding.
 
 Since SKL's packing functions already copy data, they can be used to implement blocked GEMM by simply calling them on each tile.
-For example, the code below shows an example of blocked GEMM with packing using the `xsfvqdot` kernel.
+The code below shows an example of blocked GEMM with packing using the `Xsfvqdotq` kernel.
 ```c
 const size_t m_tile = 256; // Application-chosen tile sizes
 const size_t n_tile = 128;
 const size_t k_tile = 128;
 
-// Need to ensure A-matrix is at least 4-byte aligned,
-// so just used 64-byte alignment for both.
+// To avoid misaligned loads from A, need to ensure A matrix is at least 4-byte
+// aligned, so just used 64-byte alignment for both.
 #define ALIGN _Alignas(64)
 
+ALIGN static int8_t a_tile[m_tile * k_tile];  // Workspace for padded A
 ALIGN static int8_t b_tile[k_tile * n_tile];  // Workspace for packed B
-ALIGN static int8_t a_tile[k_tile * m_tile];  // Workspace for padded A
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
@@ -342,16 +337,7 @@ void example_blocked_gemm(size_t m, size_t n, size_t k, const int8_t *a,
         size_t k1 = (kt + 3) / 4;
         uint8_t pad = 0; // Padding value
 
-        // Pack and pad B tile:
-        // Pack into [k1 x nt] x [ 4 x  1] col-major, block-row-major layout
-        //        =  [k1 x n1] x [k0 x n0]
-        size_t rsb1 = 4 * nt;
-        size_t csb1 = 4;
-        // Use specialized packing function for Xsfvqdot ISA
-        skl_pack_e8_e8rcp4x1c_zve32x(kt, nt, b + kk_tile * rsb + jj_tile, rsb,
-                                     b_tile, rsb_1, pad);
-
-        // Pad A tile to ensure k0 * k1 width (multiple of 4):
+        // Pad A tile to ensure k0 * k1 row length (multiple of 4):
         // "Pack" into [mt x k1] x [ 1 x  4] block-row-major layout
         //           = [m1 x k1] x [m0 x k0]
         size_t m0 = 1;
@@ -359,15 +345,23 @@ void example_blocked_gemm(size_t m, size_t n, size_t k, const int8_t *a,
         size_t csa0 = 1;
         size_t rsa1 = k0 * k1;
         size_t csa1 = k0;
-        // Use generic "packing" function to tile/pad A
+        // Use generic packing function to pad A
         skl_pack_e8_e8rcprc_zve32x(mt, kt, a + ii_tile * rsa + kk_tile, rsa, 1,
                                    m0, k0, a_tile, rsa0, csa0, rsa1, csa1, pad);
 
+        // Pack and pad B tile:
+        // Pack into [k1 x nt] x [ 4 x  1] block-row-major layout
+        //        =  [k1 x n1] x [k0 x n0]
+        size_t rsb1 = 4 * nt;
+        size_t csb1 = 4;
+        // Use specialized packing function for Xsfvqdotq ISA
+        skl_pack_e8_e8p4x1c_zve32x(kt, nt, b + kk_tile * rsb + jj_tile, rsb,
+                                   b_tile, rsb1, pad);
+
         // Multiply A and B tiles, accumulate into un-tiled C
-        skl_gemm_a1b01_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
-            mt, nt, k1, a_tile, rsa1, csa1, b_tile,
-            rsb1, csb1, c + ii_tile * rsc + jj_tile, rsc,
-            kk_tile > 0 /* accum */);
+        skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
+            mt, nt, k1, 1 /* alpha */, a_tile, rsa1, csa1, b_tile, rsb1, csb1,
+            kk_tile ? 1 : 0 /* beta */, c + ii_tile * rsc + jj_tile, rsc);
       }
     }
   }

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -202,12 +202,13 @@ Ideally, if the original `k` was a multiple of 4 or the A matrix was already pad
 
 The packed kernel could be depicted as implemented by the following wrapper for the general packed GEMM API:
 ```c
-void skl_gemm_a1b01_i8p1x4_i8p4x1c_i32_xsfvqdotq(
+void skl_gemm_a1b01_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
   size_t m,             // Num. rows in A and C
   size_t n,             // Num. columns in B and C
   size_t k1,            // Num. 1x4 k blocks in A and 4x1 blocks in B
   const int8_t* a_pack, // Padded  matrix A [m x ceil(k/4) x 4].
-  size_t rsa,           // Row stride of A
+  size_t rsa1,           // Row stride between blocks of A
+  size_t csa1,           // Column stride between blocks of A
   const int8_t* b_pack, // Packed matrix B [ceil(k/4) x n x (4 x 1)]
   size_t rsb1,          // Row stride between blocks of B
   int32_t* c,           // Output matrix C [m x n]
@@ -217,7 +218,7 @@ void skl_gemm_a1b01_i8p1x4_i8p4x1c_i32_xsfvqdotq(
   skl_gemm_i8rcprc_i8rcprc_i32rcprc_ref(
     1, 1, 4, m, n, k1,      // m0, n0, k0, m1, n1, k1
     1,                      // alpha
-    a_pack, 0, 1, rsa, 4,   // a_pack, rsa0, csa0, rsa1, csa1
+    a_pack, 0, 1, rsa1, csa1,   // a_pack, rsa0, csa0, rsa1, csa1
     b_pack, 1, 0, rsb1, 4,  // b_pack, rsb0, csb0, rsb1, csb1
     accum ? 1 : 0,          // beta
     c, 0, 0, rsc, 1         // c_pack, rsc0, csc0, rsc1, csc1
@@ -334,8 +335,8 @@ void example_blocked_gemm(size_t m, size_t n, size_t k, const int8_t *a,
         size_t k0 = min(k_tile, k - kk_tile);
         // Pack and compute tile
         skl_pack_b_i8_xsfvqdotq(k0, n0, b + kk_tile * rsb + jj_tile, rsb, b_pack, 4 * n0);
-        skl_gemm_a1b01_i8p1x4_i8p4x1c_i32_xsfvqdotq(
-            m0, n0, (k0 + 3) / 4, a + ii_tile * rsa + kk_tile, rsa, b_pack,
+        skl_gemm_a1b01_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
+            m0, n0, (k0 + 3) / 4, a + ii_tile * rsa + kk_tile, rsa, 4, b_pack,
             4 * n0, c + ii_tile * rsc + jj_tile, rsc, kk_tile > 0 /* accum */);
       }
     }

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -30,7 +30,8 @@ void skl_pack_<src type>_<dst_type>_<isa>(
   size_t rs0,         // Row stride within a block of the output matrix
   size_t cs0,         // Column stride within a block of the output matrix
   size_t rs1,         // Row stride between blocks of the output matrix
-  size_t cs1          // Column stride between blocks of the output matrix
+  size_t cs1,         // Column stride between blocks of the output matrix
+  <dst type> pad      // Value to insert for padded elements (usually 0)
 ) {
   size_t m1 = (m + m0 - 1) / m0; // Num. row blocks in the input matrix
   size_t n1 = (n + n0 - 1) / n0; // Num. column blocks in the input matrix
@@ -44,7 +45,7 @@ void skl_pack_<src type>_<dst_type>_<isa>(
             dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0 * cs];
           } else {
             // Pad with zeros
-            dst_block[ii0 * rs0 + jj0 * cs0] = 0;
+            dst_block[ii0 * rs0 + jj0 * cs0] = pad;
           }
         }
       }
@@ -176,7 +177,7 @@ It is for illustrative purposes only.
 All of these kernels are required for correct operation of the corresponding GEMM kernels.
 
 #### Xsfvqdotq
-- `skl_pack_e8_e8p4x1c_zve32x`: Pack the B matrix into 4x1 panels (4x1 block-row-major example above) to use `sf.vqdot.vx` without reduction summation.
+- `skl_pack_e8_e8rcp4x1c_zve32x`: Pack the B matrix into 4x1 panels (4x1 block-row-major example above) to use `sf.vqdot.vx` without reduction summation.
 
 #### Xsfvqmaccqoq
 These kernels are required for use of the `sf.vqmacc.4x8x4` instruction.

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -62,7 +62,7 @@ The general form is `skl_pack_<src type>_<dst type>_<isa>`.
 
 The datatype specifiers follow the same conventions as in the corresponding [GEMM kernels](../gemm/packed-gemm.md) in which the matrix will be used, except that only the element width is indicated, as the internal format is irrelevant to the packing implementation (e.g. `e32` is used rather than `f32`).
 
-Thus, the `<dst type>` term may further be broken down as `e<sew>[rc]p<m0>x<n0>[rc]`, where `m0` and `n0` are the block dimensions (rows and columns per block, respectively).
+Thus, the `<dst type>` term may further be broken down as `e<sew>[<outer-block-order>]p<m0>x<n0>[<inner-block-order>]`, where `m0` and `n0` are the block dimensions (rows and columns per block, respectively).
 
 It is assumed by default that the ordering of elements within a block is fixed to be row-major.
 If instead the layout within a block is column-major, the inner-block-order term is `c`, and if it may be either, `rc` is used.

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -3,7 +3,7 @@
 This family of kernels implements the pack and unpack operations for matrices used in the [packed GEMM kernels](../gemm/packed-gemm.md).
 It includes a set of packing and, when relevant, unpacking functions for each GEMM-related ISA extension.
 
-These routines reorder the elements of a 2D, row-major matrix of size `m` x `n` into a blocked layout where blocks of size `m0` x `n0` are stored contiguously, and padded with zeros if necessary, for a total of `m1` x `n1` blocks, where `m1 = ceil(m/m0)` and `n1 = ceil(n/n0)`.
+These routines reorder the elements of a 2D, row-major matrix of size `m` x `n` into a blocked layout where blocks of size `m0` x `n0` are stored contiguously, and padded if necessary, for a total of `m1` x `n1` blocks, where `m1 = ceil(m/m0)` and `n1 = ceil(n/n0)`.
 Depending on the requirements of the target ISA or application, the elements within each block may also be transposed, and the blocks themselves may be stored in row- or column-major order.
 
 When a matrix is packed along only one dimension and no transposition is implied, then the "packing" operation consists entirely of _padding_ the matrix to a multiple of the block size.

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -15,7 +15,7 @@ See the [list of packing kernels](#list-of-packing-kernels) for details.
 
 These functions specialize the general form:
 ```c
-void skl_pack_<datatypes>_<isa>(
+void skl_pack_<src type>_<dst_type>_<isa>(
   size_t m,           // Num. rows in input matrix
   size_t n,           // Num. columns in input matrix
   const <type>* src,  // Input matrix
@@ -66,7 +66,7 @@ Thus, the `<dst type>` term may further be broken down as `e<sew>[rc]p<m0>x<n0>[
 
 It is assumed by default that the ordering of elements within a block is fixed to be row-major.
 If instead the layout within a block is column-major, the inner-block-order term is `c`, and if it may be either, `rc` is used.
-Similarly, the ordering of blocks relative to each other is assumed to be block-row-major, but if it is either block-column-major or configurable, then either `c` or `rc` is inserted before the packing specifier `p`.
+Similarly, the ordering of blocks relative to each other is assumed to be block-row-major, but if it is either block-column-major or configurable, then either `c` or `rc` is inserted, respectively, before the packing specifier `p`.
 
 When one of the dimensions is `1`, there is technically no difference in memory ordering between row- and column-major; however, the order is still said to be "column-major" when the second dimension is `1`, as this corresponds to the canonical layout of a column vector, and better communicates the transposition implied by the layout.
 Use of `1` for either block dimension effectively creates a block with one side of arbitrary size, referred to as a _panel_.
@@ -76,6 +76,8 @@ Use of `1` for either block dimension effectively creates a block with one side 
 > The `skl_pack_e8_e8ptex1c_xsfmm` function is an exception, as it uses the matrix engine to accelerate transposition within blocks.
 
 ## Packing Layout Examples
+
+Several examples of packed layouts are shown below, with element types omitted.
 
 ### Example: p4x1c Block Layout (Block-Row-Major with Inner Transposition)
 ```
@@ -175,7 +177,7 @@ All of these kernels are required for correct operation of the corresponding GEM
 
 #### Xsfvqmaccqoq
 These kernels are required for use of the `sf.vqmacc.4x8x4` instruction.
-Because the of the small block size, significant specialization is required to achieve reasonable performance.
+Because of the small block size, significant specialization is required to achieve reasonable performance.
 - `skl_pack_e32_e32p4x4_zve32x`: Used for the C matrix.
 - `skl_unpack_e32p4x4_e32_zve32x`: Inverse of `skl_pack_e32_e32p4x4_zve32x`.
 - `skl_pack_e8_e8p4x8_zve32x`: Used for the A matrix.

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -5,6 +5,7 @@ It includes a set of packing and, when relevant, unpacking functions for each GE
 
 These routines reorder the elements of a 2D, row-major matrix of size `m` x `n` into a blocked layout where blocks of size `m0` x `n0` are stored contiguously, and padded with zeros if necessary, for a total of `m1` x `n1` blocks, where `m1 = ceil(m/m0)` and `n1 = ceil(n/n0)`.
 Depending on the requirements of the target ISA or application, the elements within each block may also be transposed, and the blocks themselves may be stored in row- or column-major order.
+When a matrix is packed along only one dimension and no transposition is implied, then the "packing" operation consists entirely of _padding_ the matrix to a multiple of the block size.
 
 Not all extensions require packing for all matrices, but kernels for such cases may nevertheless be provided, as some applications may require similar layouts across all matrices, or seek locality benefits from arranging data in the shape of the underlying multiplication operation, or one of its dimensions.
 The documentation for each kernel indicates whether it is required or optional.
@@ -14,7 +15,7 @@ See the [list of packing kernels](#list-of-packing-kernels) for details.
 
 These functions specialize the general form:
 ```c
-void skl_pack_rcbrc_<datatype>_<isa>(
+void skl_pack_<datatypes>_<isa>(
   size_t m,           // Num. rows in input matrix
   size_t n,           // Num. columns in input matrix
   const <type>* src,  // Input matrix
@@ -52,34 +53,31 @@ Unpacking functions work analogously.
 
 
 As in the case of GEMM kernels, most packing kernels will fully specialize or constrain most of the parameters, and they are thus omitted from the API.
-Usually, `m0`, `n0`, `rs0`, and `cs0` are all fixed by the target's layout, and indicated in the kernel's name as part of the _layout term_ (`_rcbrc_` in the generic case shown above).
+Usually, `m0`, `n0`, `rs0`, and `cs0` are all fixed by the target's layout, and indicated in the kernel's name as part of the datatype specifier of the output matrix.
 
 ### Naming Convention for Packing Kernels
 
 The name of the packing kernel indicates the block size and ISA extension required by the kernel, and whether it is required or optional.
-The general form is `skl_pack_<layout>_<datatype>_<isa>`.
+The general form is `skl_pack_<src type>_<dst type>_<isa>`.
 
-> **Note**: As in other kernel families, the ISA suffix indicates the minimum requirement to execute the packing kernel itself (normally `zve32x`), but its primary intended use may be for a particular matrix extension. This is indicated in the documentation for each kernel (packing and GEMM).
->
-> The `skl_pack_tex1c_e8_xsfmm` function is an exception, as it uses the matrix engine to accelerate transposition within blocks.
+The datatype specifiers follow the same conventions as in the corresponding [GEMM kernels](../gemm/packed-gemm.md) in which the matrix will be used, except that only the element width is indicated, as the internal format is irrelevant to the packing implementation (e.g. `e32` is used rather than `f32`).
 
-#### Layout Term
-
-The layout term may further be decomposed as `<m0>x<n0>[<inner-block-order>][<block-order>]`, where `m0` and `n0` are the block dimensions (rows and columns per block, respectively).
+Thus, the `<dst type>` term may further be broken down as `e<sew>[rc]p<m0>x<n0>[rc]`, where `m0` and `n0` are the block dimensions (rows and columns per block, respectively).
 
 It is assumed by default that the ordering of elements within a block is fixed to be row-major.
 If instead the layout within a block is column-major, the inner-block-order term is `c`, and if it may be either, `rc` is used.
-Similarly, the ordering of blocks relative to each other is assumed to be block-row-major, but if it is either block-column-major or configurable, a block-order term of `bc` or `brc` is added to the end of the layout term.
+Similarly, the ordering of blocks relative to each other is assumed to be block-row-major, but if it is either block-column-major or configurable, then either `c` or `rc` is inserted before the packing specifier `p`.
 
 When one of the dimensions is `1`, there is technically no difference in memory ordering between row- and column-major; however, the order is still said to be "column-major" when the second dimension is `1`, as this corresponds to the canonical layout of a column vector, and better communicates the transposition implied by the layout.
-
 Use of `1` for either block dimension effectively creates a block with one side of arbitrary size, referred to as a _panel_.
 
-The examples below illustrate these different layouts, and relation to the layout term.
+> **Note**: As in other kernel families, the ISA suffix indicates the minimum requirement to execute the packing kernel itself (normally `zve32x`), but its primary intended use may be for a particular matrix extension. This is indicated in the documentation for each kernel (packing and GEMM).
+>
+> The `skl_pack_e8_e8ptex1c_xsfmm` function is an exception, as it uses the matrix engine to accelerate transposition within blocks.
 
 ## Packing Layout Examples
 
-### Example: 4x1c Block Layout (Block-Row-Major with Inner Transposition)
+### Example: p4x1c Block Layout (Block-Row-Major with Inner Transposition)
 ```
 Original row-major matrix (8x4):        Packed layout [m0=4, n0=1, m1=2, n1=4]:
 
@@ -107,7 +105,7 @@ Strides: rs0=1 (row stride within block), cs0=4 (column stride within block)
          rs1=16 (row stride between blocks), cs1=4 (column stride between blocks)
 ```
 
-### Example: 1x4bc Block Layout (Block-Column-Major with Outer Transposition)
+### Example: cp1x4 Block Layout (Block-Column-Major with Outer Transposition)
 ```
 Original row-major matrix (4x8):        Packed layout [m0=1, n0=4, m1=4, n1=2]:
 
@@ -139,7 +137,7 @@ Strides: rs0=4 (row stride within block), cs0=1 (column stride within block)
          rs1=4 (row stride between blocks), cs1=16 (column stride between blocks)
 ```
 
-### Example: 2x2c Block Layout (Block-Row-Major with Column-Major Within Blocks)
+### Example: p2x2c Block Layout (Block-Row-Major with Column-Major Within Blocks)
 ```
 Original row-major matrix (4x4):        Packed layout [m0=2, n0=2, m1=2, n1=2]:
 
@@ -173,28 +171,28 @@ It is for illustrative purposes only.
 All of these kernels are required for correct operation of the corresponding GEMM kernels.
 
 #### Xsfvqdotq
-- `skl_pack_4x1c_e8_zve32x`: Pack the B matrix into 4x1 panels (4x1 block-row-major example above) to use `sf.vqdot.vx` without reduction summation.
+- `skl_pack_e8_e8p4x1c_zve32x`: Pack the B matrix into 4x1 panels (4x1 block-row-major example above) to use `sf.vqdot.vx` without reduction summation.
 
 #### Xsfvqmaccqoq
 These kernels are required for use of the `sf.vqmacc.4x8x4` instruction.
 Because the of the small block size, significant specialization is required to achieve reasonable performance.
-- `skl_pack_4x4_e32_zve32x`: Used for the C matrix.
-- `skl_unpack_4x4_e32_zve32x`: Inverse of `skl_pack_4x4_e32_zve32x`.
-- `skl_pack_4x8_e8_zve32x`: Used for the A matrix.
-- `skl_pack_8x4_e8_zve32x`: Used for the B matrix.
+- `skl_pack_e32_e32p4x4_zve32x`: Used for the C matrix.
+- `skl_unpack_e32p4x4_e32_zve32x`: Inverse of `skl_pack_e32_e32p4x4_zve32x`.
+- `skl_pack_e8_e8p4x8_zve32x`: Used for the A matrix.
+- `skl_pack_e8_e8p8x4_zve32x`: Used for the B matrix.
 
 ### Optional Packing Kernels
 None of these are strictly required for correct operation of the corresponding GEMM kernels, but they may be useful for performance or compatibility reasons.
 (For Xsfmm, it is never required to pack any matrix; only [transposition](../transpose/README.md) is required if the A matrix is in row-major format, or B is in column-major format.)
-- `skl_pack_tex1c_e8_xsfmm`: Transpose (TE x K) panels using the matrix engine. Used on a row-major A matrix or column-major B matrix.
+- `skl_pack_e8_e8ptex1c_xsfmm`: Transpose (TE x K) panels using the matrix engine. Used on a row-major A matrix or column-major B matrix.
 
 ### Packing Kernels That Do Not Exist
 These names refer to kernels that users might expect to exist, but do not, because they can be implemented with an appropriate block size in the generic RVV packing kernel at reasonable performance.
 In general, so long as the block size is large enough in at least one dimension (as is the case in paneling), a generic packing kernel with a large enough vector length can achieve reasonable performance.
 
-- ~~`skl_pack_1xte_e8_zve32x`~~: Pack (K x TE) panels. Used on a column-major A matrix or row-major B matrix.
-- ~~`skl_pack_texte_e32_zve32x`~~: Pack (TE x TE) blocks without transposition. Used on a C matrix.
-- ~~`skl_pack_1xvlm8_e8_zve32x`~~: Pack (1 x VLMAX*8) column panels.
+- ~~`skl_pack_e8_e8rcp1xte_zve32x`~~: Pack (K x TE) panels. Used on a column-major A matrix or row-major B matrix.
+- ~~`skl_pack_e32_e32rcptexte_zve32x`~~: Pack (TE x TE) blocks without transposition. Used on a C matrix.
+- ~~`skl_pack_e8_e8cp1xvlm8_zve32x`~~: Pack (1 x VLMAX*8) column panels.
 
 In addition to being unnecessary for correct execution, these can all be implemented by supplying the machine-dependent dimension (TE or VLMAX) to the generic packing kernel.
 

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -69,7 +69,7 @@ Similarly, the ordering of blocks relative to each other is assumed to be block-
 
 > **Note**: As in other kernel families, the ISA suffix indicates the minimum requirement to execute the packing kernel itself (normally `zve32x`), but its primary intended use may be for a particular matrix extension. This is indicated in the documentation for each kernel (packing and GEMM).
 >
-> The `skl_pack_e8_e8ptex1c_xsfmmbase` function is an exception, as it uses the matrix engine to accelerate transposition within blocks.
+> The `skl_pack_e8_e8petex1c_xsfmmbase` function is an exception, as it uses the matrix engine to accelerate transposition within blocks.
 
 ## Packing Layout Examples
 
@@ -177,18 +177,18 @@ Because of the small block size, significant specialization is required to achie
 ### Optional Packing Kernels
 None of these are strictly required for correct operation of the corresponding GEMM kernels, but they may be useful for performance or compatibility reasons.
 (For Xsfmm, it is never required to pack any matrix; only [transposition](../transpose/README.md) is required if the `A` matrix is in row-major format, or `B` is in column-major format.)
-- `skl_pack_e8_e8ptex1c_xsfmmbase`: Transpose (`TE` x `K`) panels using the matrix engine. Used on a row-major `A` matrix or column-major `B` matrix.
+- `skl_pack_e8_e8petex1c_xsfmmbase`: Transpose (`ETE` x `K`) panels using the matrix engine. Used on a row-major `A` matrix or column-major `B` matrix.
 
 ### Packing Kernels That Do Not Exist
 These names refer to kernels that users might expect to exist, but do not, because they can be implemented with an appropriate block size in the generic RVV packing kernel at reasonable performance.
 In general, so long as the block size is large enough in at least one dimension (as is the case in paneling), a generic packing kernel with a large enough vector length can achieve reasonable performance.
 
 - ~~`skl_pack_e8_e8p4x1c_zve32x`~~: Pack (4 x `N`) column-major row panels.
-- ~~`skl_pack_e8_e8cp1xte_zve32x`~~: Pack (`K` x `TE`) panels. Used on a column-major `A` matrix or row-major `B` matrix.
-- ~~`skl_pack_e32_e32rcptexte_zve32x`~~: Pack (`TE` x `TE`) blocks without transposition. Used on a `C` matrix.
+- ~~`skl_pack_e8_e8cp1xete_zve32x`~~: Pack (`K` x `ETE`) panels. Used on a column-major `A` matrix or row-major `B` matrix.
+- ~~`skl_pack_e32_e32rcpetexete_zve32x`~~: Pack (`ETE` x `ETE`) blocks without transposition. Used on a `C` matrix.
 - ~~`skl_pack_e8_e8cp1xvlm8_zve32x`~~: Pack (`K` x `VLMAX*8`) column panels.
 
-In addition to being unnecessary for correct execution, these can all be implemented by supplying the machine-dependent dimension (`TE` or `VLMAX`) to the generic packing kernel.
+In addition to being unnecessary for correct execution, these can all be implemented by supplying the machine-dependent dimension (`ETE` or `VLMAX`) to the generic packing kernel.
 
 ## Generic RVV Packing Kernel [**Future Work**]
 

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -6,11 +6,7 @@ It includes a set of packing and, when relevant, unpacking functions for each GE
 These routines reorder the elements of a 2D, row-major matrix of size `m` x `n` into a blocked layout where blocks of size `m0` x `n0` are stored contiguously, and padded if necessary, for a total of `m1` x `n1` blocks, where `m1 = ceil(m/m0)` and `n1 = ceil(n/n0)`.
 Depending on the requirements of the target ISA or application, the elements within each block may also be transposed, and the blocks themselves may be stored in row- or column-major order.
 
-When a matrix is packed along only one dimension and no transposition is implied, then the "packing" operation consists entirely of _padding_ the matrix to a multiple of the block size.
-For an `m` x `n` row-major array to be packed into `m0` x `n` blocks, no data reordering is required.
-However, if the array is packed into `m` x `n0`, data reordering occurs whenever `n0` < `n`.
-
-Not all extensions require packing for all matrices, but kernels for such cases may nevertheless be provided, as some applications may require similar layouts across all matrices, or seek locality benefits from arranging data in the shape of the underlying multiplication operation, or one of its dimensions.
+Not all extensions require packing for all matrices, but kernels for such cases may nevertheless be provided, as some applications may require similar layouts across all matrices, or seek locality benefits from arranging data in the shape of the underlying multiplication operation.
 The documentation for each kernel indicates whether it is required or optional.
 See the [list of packing kernels](#list-of-packing-kernels) for details.
 
@@ -18,7 +14,7 @@ See the [list of packing kernels](#list-of-packing-kernels) for details.
 
 These functions specialize the general form:
 ```c
-void skl_pack_<src type>_<dst_type>_<isa>(
+void skl_pack_<src_type>_<dst_type>_<isa>(
   size_t m,           // Num. rows in input matrix
   size_t n,           // Num. columns in input matrix
   const <type>* src,  // Input matrix
@@ -26,15 +22,15 @@ void skl_pack_<src type>_<dst_type>_<isa>(
   size_t cs,          // Column stride of input matrix
   size_t m0,          // Num. rows in a block of the input matrix
   size_t n0,          // Num. columns in a block of the input matrix
-  <type>* dst,        // Output packed matrix [m1 x n1]
+  <type>* dst,        // Output packed matrix [m1 x n1 x (m0 x n0)]
   size_t rs0,         // Row stride within a block of the output matrix
   size_t cs0,         // Column stride within a block of the output matrix
   size_t rs1,         // Row stride between blocks of the output matrix
   size_t cs1,         // Column stride between blocks of the output matrix
-  <dst type> pad      // Value to insert for padded elements (usually 0)
+  <type> pad          // Value to insert for padded elements (usually 0)
 ) {
-  size_t m1 = (m + m0 - 1) / m0; // Num. row blocks in the input matrix
-  size_t n1 = (n + n0 - 1) / n0; // Num. column blocks in the input matrix
+  size_t m1 = (m + m0 - 1) / m0; // Num. block-rows in the input matrix
+  size_t n1 = (n + n0 - 1) / n0; // Num. block-columns in the input matrix
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
       const <type>* src_block = src + ii1 * m0 * rs + jj1 * n0 * cs;
@@ -44,7 +40,6 @@ void skl_pack_<src type>_<dst_type>_<isa>(
           if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
             dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0 * cs];
           } else {
-            // Pad with zeros
             dst_block[ii0 * rs0 + jj0 * cs0] = pad;
           }
         }
@@ -55,25 +50,21 @@ void skl_pack_<src type>_<dst_type>_<isa>(
 ```
 Unpacking functions work analogously.
 
-
 As in the case of GEMM kernels, most packing kernels will fully specialize or constrain most of the parameters, and they are thus omitted from the API.
 Usually, `m0`, `n0`, `rs0`, and `cs0` are all fixed by the target's layout, and indicated in the kernel's name as part of the datatype specifier of the output matrix.
 
 ### Naming Convention for Packing Kernels
 
-The name of the packing kernel indicates the block size and ISA extension required by the kernel, and whether it is required or optional.
-The general form is `skl_pack_<src type>_<dst type>_<isa>`.
+The name of the packing kernel indicates the block size and ISA extension required by the kernel.
+The general form is `skl_pack_<src_type>_<dst_type>_<isa>`.
 
 The datatype specifiers follow the same conventions as in the corresponding [GEMM kernels](../gemm/packed-gemm.md) in which the matrix will be used, except that only the element width is indicated, as the internal format is irrelevant to the packing implementation (e.g. `e32` is used rather than `f32`).
 
-Thus, the `<dst type>` term may further be broken down as `e<sew>[<outer-block-order>]p<m0>x<n0>[<inner-block-order>]`, where `m0` and `n0` are the block dimensions (rows and columns per block, respectively).
+Thus, the `<dst_type>` term may further be broken down as `e<sew>[<outer-block-order>]p<m0>x<n0>[<inner-block-order>]`, where `m0` and `n0` are the block dimensions.
 
-It is assumed by default that the ordering of elements within a block is fixed to be row-major.
+It is assumed by default that the ordering of elements within a block is row-major.
 If instead the layout within a block is column-major, the inner-block-order term is `c`, and if it may be either, `rc` is used.
 Similarly, the ordering of blocks relative to each other is assumed to be block-row-major, but if it is either block-column-major or configurable, then either `c` or `rc` is inserted, respectively, before the packing specifier `p`.
-
-When one of the dimensions is `1`, there is technically no difference in memory ordering between row- and column-major; however, the order is still said to be "column-major" when the second dimension is `1`, as this corresponds to the canonical layout of a column vector, and better communicates the transposition implied by the layout.
-Use of `1` for either block dimension effectively creates a block with one side of arbitrary size, referred to as a _panel_.
 
 > **Note**: As in other kernel families, the ISA suffix indicates the minimum requirement to execute the packing kernel itself (normally `zve32x`), but its primary intended use may be for a particular matrix extension. This is indicated in the documentation for each kernel (packing and GEMM).
 >
@@ -88,30 +79,30 @@ Several examples of packed layouts are shown below, with element types omitted.
 Original row-major matrix (8x4):        Packed layout [m0=4, n0=1, m1=2, n1=4]:
 
  0  1  2  3                             Block(0,0)  Block(0,1)  Block(0,2)  Block(0,3)
- 4  5  6  7                             ┌─────┐     ┌─────┐     ┌─────┐     ┌─────┐
- 8  9 10 11                             │  0  │     │  1  │     │  2  │     │  3  │
-12 13 14 15                             │  4  │     │  5  │     │  6  │     │  7  │
-16 17 18 19                             │  8  │     │  9  │     │ 10  │     │ 11  │
-20 21 22 23                             │ 12  │     │ 13  │     │ 14  │     │ 15  │
-24 25 26 27                             └─────┘     └─────┘     └─────┘     └─────┘
+ 4  5  6  7                             ┌────┐      ┌────┐      ┌────┐      ┌────┐
+ 8  9 10 11                             │  0 │      │  1 │      │  2 │      │  3 │
+12 13 14 15                             │  4 │      │  5 │      │  6 │      │  7 │
+16 17 18 19                             │  8 │      │  9 │      │ 10 │      │ 11 │
+20 21 22 23                             │ 12 │      │ 13 │      │ 14 │      │ 15 │
+24 25 26 27                             └────┘      └────┘      └────┘      └────┘
 28 29 30 31
                                         Block(1,0)  Block(1,1)  Block(1,2)  Block(1,3)
-                                        ┌─────┐     ┌─────┐     ┌─────┐     ┌─────┐
-                                        │ 16  │     │ 17  │     │ 18  │     │ 19  │
-                                        │ 20  │     │ 21  │     │ 22  │     │ 23  │
-                                        │ 24  │     │ 25  │     │ 26  │     │ 27  │
-                                        │ 28  │     │ 29  │     │ 30  │     │ 31  │
-                                        └─────┘     └─────┘     └─────┘     └─────┘
+                                        ┌────┐      ┌────┐      ┌────┐      ┌────┐
+                                        │ 16 │      │ 17 │      │ 18 │      │ 19 │
+                                        │ 20 │      │ 21 │      │ 22 │      │ 23 │
+                                        │ 24 │      │ 25 │      │ 26 │      │ 27 │
+                                        │ 28 │      │ 29 │      │ 30 │      │ 31 │
+                                        └────┘      └────┘      └────┘      └────┘
 
 Memory layout:
 [ 0, 4, 8,12,  1, 5, 9,13,  2, 6,10,14,  3, 7,11,15, 16,20,24,28, 17,21,25,29, ...]
  └Block(0,0)┘ └Block(0,1)┘ └Block(0,2)┘ └Block(0,3)┘ └Block(1,0)┘ └Block(1,1)┘
 
-Strides: rs0=1 (row stride within block), cs0=4 (column stride within block)
+Strides: rs0=1 (row stride within block), cs0 (unused, blocks have only 1 column)
          rs1=16 (row stride between blocks), cs1=4 (column stride between blocks)
 ```
 
-### Example: cp1x4 Block Layout (Block-Column-Major with Outer Transposition)
+### Example: cp1x4 Block Layout (Block-Column-Major/Outer Transposition)
 ```
 Original row-major matrix (4x8):        Packed layout [m0=1, n0=4, m1=4, n1=2]:
 
@@ -139,25 +130,25 @@ Memory layout:
 [ 0, 1, 2, 3,  8, 9,10,11, 16,17,18,19, 24,25,26,27,  4, 5, 6, 7, 12,13,14,15, ...]
  └Block(0,0)┘ └Block(1,0)┘ └Block(2,0)┘ └Block(3,0)┘ └Block(0,1)┘ └Block(1,1)┘
 
-Strides: rs0=4 (row stride within block), cs0=1 (column stride within block)
+Strides: rs0 (unused, blocks have only 1 row), cs0=1 (column stride within block)
          rs1=4 (row stride between blocks), cs1=16 (column stride between blocks)
 ```
 
-### Example: p2x2c Block Layout (Block-Row-Major with Column-Major Within Blocks)
+### Example: p2x2c Block Layout (Block-Row-Major with Column-Major Blocks)
 ```
 Original row-major matrix (4x4):        Packed layout [m0=2, n0=2, m1=2, n1=2]:
 
  0  1  2  3                             Block(0,0)  Block(0,1)
- 4  5  6  7                             ┌───────┐   ┌───────┐
- 8  9 10 11                             │ 0  4  │   │ 2  6  │
-12 13 14 15                             │ 1  5  │   │ 3  7  │
-                                        └───────┘   └───────┘
+ 4  5  6  7                             ┌──────┐    ┌──────┐
+ 8  9 10 11                             │ 0  1 │    │ 2  3 │
+12 13 14 15                             │ 4  5 │    │ 6  7 │
+                                        └──────┘    └──────┘
 
                                         Block(1,0)  Block(1,1)
-                                        ┌───────┐   ┌───────┐
-                                        │ 8 12  │   │10 14  │
-                                        │ 9 13  │   │11 15  │
-                                        └───────┘   └───────┘
+                                        ┌──────┐    ┌──────┐
+                                        │ 8  9 │    │10 11 │
+                                        │12 13 │    │14 15 │
+                                        └──────┘    └──────┘
 
 Memory layout:
 [ 0, 4, 1, 5,  2, 6, 3, 7,  8,12, 9,13, 10,14,11,15 ]
@@ -169,38 +160,36 @@ Strides: rs0=1 (row stride within block), cs0=2 (column stride within block)
 Note: This layout does not occur in any of the current SKL GEMM kernels.
 It is for illustrative purposes only.
 
-
-
 ## List of Packing Kernels
 
 ### Required Packing Kernels
 All of these kernels are required for correct operation of the corresponding GEMM kernels.
 
 #### Xsfvqdotq
-- `skl_pack_e8_e8rcp4x1c_zve32x`: Pack the B matrix into 4x1 panels (4x1 block-row-major example above) to use `sf.vqdot.vx` without reduction summation.
+- `skl_pack_e8_e8p4x1c_zve32x`: Pack the B matrix into 4xN panels (4x1 block-row-major example above) to use `sf.vqdot.vx` without reduction summation.
 
 #### Xsfvqmaccqoq
 These kernels are required for use of the `sf.vqmacc.4x8x4` instruction.
 Because of the small block size, significant specialization is required to achieve reasonable performance.
-- `skl_pack_e32_e32p4x4_zve32x`: Used for the C matrix.
+- `skl_pack_e32_e32p4x4_zve32x`: Used for the `C` matrix.
 - `skl_unpack_e32p4x4_e32_zve32x`: Inverse of `skl_pack_e32_e32p4x4_zve32x`.
-- `skl_pack_e8_e8p4x8_zve32x`: Used for the A matrix.
-- `skl_pack_e8_e8p8x4_zve32x`: Used for the B matrix.
+- `skl_pack_e8_e8p4x8_zve32x`: Used for the `A` matrix.
+- `skl_pack_e8_e8p8x4_zve32x`: Used for the `B` matrix.
 
 ### Optional Packing Kernels
 None of these are strictly required for correct operation of the corresponding GEMM kernels, but they may be useful for performance or compatibility reasons.
-(For Xsfmm, it is never required to pack any matrix; only [transposition](../transpose/README.md) is required if the A matrix is in row-major format, or B is in column-major format.)
-- `skl_pack_e8_e8ptex1c_xsfmmbase`: Transpose (TE x K) panels using the matrix engine. Used on a row-major A matrix or column-major B matrix.
+(For Xsfmm, it is never required to pack any matrix; only [transposition](../transpose/README.md) is required if the `A` matrix is in row-major format, or `B` is in column-major format.)
+- `skl_pack_e8_e8ptex1c_xsfmmbase`: Transpose (`TE` x `K`) panels using the matrix engine. Used on a row-major `A` matrix or column-major `B` matrix.
 
 ### Packing Kernels That Do Not Exist
 These names refer to kernels that users might expect to exist, but do not, because they can be implemented with an appropriate block size in the generic RVV packing kernel at reasonable performance.
 In general, so long as the block size is large enough in at least one dimension (as is the case in paneling), a generic packing kernel with a large enough vector length can achieve reasonable performance.
 
-- ~~`skl_pack_e8_e8rcp1xte_zve32x`~~: Pack (K x TE) panels. Used on a column-major A matrix or row-major B matrix.
-- ~~`skl_pack_e32_e32rcptexte_zve32x`~~: Pack (TE x TE) blocks without transposition. Used on a C matrix.
-- ~~`skl_pack_e8_e8cp1xvlm8_zve32x`~~: Pack (1 x VLMAX*8) column panels.
+- ~~`skl_pack_e8_e8cp1xte_zve32x`~~: Pack (`K` x `TE`) panels. Used on a column-major `A` matrix or row-major `B` matrix.
+- ~~`skl_pack_e32_e32rcptexte_zve32x`~~: Pack (`TE` x `TE`) blocks without transposition. Used on a `C` matrix.
+- ~~`skl_pack_e8_e8cp1xvlm8_zve32x`~~: Pack (`1` x `VLMAX*8`) column panels.
 
-In addition to being unnecessary for correct execution, these can all be implemented by supplying the machine-dependent dimension (TE or VLMAX) to the generic packing kernel.
+In addition to being unnecessary for correct execution, these can all be implemented by supplying the machine-dependent dimension (`TE` or `VLMAX`) to the generic packing kernel.
 
 ## Generic RVV Packing Kernel [**Future Work**]
 
@@ -208,4 +197,3 @@ The fully-general packing function described [above](#general-api-for-packing--u
 Specifically, if the input is row-major, the innermost loop can be vectorized, and if `cs0` is 1, unit-stride loads and stores can be used.
 So long as the block width `n0 * SEW` is at least as large as the machine data path width, no specialized optimizations should be required.
 **This implementation is not yet provided by SKL.**
-

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -51,7 +51,7 @@ void skl_pack_<src_type>_<dst_type>_<isa>(
 Unpacking functions work analogously.
 
 As in the case of GEMM kernels, most packing kernels will fully specialize or constrain most of the parameters, and they are thus omitted from the API.
-Usually, `m0`, `n0`, `rs0`, and `cs0` are all fixed by the target's layout, and indicated in the kernel's name as part of the datatype specifier of the output matrix.
+Usually, `m0`, `n0`, `rs0`, and `cs0` are all fixed by the target's layout and indicated in the kernel's name as part of the datatype specifier of the output matrix.
 
 ### Naming Convention for Packing Kernels
 
@@ -74,7 +74,7 @@ Similarly, the ordering of blocks relative to each other is assumed to be block-
 
 Several examples of packed layouts are shown below, with element types omitted.
 
-### Example: p4x1c Block Layout (Block-Row-Major with Inner Transposition)
+### Example: p4x1c Block Layout (Block-Row-Major with Column-Major Blocks)
 ```
 Original row-major matrix (8x4):        Packed layout [m0=4, n0=1, m1=2, n1=4]:
 
@@ -102,7 +102,7 @@ Strides: rs0=1 (row stride within block), cs0 (unused, blocks have only 1 column
          rs1=16 (row stride between blocks), cs1=4 (column stride between blocks)
 ```
 
-### Example: cp1x4 Block Layout (Block-Column-Major/Outer Transposition)
+### Example: cp1x4 Block Layout (Block-Column-Major)
 ```
 Original row-major matrix (4x8):        Packed layout [m0=1, n0=4, m1=4, n1=2]:
 
@@ -166,7 +166,7 @@ It is for illustrative purposes only.
 All of these kernels are required for correct operation of the corresponding GEMM kernels.
 
 #### Xsfvqdotq
-- `skl_pack_e8_e8p4x1c_zve32x`: Pack the B matrix into 4xN panels (4x1 block-row-major example above) to use `sf.vqdot.vx` without reduction summation.
+- `skl_pack_e8_e8p4x1c_zve32x`: Pack the `B` matrix into 4 x `N` panels (4 x 1 block-row-major example above) to use `sf.vqdot.vx` without reduction summation.
 
 #### Xsfvqmaccqoq
 These kernels are required for use of the `sf.vqmacc.4x8x4` instruction.

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -73,7 +73,7 @@ Use of `1` for either block dimension effectively creates a block with one side 
 
 > **Note**: As in other kernel families, the ISA suffix indicates the minimum requirement to execute the packing kernel itself (normally `zve32x`), but its primary intended use may be for a particular matrix extension. This is indicated in the documentation for each kernel (packing and GEMM).
 >
-> The `skl_pack_e8_e8ptex1c_xsfmm` function is an exception, as it uses the matrix engine to accelerate transposition within blocks.
+> The `skl_pack_e8_e8ptex1c_xsfmmbase` function is an exception, as it uses the matrix engine to accelerate transposition within blocks.
 
 ## Packing Layout Examples
 
@@ -186,7 +186,7 @@ Because of the small block size, significant specialization is required to achie
 ### Optional Packing Kernels
 None of these are strictly required for correct operation of the corresponding GEMM kernels, but they may be useful for performance or compatibility reasons.
 (For Xsfmm, it is never required to pack any matrix; only [transposition](../transpose/README.md) is required if the A matrix is in row-major format, or B is in column-major format.)
-- `skl_pack_e8_e8ptex1c_xsfmm`: Transpose (TE x K) panels using the matrix engine. Used on a row-major A matrix or column-major B matrix.
+- `skl_pack_e8_e8ptex1c_xsfmmbase`: Transpose (TE x K) panels using the matrix engine. Used on a row-major A matrix or column-major B matrix.
 
 ### Packing Kernels That Do Not Exist
 These names refer to kernels that users might expect to exist, but do not, because they can be implemented with an appropriate block size in the generic RVV packing kernel at reasonable performance.

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -5,7 +5,10 @@ It includes a set of packing and, when relevant, unpacking functions for each GE
 
 These routines reorder the elements of a 2D, row-major matrix of size `m` x `n` into a blocked layout where blocks of size `m0` x `n0` are stored contiguously, and padded with zeros if necessary, for a total of `m1` x `n1` blocks, where `m1 = ceil(m/m0)` and `n1 = ceil(n/n0)`.
 Depending on the requirements of the target ISA or application, the elements within each block may also be transposed, and the blocks themselves may be stored in row- or column-major order.
+
 When a matrix is packed along only one dimension and no transposition is implied, then the "packing" operation consists entirely of _padding_ the matrix to a multiple of the block size.
+For an `m` x `n` row-major array to be packed into `m0` x `n` blocks, no data reordering is required.
+However, if the array is packed into `m` x `n0`, data reordering occurs whenever `n0` < `n`.
 
 Not all extensions require packing for all matrices, but kernels for such cases may nevertheless be provided, as some applications may require similar layouts across all matrices, or seek locality benefits from arranging data in the shape of the underlying multiplication operation, or one of its dimensions.
 The documentation for each kernel indicates whether it is required or optional.

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -69,7 +69,7 @@ Similarly, the ordering of blocks relative to each other is assumed to be block-
 
 > **Note**: As in other kernel families, the ISA suffix indicates the minimum requirement to execute the packing kernel itself (normally `zve32x`), but its primary intended use may be for a particular matrix extension. This is indicated in the documentation for each kernel (packing and GEMM).
 >
-> The `skl_pack_e8_e8petex1c_xsfmmbase` function is an exception, as it uses the matrix engine to accelerate transposition within blocks.
+> The `skl_pack_e8_e8ptex1c_xsfmmbase` function is an exception, as it uses the matrix engine to accelerate transposition within blocks.
 
 ## Packing Layout Examples
 
@@ -177,18 +177,18 @@ Because of the small block size, significant specialization is required to achie
 ### Optional Packing Kernels
 None of these are strictly required for correct operation of the corresponding GEMM kernels, but they may be useful for performance or compatibility reasons.
 (For Xsfmm, it is never required to pack any matrix; only [transposition](../transpose/README.md) is required if the `A` matrix is in row-major format, or `B` is in column-major format.)
-- `skl_pack_e8_e8petex1c_xsfmmbase`: Transpose (`ETE` x `K`) panels using the matrix engine. Used on a row-major `A` matrix or column-major `B` matrix.
+- `skl_pack_e8_e8ptex1c_xsfmmbase`: Transpose (`TE` x `K`) panels using the matrix engine. Used on a row-major `A` matrix or column-major `B` matrix.
 
 ### Packing Kernels That Do Not Exist
 These names refer to kernels that users might expect to exist, but do not, because they can be implemented with an appropriate block size in the generic RVV packing kernel at reasonable performance.
 In general, so long as the block size is large enough in at least one dimension (as is the case in paneling), a generic packing kernel with a large enough vector length can achieve reasonable performance.
 
 - ~~`skl_pack_e8_e8p4x1c_zve32x`~~: Pack (4 x `N`) column-major row panels.
-- ~~`skl_pack_e8_e8cp1xete_zve32x`~~: Pack (`K` x `ETE`) panels. Used on a column-major `A` matrix or row-major `B` matrix.
-- ~~`skl_pack_e32_e32rcpetexete_zve32x`~~: Pack (`ETE` x `ETE`) blocks without transposition. Used on a `C` matrix.
+- ~~`skl_pack_e8_e8cp1xte_zve32x`~~: Pack (`K` x `TE`) panels. Used on a column-major `A` matrix or row-major `B` matrix.
+- ~~`skl_pack_e32_e32rcptexte_zve32x`~~: Pack (`TE` x `TE`) blocks without transposition. Used on a `C` matrix.
 - ~~`skl_pack_e8_e8cp1xvlm8_zve32x`~~: Pack (`K` x `VLMAX*8`) column panels.
 
-In addition to being unnecessary for correct execution, these can all be implemented by supplying the machine-dependent dimension (`ETE` or `VLMAX`) to the generic packing kernel.
+In addition to being unnecessary for correct execution, these can all be implemented by supplying the machine-dependent dimension (`TE` or `VLMAX`) to the generic packing kernel.
 
 ## Generic RVV Packing Kernel [**Future Work**]
 

--- a/src/pack/README.md
+++ b/src/pack/README.md
@@ -18,19 +18,20 @@ void skl_pack_<src_type>_<dst_type>_<isa>(
   size_t m,           // Num. rows in input matrix
   size_t n,           // Num. columns in input matrix
   const <type>* src,  // Input matrix
-  size_t rs,          // Row stride of input matrix
-  size_t cs,          // Column stride of input matrix
-  size_t m0,          // Num. rows in a block of the input matrix
-  size_t n0,          // Num. columns in a block of the input matrix
-  <type>* dst,        // Output packed matrix [m1 x n1 x (m0 x n0)]
-  size_t rs0,         // Row stride within a block of the output matrix
-  size_t cs0,         // Column stride within a block of the output matrix
-  size_t rs1,         // Row stride between blocks of the output matrix
-  size_t cs1,         // Column stride between blocks of the output matrix
+  size_t rs,          // Stride between rows of input matrix
+  size_t cs,          // Stride between columns of input matrix
+  size_t m0,          // Num. rows in a block of output matrix
+  size_t n0,          // Num. columns in a block of output matrix
+  <type>* dst,        // Packed output matrix
+                      // [ceil(m/m0) x ceil(n/n0) x (m0 x n0)]
+  size_t rs0,         // Row stride within a block of output matrix
+  size_t cs0,         // Column stride within a block of output matrix
+  size_t rs1,         // Row stride between blocks of output matrix
+  size_t cs1,         // Column stride between blocks of output matrix
   <type> pad          // Value to insert for padded elements (usually 0)
 ) {
-  size_t m1 = (m + m0 - 1) / m0; // Num. block-rows in the input matrix
-  size_t n1 = (n + n0 - 1) / n0; // Num. block-columns in the input matrix
+  size_t m1 = (m + m0 - 1) / m0; // Num. block-rows in output matrix
+  size_t n1 = (n + n0 - 1) / n0; // Num. block-columns in output matrix
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
       const <type>* src_block = src + ii1 * m0 * rs + jj1 * n0 * cs;
@@ -165,9 +166,6 @@ It is for illustrative purposes only.
 ### Required Packing Kernels
 All of these kernels are required for correct operation of the corresponding GEMM kernels.
 
-#### Xsfvqdotq
-- `skl_pack_e8_e8p4x1c_zve32x`: Pack the `B` matrix into 4 x `N` panels (4 x 1 block-row-major example above) to use `sf.vqdot.vx` without reduction summation.
-
 #### Xsfvqmaccqoq
 These kernels are required for use of the `sf.vqmacc.4x8x4` instruction.
 Because of the small block size, significant specialization is required to achieve reasonable performance.
@@ -185,9 +183,10 @@ None of these are strictly required for correct operation of the corresponding G
 These names refer to kernels that users might expect to exist, but do not, because they can be implemented with an appropriate block size in the generic RVV packing kernel at reasonable performance.
 In general, so long as the block size is large enough in at least one dimension (as is the case in paneling), a generic packing kernel with a large enough vector length can achieve reasonable performance.
 
+- ~~`skl_pack_e8_e8p4x1c_zve32x`~~: Pack (4 x `N`) column-major row panels.
 - ~~`skl_pack_e8_e8cp1xte_zve32x`~~: Pack (`K` x `TE`) panels. Used on a column-major `A` matrix or row-major `B` matrix.
 - ~~`skl_pack_e32_e32rcptexte_zve32x`~~: Pack (`TE` x `TE`) blocks without transposition. Used on a `C` matrix.
-- ~~`skl_pack_e8_e8cp1xvlm8_zve32x`~~: Pack (`1` x `VLMAX*8`) column panels.
+- ~~`skl_pack_e8_e8cp1xvlm8_zve32x`~~: Pack (`K` x `VLMAX*8`) column panels.
 
 In addition to being unnecessary for correct execution, these can all be implemented by supplying the machine-dependent dimension (`TE` or `VLMAX`) to the generic packing kernel.
 


### PR DESCRIPTION
Following discussion on https://github.com/sifive/skl/pull/64#issuecomment-4145894552, we agreed (@myeh01 @peichialin  @Harlen126 @france5289) to change the naming scheme for packing kernels and packed GEMMs. This PR updates the markdown documentation ([`packed-gemm.md`](https://github.com/sifive/skl/blob/main/src/gemm/packed-gemm.md) and [`pack/README.md`](https://github.com/sifive/skl/blob/main/src/pack/README.md)) to reflect the new conventions.

Specifically, the changes include:

1. Aligning both kernel families to indicate layout dimensions in matrix type specifiers
2. Adopting a unified type specifier format of `<type><sew>[rc]p<m0>x<n0>[rc]`
3. Conforming the `Xsfvqdotq` GEMM kernel API examples to `[k0, k1]` format, rather than arbitrary `k`

Note that this PR **does not implement the proposed changes** in the codebase; that will be done in forthcoming work by @myeh01 and @Harlen126 .  I had debated keeping this as a draft PR, but since there is no chance we'll update both code and READMEs atomically, I'm not sure it matters much.