### PR TITLE
[GEMM] Rename Xsfmm GEMM kernels

### DIFF
--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c
@@ -1306,7 +1306,7 @@ SKL_FUNC void skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f(
 }
 
 SKL_XSFMM_NEW
-SKL_FUNC void skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+SKL_FUNC void skl_gemm_a1b01_bf16ptex1c_bf16cp1xte_f32rcptexte_xsfmm32a16f(
     size_t m1, size_t n1, size_t k, const __bf16 *a_pack, size_t rsa1,
     const __bf16 *b_pack, size_t csb1, float *c_pack, size_t rsc1, size_t csc1,
     bool accum) {

--- a/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.h
@@ -91,7 +91,7 @@ void skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f(size_t m, size_t n, size_t k,
  * );
  * ```
  */
-void skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+void skl_gemm_a1b01_bf16ptex1c_bf16cp1xte_f32rcptexte_xsfmm32a16f(
     size_t m1, size_t n1, size_t k, const __bf16 *a_pack, size_t rsa1,
     const __bf16 *b_pack, size_t csb1, float *c_pack, size_t rsc1, size_t csc1,
     bool accum);

--- a/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.c
@@ -1304,7 +1304,7 @@ SKL_FUNC void skl_gemm_a1b01_f16c_f16_f32_xsfmm32a16f(
 }
 
 SKL_XSFMM_NEW
-SKL_FUNC void skl_gemm_a1b01_f16pc_f16cp_f32rcp_xsfmm32a16f(
+SKL_FUNC void skl_gemm_a1b01_f16ptex1c_f16cp1xte_f32rcptexte_xsfmm32a16f(
     size_t m1, size_t n1, size_t k, const _Float16 *a_pack, size_t rsa1,
     const _Float16 *b_pack, size_t csb1, float *c_pack, size_t rsc1,
     size_t csc1, bool accum) {

--- a/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f16c_f16_f32_xsfmm32a16f.h
@@ -90,7 +90,7 @@ void skl_gemm_a1b01_f16c_f16_f32_xsfmm32a16f(size_t m, size_t n, size_t k,
  * );
  * ```
  */
-void skl_gemm_a1b01_f16pc_f16cp_f32rcp_xsfmm32a16f(
+void skl_gemm_a1b01_f16ptex1c_f16cp1xte_f32rcptexte_xsfmm32a16f(
     size_t m1, size_t n1, size_t k, const _Float16 *a_pack, size_t rsa1,
     const _Float16 *b_pack, size_t csb1, float *c_pack, size_t rsc1,
     size_t csc1, bool accum);

--- a/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c
@@ -949,7 +949,7 @@ SKL_FUNC void skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f(
 }
 
 SKL_XSFMM_NEW
-SKL_FUNC void skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f(
+SKL_FUNC void skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f(
     size_t m1, size_t n1, size_t k, const float *a_pack, size_t rsa1,
     const float *b_pack, size_t csb1, float *c_pack, size_t rsc1, size_t csc1,
     bool accum) {

--- a/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.h
@@ -88,7 +88,7 @@ void skl_gemm_a1b01_f32c_f32_f32_xsfmm32a32f(size_t m, size_t n, size_t k,
  * );
  * ```
  */
-void skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f(
+void skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f(
     size_t m1, size_t n1, size_t k, const float *a_pack, size_t rsa1,
     const float *b_pack, size_t csb1, float *c_pack, size_t rsc1, size_t csc1,
     bool accum);

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -2414,7 +2414,7 @@ SKL_FUNC void skl_gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(
 }
 
 SKL_XSFMM_NEW
-SKL_FUNC void skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
+SKL_FUNC void skl_gemm_a1b01_f8e4m3ptex1c_f8e4m3cp1xte_f32rcptexte_xsfmm32a8f(
     size_t m1, size_t n1, size_t k, const uint8_t *a_pack, size_t rsa1,
     const uint8_t *b_pack, size_t csb1, float *c_pack, size_t rsc1, size_t csc1,
     bool accum) {

--- a/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.h
@@ -94,7 +94,7 @@ void skl_gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f(size_t m, size_t n, size_t k,
  * );
  * ```
  */
-void skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
+void skl_gemm_a1b01_f8e4m3ptex1c_f8e4m3cp1xte_f32rcptexte_xsfmm32a8f(
     size_t m1, size_t n1, size_t k, const uint8_t *a_pack, size_t rsa1,
     const uint8_t *b_pack, size_t csb1, float *c_pack, size_t rsc1, size_t csc1,
     bool accum);

--- a/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
@@ -2414,7 +2414,7 @@ SKL_FUNC void skl_gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f(
 }
 
 SKL_XSFMM_NEW
-SKL_FUNC void skl_gemm_a1b01_f8e5m2pc_f8e5m2cp_f32rcp_xsfmm32a8f(
+SKL_FUNC void skl_gemm_a1b01_f8e5m2ptex1c_f8e5m2cp1xte_f32rcptexte_xsfmm32a8f(
     size_t m1, size_t n1, size_t k, const uint8_t *a_pack, size_t rsa1,
     const uint8_t *b_pack, size_t csb1, float *c_pack, size_t rsc1, size_t csc1,
     bool accum) {

--- a/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.h
+++ b/src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.h
@@ -94,7 +94,7 @@ void skl_gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f(size_t m, size_t n, size_t k,
  * );
  * ```
  */
-void skl_gemm_a1b01_f8e5m2pc_f8e5m2cp_f32rcp_xsfmm32a8f(
+void skl_gemm_a1b01_f8e5m2ptex1c_f8e5m2cp1xte_f32rcptexte_xsfmm32a8f(
     size_t m1, size_t n1, size_t k, const uint8_t *a_pack, size_t rsa1,
     const uint8_t *b_pack, size_t csb1, float *c_pack, size_t rsc1, size_t csc1,
     bool accum);

--- a/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
+++ b/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c
@@ -2414,7 +2414,7 @@ SKL_FUNC void skl_gemm_a1b01_i8c_i8_i32_xsfmm32a8i(size_t m, size_t n, size_t k,
 }
 
 SKL_XSFMM_NEW
-SKL_FUNC void skl_gemm_a1b01_i8pc_i8cp_i32rcp_xsfmm32a8i(
+SKL_FUNC void skl_gemm_a1b01_i8ptex1c_i8cp1xte_i32rcptexte_xsfmm32a8i(
     size_t m1, size_t n1, size_t k, const int8_t *a_pack, size_t rsa1,
     const int8_t *b_pack, size_t csb1, int32_t *c_pack, size_t rsc1,
     size_t csc1, bool accum) {

--- a/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.h
+++ b/src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.h
@@ -91,7 +91,7 @@ void skl_gemm_a1b01_i8c_i8_i32_xsfmm32a8i(size_t m, size_t n, size_t k,
  * );
  * ```
  */
-void skl_gemm_a1b01_i8pc_i8cp_i32rcp_xsfmm32a8i(
+void skl_gemm_a1b01_i8ptex1c_i8cp1xte_i32rcptexte_xsfmm32a8i(
     size_t m1, size_t n1, size_t k, const int8_t *a_pack, size_t rsa1,
     const int8_t *b_pack, size_t csb1, int32_t *c_pack, size_t rsc1,
     size_t csc1, bool accum);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -277,9 +277,9 @@ skl_add_test(
   ""
 )
 skl_add_test(
-  skl_gemm_a1b01_f16pc_f16cp_f32rcp_xsfmm32a16f
+  skl_gemm_a1b01_f16ptex1c_f16cp1xte_f32rcptexte_xsfmm32a16f
   gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
-  gemm/xsfmm/skl_gemm_a1b01_f16pc_f16cp_f32rcp_xsfmm32a16f.c
+  gemm/xsfmm/skl_gemm_a1b01_f16ptex1c_f16cp1xte_f32rcptexte_xsfmm32a16f.c
   "xsfmm32a16f"
   ""
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -298,9 +298,9 @@ skl_add_test(
   ""
 )
 skl_add_test(
-  skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f
+  skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f
   gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
-  gemm/xsfmm/skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f.c
+  gemm/xsfmm/skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f.c
   "xsfmm32a32f"
   ""
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -228,9 +228,9 @@ skl_add_test(
   ""
 )
 skl_add_test(
-  skl_gemm_a1b01_f8e5m2pc_f8e5m2cp_f32rcp_xsfmm32a8f
+  skl_gemm_a1b01_f8e5m2ptex1c_f8e5m2cp1xte_f32rcptexte_xsfmm32a8f
   gemm/gemm_f8rcprc_f8rcprc_f32rcprc.c
-  gemm/xsfmm/skl_gemm_a1b01_f8e5m2pc_f8e5m2cp_f32rcp_xsfmm32a8f.c
+  gemm/xsfmm/skl_gemm_a1b01_f8e5m2ptex1c_f8e5m2cp1xte_f32rcptexte_xsfmm32a8f.c
   "xsfmm32a8f"
   ""
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -249,9 +249,9 @@ skl_add_test(
   ""
 )
 skl_add_test(
-  skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f
+  skl_gemm_a1b01_bf16ptex1c_bf16cp1xte_f32rcptexte_xsfmm32a16f
   gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
-  gemm/xsfmm/skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f.c
+  gemm/xsfmm/skl_gemm_a1b01_bf16ptex1c_bf16cp1xte_f32rcptexte_xsfmm32a16f.c
   "xsfmm32a16f"
   ""
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -200,9 +200,9 @@ skl_add_test(
   ""
 )
 skl_add_test(
-  skl_gemm_a1b01_i8pc_i8cp_i32rcp_xsfmm32a8i
+  skl_gemm_a1b01_i8ptex1c_i8cp1xte_i32rcptexte_xsfmm32a8i
   gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
-  gemm/xsfmm/skl_gemm_a1b01_i8pc_i8cp_i32rcp_xsfmm32a8i.c
+  gemm/xsfmm/skl_gemm_a1b01_i8ptex1c_i8cp1xte_i32rcptexte_xsfmm32a8i.c
   "xsfmm32a8i"
   ""
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -214,9 +214,9 @@ skl_add_test(
   ""
 )
 skl_add_test(
-  skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f
+  skl_gemm_a1b01_f8e4m3ptex1c_f8e4m3cp1xte_f32rcptexte_xsfmm32a8f
   gemm/gemm_f8rcprc_f8rcprc_f32rcprc.c
-  gemm/xsfmm/skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f.c
+  gemm/xsfmm/skl_gemm_a1b01_f8e4m3ptex1c_f8e4m3cp1xte_f32rcptexte_xsfmm32a8f.c
   "xsfmm32a8f"
   ""
 )

--- a/test/gemm/xsfmm/skl_gemm_a1b01_bf16ptex1c_bf16cp1xte_f32rcptexte_xsfmm32a16f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_bf16ptex1c_bf16cp1xte_f32rcptexte_xsfmm32a16f.c
@@ -14,8 +14,8 @@
 #endif
 
 /**
- * @brief Test cases for the skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f
- * kernel.
+ * @brief Test cases for the
+ * skl_gemm_a1b01_bf16ptex1c_bf16cp1xte_f32rcptexte_xsfmm32a16f kernel.
  *
  * This test uses the gemm_bf16rcprc_bf16rcprc_f32rcprc harness with the
  * following restrictions on the input parameters:
@@ -183,7 +183,7 @@ gemm_bf16rcprc_bf16rcprc_f32rcprc_t tests[] = {
 // clang-format on
 
 static skl_test_suite_t suite = {
-    .name = "skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f",
+    .name = "skl_gemm_a1b01_bf16ptex1c_bf16cp1xte_f32rcptexte_xsfmm32a16f",
     .num_tests = sizeof(tests) / sizeof(tests[0]),
     .test_size = sizeof(gemm_bf16rcprc_bf16rcprc_f32rcprc_t),
     .tests = tests};
@@ -212,7 +212,7 @@ static void execute(skl_test_t *t) {
   const gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
       (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
 
-  skl_gemm_a1b01_bf16pc_bf16cp_f32rcp_xsfmm32a16f(
+  skl_gemm_a1b01_bf16ptex1c_bf16cp1xte_f32rcptexte_xsfmm32a16f(
       h->m1, h->n1, h->k1, h->a_pack.data, h->rsa1, h->b_pack.data, h->csb1,
       h->c_pack.data, h->rsc1, h->csc1, h->beta != 0.f);
 }

--- a/test/gemm/xsfmm/skl_gemm_a1b01_bf16ptex1c_bf16cp1xte_f32rcptexte_xsfmm32a16f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_bf16ptex1c_bf16cp1xte_f32rcptexte_xsfmm32a16f.c
@@ -14,8 +14,7 @@
 #endif
 
 /**
- * @brief Test cases for the
- * skl_gemm_a1b01_bf16ptex1c_bf16cp1xte_f32rcptexte_xsfmm32a16f kernel.
+ * @brief Test cases for GEMM with Xsfmm32a16f extension.
  *
  * This test uses the gemm_bf16rcprc_bf16rcprc_f32rcprc harness with the
  * following restrictions on the input parameters:

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f16ptex1c_f16cp1xte_f32rcptexte_xsfmm32a16f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f16ptex1c_f16cp1xte_f32rcptexte_xsfmm32a16f.c
@@ -15,8 +15,8 @@
 #endif
 
 /**
- * @brief Test cases for the skl_gemm_a1b01_f16pc_f16cp_f32rcp_xsfmm32a16f
- * kernel.
+ * @brief Test cases for the
+ * skl_gemm_a1b01_f16ptex1c_f16cp1xte_f32rcptexte_xsfmm32a16f kernel.
  *
  * This test uses the gemm_f16rcprc_f16rcprc_f32rcprc harness with the following
  * restrictions on the input parameters:
@@ -184,7 +184,7 @@ gemm_f16rcprc_f16rcprc_f32rcprc_t tests[] = {
 // clang-format on
 
 static skl_test_suite_t suite = {
-    .name = "skl_gemm_a1b01_f16pc_f16cp_f32rcp_xsfmm32a16f",
+    .name = "skl_gemm_a1b01_f16ptex1c_f16cp1xte_f32rcptexte_xsfmm32a16f",
     .num_tests = sizeof(tests) / sizeof(tests[0]),
     .test_size = sizeof(gemm_f16rcprc_f16rcprc_f32rcprc_t),
     .tests = tests};
@@ -213,7 +213,7 @@ static void execute(skl_test_t *t) {
   const gemm_f16rcprc_f16rcprc_f32rcprc_t *h =
       (gemm_f16rcprc_f16rcprc_f32rcprc_t *)t->harness;
 
-  skl_gemm_a1b01_f16pc_f16cp_f32rcp_xsfmm32a16f(
+  skl_gemm_a1b01_f16ptex1c_f16cp1xte_f32rcptexte_xsfmm32a16f(
       h->m1, h->n1, h->k1, h->a_pack.data, h->rsa1, h->b_pack.data, h->csb1,
       h->c_pack.data, h->rsc1, h->csc1, h->beta != 0.f);
 }

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f16ptex1c_f16cp1xte_f32rcptexte_xsfmm32a16f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f16ptex1c_f16cp1xte_f32rcptexte_xsfmm32a16f.c
@@ -15,8 +15,7 @@
 #endif
 
 /**
- * @brief Test cases for the
- * skl_gemm_a1b01_f16ptex1c_f16cp1xte_f32rcptexte_xsfmm32a16f kernel.
+ * @brief Test cases for GEMM with Xsfmm32a16f extension.
  *
  * This test uses the gemm_f16rcprc_f16rcprc_f32rcprc harness with the following
  * restrictions on the input parameters:

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f.c
@@ -159,7 +159,7 @@ gemm_f32rcprc_f32rcprc_f32rcprc_t tests[] = {
 // clang-format on
 
 static skl_test_suite_t suite = {
-    .name = "skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f",
+    .name = "skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f",
     .num_tests = sizeof(tests) / sizeof(tests[0]),
     .test_size = sizeof(gemm_f32rcprc_f32rcprc_f32rcprc_t),
     .tests = tests};
@@ -191,7 +191,7 @@ static void execute(skl_test_t *t) {
   // Call the kernel with the appropriate parameters
   // The kernel signature is: (m1, n1, k, a_pack, rsa1, b_pack, csb1, c_pack,
   // rsc1, csc1, accum) where accum = (beta != 0)
-  skl_gemm_a1b01_f32pc_f32cp_f32rcp_xsfmm32a32f(
+  skl_gemm_a1b01_f32ptex1c_f32cp1xte_f32rcptexte_xsfmm32a32f(
       h->m1, h->n1, h->k1 * h->k0, h->a_pack.data, h->rsa1, h->b_pack.data,
       h->csb1, h->c_pack.data, h->rsc1, h->csc1, h->beta != 0.f);
 }

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f8e4m3ptex1c_f8e4m3cp1xte_f32rcptexte_xsfmm32a8f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f8e4m3ptex1c_f8e4m3cp1xte_f32rcptexte_xsfmm32a8f.c
@@ -230,7 +230,7 @@ gemm_f8rcprc_f8rcprc_f32rcprc_t tests[] = {
 // clang-format on
 
 static skl_test_suite_t suite = {
-    .name = "skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f",
+    .name = "skl_gemm_a1b01_f8e4m3ptex1c_f8e4m3cp1xte_f32rcptexte_xsfmm32a8f",
     .num_tests = sizeof(tests) / sizeof(tests[0]),
     .test_size = sizeof(gemm_f8rcprc_f8rcprc_f32rcprc_t),
     .tests = tests};
@@ -262,7 +262,7 @@ static void execute(skl_test_t *t) {
   // Call the kernel with the appropriate parameters
   // The kernel signature is: (m1, n1, k, a_pack, rsa1, b_pack, csb1, c_pack,
   // rsc1, csc1, accum) where accum = (beta != 0)
-  skl_gemm_a1b01_f8e4m3pc_f8e4m3cp_f32rcp_xsfmm32a8f(
+  skl_gemm_a1b01_f8e4m3ptex1c_f8e4m3cp1xte_f32rcptexte_xsfmm32a8f(
       h->m1, h->n1, h->k1 * h->k0, h->a_pack.data, h->rsa1, h->b_pack.data,
       h->csb1, h->c_pack.data, h->rsc1, h->csc1, h->beta != 0.f);
 }

--- a/test/gemm/xsfmm/skl_gemm_a1b01_f8e5m2ptex1c_f8e5m2cp1xte_f32rcptexte_xsfmm32a8f.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_f8e5m2ptex1c_f8e5m2cp1xte_f32rcptexte_xsfmm32a8f.c
@@ -230,7 +230,7 @@ gemm_f8rcprc_f8rcprc_f32rcprc_t tests[] = {
 // clang-format on
 
 static skl_test_suite_t suite = {
-    .name = "skl_gemm_a1b01_f8e5m2pc_f8e5m2cp_f32rcp_xsfmm32a8f",
+    .name = "skl_gemm_a1b01_f8e5m2ptex1c_f8e5m2cp1xte_f32rcptexte_xsfmm32a8f",
     .num_tests = sizeof(tests) / sizeof(tests[0]),
     .test_size = sizeof(gemm_f8rcprc_f8rcprc_f32rcprc_t),
     .tests = tests};
@@ -262,7 +262,7 @@ static void execute(skl_test_t *t) {
   // Call the kernel with the appropriate parameters
   // The kernel signature is: (m1, n1, k, a_pack, rsa1, b_pack, csb1, c_pack,
   // rsc1, csc1, accum) where accum = (beta != 0)
-  skl_gemm_a1b01_f8e5m2pc_f8e5m2cp_f32rcp_xsfmm32a8f(
+  skl_gemm_a1b01_f8e5m2ptex1c_f8e5m2cp1xte_f32rcptexte_xsfmm32a8f(
       h->m1, h->n1, h->k1 * h->k0, h->a_pack.data, h->rsa1, h->b_pack.data,
       h->csb1, h->c_pack.data, h->rsc1, h->csc1, h->beta != 0.f);
 }

--- a/test/gemm/xsfmm/skl_gemm_a1b01_i8ptex1c_i8cp1xte_i32rcptexte_xsfmm32a8i.c
+++ b/test/gemm/xsfmm/skl_gemm_a1b01_i8ptex1c_i8cp1xte_i32rcptexte_xsfmm32a8i.c
@@ -230,7 +230,7 @@ gemm_i8rcprc_i8rcprc_i32rcprc_t tests[] = {
 // clang-format on
 
 static skl_test_suite_t suite = {
-    .name = "skl_gemm_a1b01_i8pc_i8cp_i32rcp_xsfmm32a8i",
+    .name = "skl_gemm_a1b01_i8ptex1c_i8cp1xte_i32rcptexte_xsfmm32a8i",
     .num_tests = sizeof(tests) / sizeof(tests[0]),
     .test_size = sizeof(gemm_i8rcprc_i8rcprc_i32rcprc_t),
     .tests = tests};
@@ -262,7 +262,7 @@ static void execute(skl_test_t *t) {
   // Call the kernel with the appropriate parameters
   // The kernel signature is: (m1, n1, k, a_pack, rsa1, b_pack, csb1, c_pack,
   // rsc1, csc1, accum) where accum = (beta != 0)
-  skl_gemm_a1b01_i8pc_i8cp_i32rcp_xsfmm32a8i(
+  skl_gemm_a1b01_i8ptex1c_i8cp1xte_i32rcptexte_xsfmm32a8i(
       h->m1, h->n1, h->k1 * h->k0, h->a_pack.data, h->rsa1, h->b_pack.data,
       h->csb1, h->c_pack.data, h->rsc1, h->csc1, h->beta != 0);
 }


### PR DESCRIPTION
This PR renames the relevant GEMM and packing kernels according to #105:
- The public packed Xsfmm kernels have been renamed: `skl_gemm_a1b01_?pc_?cp_?rcp_xsfmm32a? -> skl_gemm_a1b01_?ptex1c_?cp1xte_?rcptexte_xsfmm32a?`.
- The private Xsfmm kernels have not been renamed since they will be substantially revised in #14.
- The corresponding Xsfmm test harnesses that have been converted to the new format have been renamed.