### PR TITLE
[Pack] Add RVV-based 16-bit & 32-bit Pack Kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ add_skl_src(src/logistic/logistic_f32_xsfvfexpa.c "xsfvfexpa")
 add_skl_src(src/logistic/logistic_f32_zve32f.c "zve32f")
 
 add_skl_src(src/pack/rvv/skl_pack_e16_zve32x.c "zve32x")
+add_skl_src(src/pack/rvv/skl_pack_e32_zve32x.c "zve32x")
 add_skl_src(src/pack/rvv/skl_pack_e8_zve32x.c "zve32x")
 
 add_skl_src(src/silu/silu_f16_xsfvfexp16e.c "xsfvfexp16e")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ add_skl_src(src/logistic/logistic_f32_xsfvfexp32e.c "xsfvfexp32e")
 add_skl_src(src/logistic/logistic_f32_xsfvfexpa.c "xsfvfexpa")
 add_skl_src(src/logistic/logistic_f32_zve32f.c "zve32f")
 
+add_skl_src(src/pack/rvv/skl_pack_e16_zve32x.c "zve32x")
 add_skl_src(src/pack/rvv/skl_pack_e8_zve32x.c "zve32x")
 
 add_skl_src(src/silu/silu_f16_xsfvfexp16e.c "xsfvfexp16e")

--- a/include/skl-ref.h
+++ b/include/skl-ref.h
@@ -88,6 +88,7 @@
  * Pack Kernels
  */
 
+#include "../ref/pack/pack_e16rc_e16rcprc.h"
 #include "../ref/pack/pack_e8rc_e8rcprc.h"
 
 // IWYU pragma: end_exports

--- a/include/skl-ref.h
+++ b/include/skl-ref.h
@@ -89,6 +89,7 @@
  */
 
 #include "../ref/pack/pack_e16rc_e16rcprc.h"
+#include "../ref/pack/pack_e32rc_e32rcprc.h"
 #include "../ref/pack/pack_e8rc_e8rcprc.h"
 
 // IWYU pragma: end_exports

--- a/include/skl.h
+++ b/include/skl.h
@@ -265,6 +265,7 @@
  */
 #if defined(__riscv_zve32x)
 #include "../src/pack/rvv/skl_pack_e16_zve32x.h"
+#include "../src/pack/rvv/skl_pack_e32_zve32x.h"
 #include "../src/pack/rvv/skl_pack_e8_zve32x.h"
 #endif
 

--- a/include/skl.h
+++ b/include/skl.h
@@ -264,6 +264,7 @@
  * Pack Kernels
  */
 #if defined(__riscv_zve32x)
+#include "../src/pack/rvv/skl_pack_e16_zve32x.h"
 #include "../src/pack/rvv/skl_pack_e8_zve32x.h"
 #endif
 

--- a/ref/CMakeLists.txt
+++ b/ref/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(skl-ref
     logistic/logistic_f16.c
     logistic/logistic_f32.c
     pack/pack_e16rc_e16rcprc.c
+    pack/pack_e32rc_e32rcprc.c
     pack/pack_e8rc_e8rcprc.c
     silu/silu_f16.c
     silu/silu_f32.c

--- a/ref/CMakeLists.txt
+++ b/ref/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(skl-ref
     logistic/logistic_bf16.c
     logistic/logistic_f16.c
     logistic/logistic_f32.c
+    pack/pack_e16rc_e16rcprc.c
     pack/pack_e8rc_e8rcprc.c
     silu/silu_f16.c
     silu/silu_f32.c

--- a/ref/pack/pack_e16rc_e16rcprc.c
+++ b/ref/pack/pack_e16rc_e16rcprc.c
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#include "skl-common.h"
+#include <stddef.h>
+#include <stdint.h>
+
+SKL_FUNC void skl_pack_e16rc_e16rcprc_ref(size_t m, size_t n,
+                                          const uint16_t *SKL_RESTRICT src,
+                                          size_t rs, size_t cs, size_t m0,
+                                          size_t n0, uint16_t *SKL_RESTRICT dst,
+                                          size_t rs0, size_t cs0, size_t rs1,
+                                          size_t cs1, uint16_t pad) {
+  size_t m1 = (m + m0 - 1) / m0; // Num. block-rows in output matrix
+  size_t n1 = (n + n0 - 1) / n0; // Num. block-columns in output matrix
+
+  for (size_t ii1 = 0; ii1 < m1; ++ii1) {
+    for (size_t jj1 = 0; jj1 < n1; ++jj1) {
+      const uint16_t *src_block = src + ii1 * m0 * rs + jj1 * n0 * cs;
+      uint16_t *dst_block = dst + ii1 * rs1 + jj1 * cs1;
+
+      for (size_t ii0 = 0; ii0 < m0; ++ii0) {
+        for (size_t jj0 = 0; jj0 < n0; ++jj0) {
+          if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
+            dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0 * cs];
+          } else {
+            // Pad with zeros
+            dst_block[ii0 * rs0 + jj0 * cs0] = pad;
+          }
+        }
+      }
+    }
+  }
+}

--- a/ref/pack/pack_e16rc_e16rcprc.c
+++ b/ref/pack/pack_e16rc_e16rcprc.c
@@ -26,7 +26,6 @@ SKL_FUNC void skl_pack_e16rc_e16rcprc_ref(size_t m, size_t n,
           if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
             dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0 * cs];
           } else {
-            // Pad with zeros
             dst_block[ii0 * rs0 + jj0 * cs0] = pad;
           }
         }

--- a/ref/pack/pack_e16rc_e16rcprc.h
+++ b/ref/pack/pack_e16rc_e16rcprc.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference implementation for packing an 16-bit 2D matrix into a 4D
+ * @brief Reference implementation for packing a 16-bit 2D matrix into a 4D
  * blocked matrix layout.
  *
  * @param m - Num. rows in input matrix

--- a/ref/pack/pack_e16rc_e16rcprc.h
+++ b/ref/pack/pack_e16rc_e16rcprc.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "skl-common.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * @brief Reference implementation for packing an 16-bit 2D matrix into a 4D
+ * blocked matrix layout.
+ *
+ * @param m - Num. rows in input matrix
+ * @param n - Num. columns in input matrix
+ * @param src - Input matrix
+ * @param rs - Stride between rows of input matrix
+ * @param cs - Stride between columns of input matrix
+ * @param m0 - Num. rows in a block of output matrix
+ * @param n0 - Num. columns in a block of output matrix
+ * @param dst - Packed output matrix [ceil(m/m0) x ceil(n/n0) x (m0 x n0)]
+ * @param rs0 - Row stride within a block of output matrix
+ * @param cs0 - Column stride within a block of output matrix
+ * @param rs1 - Row stride between blocks of output matrix
+ * @param cs1 - Column stride between blocks of output matrix
+ * @param pad - Value to insert for padded elements (usually 0)
+ *
+ * Transforms a 2D matrix into a blocked 4D layout.
+ *
+ * The output layout consists of m1 × n1 blocks, where:
+ *   - m1 = ceil(m / m0) = (m + m0 - 1) / m0  (number of block-rows)
+ *   - n1 = ceil(n / n0) = (n + n0 - 1) / n0  (number of block-columns)
+ *
+ * Each block has dimensions m0 × n0. If m is not a multiple of m0 or n is not
+ * a multiple of n0, the incomplete blocks are padded with the specified padding
+ * value.
+ */
+void skl_pack_e16rc_e16rcprc_ref(size_t m, size_t n,
+                                 const uint16_t *SKL_RESTRICT src, size_t rs,
+                                 size_t cs, size_t m0, size_t n0,
+                                 uint16_t *SKL_RESTRICT dst, size_t rs0,
+                                 size_t cs0, size_t rs1, size_t cs1,
+                                 uint16_t pad);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif

--- a/ref/pack/pack_e32rc_e32rcprc.c
+++ b/ref/pack/pack_e32rc_e32rcprc.c
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#include "skl-common.h"
+#include <stddef.h>
+#include <stdint.h>
+
+SKL_FUNC void skl_pack_e32rc_e32rcprc_ref(size_t m, size_t n,
+                                          const uint32_t *SKL_RESTRICT src,
+                                          size_t rs, size_t cs, size_t m0,
+                                          size_t n0, uint32_t *SKL_RESTRICT dst,
+                                          size_t rs0, size_t cs0, size_t rs1,
+                                          size_t cs1, uint32_t pad) {
+  size_t m1 = (m + m0 - 1) / m0; // Num. block-rows in output matrix
+  size_t n1 = (n + n0 - 1) / n0; // Num. block-columns in output matrix
+
+  for (size_t ii1 = 0; ii1 < m1; ++ii1) {
+    for (size_t jj1 = 0; jj1 < n1; ++jj1) {
+      const uint32_t *src_block = src + ii1 * m0 * rs + jj1 * n0 * cs;
+      uint32_t *dst_block = dst + ii1 * rs1 + jj1 * cs1;
+
+      for (size_t ii0 = 0; ii0 < m0; ++ii0) {
+        for (size_t jj0 = 0; jj0 < n0; ++jj0) {
+          if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
+            dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0 * cs];
+          } else {
+            // Pad with zeros
+            dst_block[ii0 * rs0 + jj0 * cs0] = pad;
+          }
+        }
+      }
+    }
+  }
+}

--- a/ref/pack/pack_e32rc_e32rcprc.c
+++ b/ref/pack/pack_e32rc_e32rcprc.c
@@ -26,7 +26,6 @@ SKL_FUNC void skl_pack_e32rc_e32rcprc_ref(size_t m, size_t n,
           if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
             dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0 * cs];
           } else {
-            // Pad with zeros
             dst_block[ii0 * rs0 + jj0 * cs0] = pad;
           }
         }

--- a/ref/pack/pack_e32rc_e32rcprc.h
+++ b/ref/pack/pack_e32rc_e32rcprc.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "skl-common.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * @brief Reference implementation for packing an 32-bit 2D matrix into a 4D
+ * blocked matrix layout.
+ *
+ * @param m - Num. rows in input matrix
+ * @param n - Num. columns in input matrix
+ * @param src - Input matrix
+ * @param rs - Stride between rows of input matrix
+ * @param cs - Stride between columns of input matrix
+ * @param m0 - Num. rows in a block of output matrix
+ * @param n0 - Num. columns in a block of output matrix
+ * @param dst - Packed output matrix [ceil(m/m0) x ceil(n/n0) x (m0 x n0)]
+ * @param rs0 - Row stride within a block of output matrix
+ * @param cs0 - Column stride within a block of output matrix
+ * @param rs1 - Row stride between blocks of output matrix
+ * @param cs1 - Column stride between blocks of output matrix
+ * @param pad - Value to insert for padded elements (usually 0)
+ *
+ * Transforms a 2D matrix into a blocked 4D layout.
+ *
+ * The output layout consists of m1 × n1 blocks, where:
+ *   - m1 = ceil(m / m0) = (m + m0 - 1) / m0  (number of block-rows)
+ *   - n1 = ceil(n / n0) = (n + n0 - 1) / n0  (number of block-columns)
+ *
+ * Each block has dimensions m0 × n0. If m is not a multiple of m0 or n is not
+ * a multiple of n0, the incomplete blocks are padded with the specified padding
+ * value.
+ */
+void skl_pack_e32rc_e32rcprc_ref(size_t m, size_t n,
+                                 const uint32_t *SKL_RESTRICT src, size_t rs,
+                                 size_t cs, size_t m0, size_t n0,
+                                 uint32_t *SKL_RESTRICT dst, size_t rs0,
+                                 size_t cs0, size_t rs1, size_t cs1,
+                                 uint32_t pad);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif

--- a/ref/pack/pack_e32rc_e32rcprc.h
+++ b/ref/pack/pack_e32rc_e32rcprc.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference implementation for packing an 32-bit 2D matrix into a 4D
+ * @brief Reference implementation for packing a 32-bit 2D matrix into a 4D
  * blocked matrix layout.
  *
  * @param m - Num. rows in input matrix

--- a/ref/pack/pack_e8rc_e8rcprc.c
+++ b/ref/pack/pack_e8rc_e8rcprc.c
@@ -26,7 +26,6 @@ SKL_FUNC void skl_pack_e8rc_e8rcprc_ref(size_t m, size_t n,
           if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
             dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0 * cs];
           } else {
-            // Pad with zeros
             dst_block[ii0 * rs0 + jj0 * cs0] = pad;
           }
         }

--- a/src/pack/rvv/skl_pack_e16_zve32x.c
+++ b/src/pack/rvv/skl_pack_e16_zve32x.c
@@ -1256,7 +1256,6 @@ SKL_FUNC_PRIVATE void skl_pack_e16_e16rcprc_zve32x(
             if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
               dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0];
             } else {
-              // Pad with zeros
               dst_block[ii0 * rs0 + jj0 * cs0] = pad;
             }
           }
@@ -1290,7 +1289,6 @@ SKL_FUNC void skl_pack_e16rc_e16rcprc_zve32x(
             if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
               dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0 * cs];
             } else {
-              // Pad with zeros
               dst_block[ii0 * rs0 + jj0 * cs0] = pad;
             }
           }

--- a/src/pack/rvv/skl_pack_e16_zve32x.c
+++ b/src/pack/rvv/skl_pack_e16_zve32x.c
@@ -1,0 +1,1301 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#if !defined(__riscv_zve32x)
+#error This file requires the Zve32x extension
+#endif
+
+#include <riscv_vector.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "skl-common.h"
+
+SKL_FUNC_PRIVATE void skl_set_e16_zve32x(uint16_t *dst, uint16_t value,
+                                         size_t n) {
+  size_t vl = __riscv_vsetvl_e16m8(n);
+  vuint16m8_t v_value = __riscv_vmv_v_x_u16m8(value, vl);
+  __riscv_vse16_v_u16m8(dst, v_value, vl);
+  n -= vl;
+
+  while (n) {
+    dst += vl;
+    vl = __riscv_vsetvl_e16m8(n);
+    __riscv_vse16_v_u16m8(dst, v_value, vl);
+    n -= vl;
+  }
+}
+
+SKL_FUNC_PRIVATE void skl_copy_e16_zve32x(uint16_t *SKL_RESTRICT dst,
+                                          const uint16_t *SKL_RESTRICT src,
+                                          size_t n) {
+  size_t vl = 0;
+  for (size_t i = 0; i < n; i += vl) {
+    vl = __riscv_vsetvl_e16m8(n - i);
+    vuint16m8_t v_src = __riscv_vle16_v_u16m8(src + i, vl);
+    __riscv_vse16_v_u16m8(dst + i, v_src, vl);
+  }
+}
+
+/**
+ * @brief Set a 2D region of elements to a constant value.
+ *
+ * @param dst - Pointer to the start of the 2D region.
+ * @param rs - Row stride of the 2D region in elements.
+ * @param value - Value to set each element to.
+ * @param m - Number of rows in the 2D region.
+ * @param n - Number of columns in the 2D region.
+ *
+ * This function sets each element in the 2D region to the specified value.
+ */
+SKL_FUNC_PRIVATE void skl_set_2d_e16_zve32x(uint16_t *dst, size_t rs,
+                                            uint16_t value, size_t m,
+                                            size_t n) {
+  if (n == 0 || m == 0) {
+    return;
+  }
+  if (n == rs) {
+    skl_set_e16_zve32x(dst, value, n * m);
+    return;
+  }
+  if (n <= 8) {
+
+    vuint16m8_t pad_vec =
+        __riscv_vmv_v_x_u16m8(value, __riscv_vsetvlmax_e16m8());
+
+    switch (n) {
+    case 1: {
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m8(avl);
+        __riscv_vsse16_v_u16m8(dst, (ptrdiff_t)(rs * sizeof(uint16_t)), pad_vec,
+                               vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    case 2: {
+      vuint16m4x2_t pad_vec_group2 =
+          __riscv_vcreate_v_u16m4x2(__riscv_vget_v_u16m8_u16m4(pad_vec, 0),
+                                    __riscv_vget_v_u16m8_u16m4(pad_vec, 1));
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m4(avl);
+        __riscv_vssseg2e16_v_u16m4x2(dst, (ptrdiff_t)(rs * sizeof(uint16_t)),
+                                     pad_vec_group2, vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    case 3: {
+      vuint16m2x3_t pad_vec_group3 =
+          __riscv_vcreate_v_u16m2x3(__riscv_vget_v_u16m8_u16m2(pad_vec, 0),
+                                    __riscv_vget_v_u16m8_u16m2(pad_vec, 1),
+                                    __riscv_vget_v_u16m8_u16m2(pad_vec, 2));
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m2(avl);
+        __riscv_vssseg3e16_v_u16m2x3(dst, (ptrdiff_t)(rs * sizeof(uint16_t)),
+                                     pad_vec_group3, vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    case 4: {
+      vuint16m2x4_t pad_vec_group4 =
+          __riscv_vcreate_v_u16m2x4(__riscv_vget_v_u16m8_u16m2(pad_vec, 0),
+                                    __riscv_vget_v_u16m8_u16m2(pad_vec, 1),
+                                    __riscv_vget_v_u16m8_u16m2(pad_vec, 2),
+                                    __riscv_vget_v_u16m8_u16m2(pad_vec, 3));
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m2(avl);
+        __riscv_vssseg4e16_v_u16m2x4(dst, (ptrdiff_t)(rs * sizeof(uint16_t)),
+                                     pad_vec_group4, vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    case 5: {
+      vuint16m1x5_t pad_vec_group5 =
+          __riscv_vcreate_v_u16m1x5(__riscv_vget_v_u16m8_u16m1(pad_vec, 0),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 1),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 2),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 3),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 4));
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m1(avl);
+        __riscv_vssseg5e16_v_u16m1x5(dst, (ptrdiff_t)(rs * sizeof(uint16_t)),
+                                     pad_vec_group5, vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    case 6: {
+      vuint16m1x6_t pad_vec_group6 =
+          __riscv_vcreate_v_u16m1x6(__riscv_vget_v_u16m8_u16m1(pad_vec, 0),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 1),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 2),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 3),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 4),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 5));
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m1(avl);
+        __riscv_vssseg6e16_v_u16m1x6(dst, (ptrdiff_t)(rs * sizeof(uint16_t)),
+                                     pad_vec_group6, vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    case 7: {
+      vuint16m1x7_t pad_vec_group7 =
+          __riscv_vcreate_v_u16m1x7(__riscv_vget_v_u16m8_u16m1(pad_vec, 0),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 1),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 2),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 3),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 4),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 5),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 6));
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m1(avl);
+        __riscv_vssseg7e16_v_u16m1x7(dst, (ptrdiff_t)(rs * sizeof(uint16_t)),
+                                     pad_vec_group7, vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    case 8: {
+      vuint16m1x8_t pad_vec_group8 =
+          __riscv_vcreate_v_u16m1x8(__riscv_vget_v_u16m8_u16m1(pad_vec, 0),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 1),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 2),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 3),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 4),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 5),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 6),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 7));
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m1(avl);
+        __riscv_vssseg8e16_v_u16m1x8(dst, (ptrdiff_t)(rs * sizeof(uint16_t)),
+                                     pad_vec_group8, vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    default:
+      break;
+    }
+  } else {
+    for (size_t i = 0; i < m; ++i) {
+      skl_set_e16_zve32x(dst, value, n);
+      dst += rs;
+    }
+  }
+}
+
+SKL_FUNC_PRIVATE void
+skl_copy_2d_e16_zve32x(size_t m, size_t n, const uint16_t *SKL_RESTRICT a,
+                       size_t rsa, uint16_t *SKL_RESTRICT b, size_t rsb) {
+  if (rsa == n && rsb == n) {
+    skl_copy_e16_zve32x(b, a, m * n);
+    return;
+  }
+  for (size_t i = 0; i < m; ++i) {
+    skl_copy_e16_zve32x(b + i * rsb, a + i * rsa, n);
+  }
+}
+
+/* Transposes an M x N row-major matrix (pointed by `a`) to an N x M row-major
+ * matrix (pointed by `at`) with vectorization along the M dimension.
+ */
+SKL_FUNC_PRIVATE void
+skl_transpose_mvec_e16_zve32x(size_t m, size_t n,
+                              const uint16_t *SKL_RESTRICT a, size_t rsa,
+                              uint16_t *SKL_RESTRICT at, size_t rsat) {
+
+  size_t vl = 0;
+  size_t n_multiple_8 = n / 8 * 8;
+  const ptrdiff_t input_seg_bstride = (ptrdiff_t)(rsa * sizeof(uint16_t));
+
+  if (n_multiple_8) {
+    for (size_t ii = 0; ii + 7 < n_multiple_8; ii += 8) {
+      // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+      vuint16m1x8_t vcols = __riscv_vundefined_u16m1x8();
+      // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+      const uint16_t *in_tile = a + ii;
+      uint16_t *out_tile = at + ii * rsat;
+      for (size_t jj = 0; jj < m; jj += vl) {
+        vl = __riscv_vsetvl_e16m1(m - jj);
+
+        if (rsa == 8) {
+          vcols = __riscv_vlseg8e16_v_u16m1x8(in_tile, vl);
+        } else {
+          vcols = __riscv_vlsseg8e16_v_u16m1x8(in_tile, input_seg_bstride, vl);
+        }
+
+        uint16_t *write_ptr = out_tile;
+        // store each segment continuously along m
+        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 0),
+                              vl);
+        write_ptr += rsat;
+        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 1),
+                              vl);
+        write_ptr += rsat;
+        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 2),
+                              vl);
+        write_ptr += rsat;
+        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 3),
+                              vl);
+        write_ptr += rsat;
+        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 4),
+                              vl);
+        write_ptr += rsat;
+        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 5),
+                              vl);
+        write_ptr += rsat;
+        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 6),
+                              vl);
+        write_ptr += rsat;
+        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 7),
+                              vl);
+
+        in_tile += vl * rsa;
+        out_tile += vl;
+      }
+    }
+  }
+
+  const uint16_t *in_tile = a + n_multiple_8;
+  uint16_t *out_tile = at + n_multiple_8 * rsat;
+
+  switch (n % 8) {
+  case 1: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m8_t vcol = __riscv_vundefined_u16m8();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e16m8(m - jj);
+
+      vcol = __riscv_vlse16_v_u16m8(in_tile, input_seg_bstride, vl);
+
+      // store extently along m
+      __riscv_vse16_v_u16m8(out_tile, vcol, vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+    break;
+  }
+  case 2: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m4x2_t vcols = __riscv_vundefined_u16m4x2();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e16m4(m - jj);
+
+      if (rsa == 2) {
+        vcols = __riscv_vlseg2e16_v_u16m4x2(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg2e16_v_u16m4x2(in_tile, input_seg_bstride, vl);
+      }
+
+      uint16_t *write_ptr = out_tile;
+      // store each segment extently along m
+      __riscv_vse16_v_u16m4(write_ptr, __riscv_vget_v_u16m4x2_u16m4(vcols, 0),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m4(write_ptr, __riscv_vget_v_u16m4x2_u16m4(vcols, 1),
+                            vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+    break;
+  }
+  case 3: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m2x3_t vcols = __riscv_vundefined_u16m2x3();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e16m2(m - jj);
+
+      if (rsa == 3) {
+        vcols = __riscv_vlseg3e16_v_u16m2x3(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg3e16_v_u16m2x3(in_tile, input_seg_bstride, vl);
+      }
+
+      uint16_t *write_ptr = out_tile;
+      // store each segment extently along m
+      __riscv_vse16_v_u16m2(write_ptr, __riscv_vget_v_u16m2x3_u16m2(vcols, 0),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m2(write_ptr, __riscv_vget_v_u16m2x3_u16m2(vcols, 1),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m2(write_ptr, __riscv_vget_v_u16m2x3_u16m2(vcols, 2),
+                            vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+    break;
+  }
+  case 4: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m2x4_t vcols = __riscv_vundefined_u16m2x4();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e16m2(m - jj);
+
+      if (rsa == 4) {
+        vcols = __riscv_vlseg4e16_v_u16m2x4(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg4e16_v_u16m2x4(in_tile, input_seg_bstride, vl);
+      }
+
+      uint16_t *write_ptr = out_tile;
+      // store each segment extently along m
+      __riscv_vse16_v_u16m2(write_ptr, __riscv_vget_v_u16m2x4_u16m2(vcols, 0),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m2(write_ptr, __riscv_vget_v_u16m2x4_u16m2(vcols, 1),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m2(write_ptr, __riscv_vget_v_u16m2x4_u16m2(vcols, 2),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m2(write_ptr, __riscv_vget_v_u16m2x4_u16m2(vcols, 3),
+                            vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+    break;
+  }
+  case 5: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m1x5_t vcols = __riscv_vundefined_u16m1x5();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e16m1(m - jj);
+
+      if (rsa == 5) {
+        vcols = __riscv_vlseg5e16_v_u16m1x5(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg5e16_v_u16m1x5(in_tile, input_seg_bstride, vl);
+      }
+
+      uint16_t *write_ptr = out_tile;
+      // store each segment extently along m
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x5_u16m1(vcols, 0),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x5_u16m1(vcols, 1),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x5_u16m1(vcols, 2),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x5_u16m1(vcols, 3),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x5_u16m1(vcols, 4),
+                            vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+    break;
+  }
+  case 6: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m1x6_t vcols = __riscv_vundefined_u16m1x6();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e16m1(m - jj);
+
+      if (rsa == 6) {
+        vcols = __riscv_vlseg6e16_v_u16m1x6(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg6e16_v_u16m1x6(in_tile, input_seg_bstride, vl);
+      }
+
+      uint16_t *write_ptr = out_tile;
+      // store each segment extently along m
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x6_u16m1(vcols, 0),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x6_u16m1(vcols, 1),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x6_u16m1(vcols, 2),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x6_u16m1(vcols, 3),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x6_u16m1(vcols, 4),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x6_u16m1(vcols, 5),
+                            vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+    break;
+  }
+  case 7: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m1x7_t vcols = __riscv_vundefined_u16m1x7();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e16m1(m - jj);
+
+      if (rsa == 7) {
+        vcols = __riscv_vlseg7e16_v_u16m1x7(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg7e16_v_u16m1x7(in_tile, input_seg_bstride, vl);
+      }
+
+      uint16_t *write_ptr = out_tile;
+      // store each segment extently along m
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x7_u16m1(vcols, 0),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x7_u16m1(vcols, 1),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x7_u16m1(vcols, 2),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x7_u16m1(vcols, 3),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x7_u16m1(vcols, 4),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x7_u16m1(vcols, 5),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x7_u16m1(vcols, 6),
+                            vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+    break;
+  }
+  default:
+    break;
+  }
+}
+
+/* Transposes an M x N row-major matrix (pointed by `a`) to an N x M row-major
+ * matrix (pointed by `at`) with vectorization along the N dimension.
+ */
+SKL_FUNC_PRIVATE void
+skl_transpose_nvec_e16_zve32x(size_t m, size_t n,
+                              const uint16_t *SKL_RESTRICT a, size_t rsa,
+                              uint16_t *SKL_RESTRICT at, size_t rsat) {
+
+  size_t vl = 0;
+  size_t m_align8 = m / 8 * 8;
+  const ptrdiff_t output_seg_bstride = (ptrdiff_t)(rsat * sizeof(uint16_t));
+
+  if (m_align8) {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m1_t vrow0 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow1 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow2 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow3 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow4 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow5 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow6 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow7 = __riscv_vundefined_u16m1();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t ii = 0; ii + 7 < m_align8; ii += 8) {
+      for (size_t jj = 0; jj < n; jj += vl) {
+        const uint16_t *read_ptr = a + ii * rsa + jj;
+        vl = __riscv_vsetvl_e16m1(n - jj);
+
+        vrow0 = __riscv_vle16_v_u16m1(read_ptr, vl);
+        read_ptr += rsa;
+        vrow1 = __riscv_vle16_v_u16m1(read_ptr, vl);
+        read_ptr += rsa;
+        vrow2 = __riscv_vle16_v_u16m1(read_ptr, vl);
+        read_ptr += rsa;
+        vrow3 = __riscv_vle16_v_u16m1(read_ptr, vl);
+        read_ptr += rsa;
+        vrow4 = __riscv_vle16_v_u16m1(read_ptr, vl);
+        read_ptr += rsa;
+        vrow5 = __riscv_vle16_v_u16m1(read_ptr, vl);
+        read_ptr += rsa;
+        vrow6 = __riscv_vle16_v_u16m1(read_ptr, vl);
+        read_ptr += rsa;
+        vrow7 = __riscv_vle16_v_u16m1(read_ptr, vl);
+
+        vuint16m1x8_t vrows = __riscv_vcreate_v_u16m1x8(
+            vrow0, vrow1, vrow2, vrow3, vrow4, vrow5, vrow6, vrow7);
+        if (rsat == 8) {
+          __riscv_vsseg8e16_v_u16m1x8(at + (jj * rsat) + ii, vrows, vl);
+        } else {
+          __riscv_vssseg8e16_v_u16m1x8(at + (jj * rsat) + ii,
+                                       output_seg_bstride, vrows, vl);
+        }
+      }
+    }
+  }
+
+  const uint16_t *in_tile = a + m_align8 * rsa;
+  uint16_t *out_tile = at + m_align8;
+
+  switch (m % 8) {
+  case 1: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m8_t vrow = __riscv_vundefined_u16m8();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+    for (size_t jj = 0; jj < n; jj += vl) {
+      vl = __riscv_vsetvl_e16m8(n - jj);
+      vrow = __riscv_vle16_v_u16m8(in_tile, vl);
+      __riscv_vsse16_v_u16m8(out_tile, output_seg_bstride, vrow, vl);
+
+      in_tile += vl;
+      out_tile += vl * rsat;
+    }
+    break;
+  }
+  case 2: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m4_t vrow0 = __riscv_vundefined_u16m4();
+    vuint16m4_t vrow1 = __riscv_vundefined_u16m4();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < n; jj += vl) {
+      vl = __riscv_vsetvl_e16m4(n - jj);
+      const uint16_t *read_ptr = in_tile;
+      vrow0 = __riscv_vle16_v_u16m4(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle16_v_u16m4(read_ptr, vl);
+      vuint16m4x2_t vrows = __riscv_vcreate_v_u16m4x2(vrow0, vrow1);
+      if (rsat == 2) {
+        __riscv_vsseg2e16_v_u16m4x2(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg2e16_v_u16m4x2(out_tile, output_seg_bstride, vrows, vl);
+      }
+      in_tile += vl;
+      out_tile += vl * rsat;
+    }
+    break;
+  }
+  case 3: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m2_t vrow0 = __riscv_vundefined_u16m2();
+    vuint16m2_t vrow1 = __riscv_vundefined_u16m2();
+    vuint16m2_t vrow2 = __riscv_vundefined_u16m2();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < n; jj += vl) {
+      vl = __riscv_vsetvl_e16m2(n - jj);
+      const uint16_t *read_ptr = in_tile;
+      vrow0 = __riscv_vle16_v_u16m2(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle16_v_u16m2(read_ptr, vl);
+      read_ptr += rsa;
+      vrow2 = __riscv_vle16_v_u16m2(read_ptr, vl);
+      vuint16m2x3_t vrows = __riscv_vcreate_v_u16m2x3(vrow0, vrow1, vrow2);
+      if (rsat == 3) {
+        __riscv_vsseg3e16_v_u16m2x3(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg3e16_v_u16m2x3(out_tile, output_seg_bstride, vrows, vl);
+      }
+      in_tile += vl;
+      out_tile += vl * rsat;
+    }
+    break;
+  }
+  case 4: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m2_t vrow0 = __riscv_vundefined_u16m2();
+    vuint16m2_t vrow1 = __riscv_vundefined_u16m2();
+    vuint16m2_t vrow2 = __riscv_vundefined_u16m2();
+    vuint16m2_t vrow3 = __riscv_vundefined_u16m2();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < n; jj += vl) {
+      vl = __riscv_vsetvl_e16m2(n - jj);
+      const uint16_t *read_ptr = in_tile;
+      vrow0 = __riscv_vle16_v_u16m2(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle16_v_u16m2(read_ptr, vl);
+      read_ptr += rsa;
+      vrow2 = __riscv_vle16_v_u16m2(read_ptr, vl);
+      read_ptr += rsa;
+      vrow3 = __riscv_vle16_v_u16m2(read_ptr, vl);
+      vuint16m2x4_t vrows =
+          __riscv_vcreate_v_u16m2x4(vrow0, vrow1, vrow2, vrow3);
+      if (rsat == 4) {
+        __riscv_vsseg4e16_v_u16m2x4(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg4e16_v_u16m2x4(out_tile, output_seg_bstride, vrows, vl);
+      }
+      in_tile += vl;
+      out_tile += vl * rsat;
+    }
+    break;
+  }
+  case 5: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m1_t vrow0 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow1 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow2 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow3 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow4 = __riscv_vundefined_u16m1();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < n; jj += vl) {
+      vl = __riscv_vsetvl_e16m1(n - jj);
+      const uint16_t *read_ptr = in_tile;
+      vrow0 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow2 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow3 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow4 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      vuint16m1x5_t vrows =
+          __riscv_vcreate_v_u16m1x5(vrow0, vrow1, vrow2, vrow3, vrow4);
+      if (rsat == 5) {
+        __riscv_vsseg5e16_v_u16m1x5(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg5e16_v_u16m1x5(out_tile, output_seg_bstride, vrows, vl);
+      }
+      in_tile += vl;
+      out_tile += vl * rsat;
+    }
+    break;
+  }
+  case 6: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m1_t vrow0 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow1 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow2 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow3 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow4 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow5 = __riscv_vundefined_u16m1();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < n; jj += vl) {
+      vl = __riscv_vsetvl_e16m1(n - jj);
+      const uint16_t *read_ptr = in_tile;
+      vrow0 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow2 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow3 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow4 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow5 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      vuint16m1x6_t vrows =
+          __riscv_vcreate_v_u16m1x6(vrow0, vrow1, vrow2, vrow3, vrow4, vrow5);
+      if (rsat == 6) {
+        __riscv_vsseg6e16_v_u16m1x6(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg6e16_v_u16m1x6(out_tile, output_seg_bstride, vrows, vl);
+      }
+      in_tile += vl;
+      out_tile += vl * rsat;
+    }
+    break;
+  }
+  case 7: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m1_t vrow0 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow1 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow2 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow3 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow4 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow5 = __riscv_vundefined_u16m1();
+    vuint16m1_t vrow6 = __riscv_vundefined_u16m1();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < n; jj += vl) {
+      vl = __riscv_vsetvl_e16m1(n - jj);
+      const uint16_t *read_ptr = in_tile;
+      vrow0 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow2 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow3 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow4 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow5 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow6 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      vuint16m1x7_t vrows = __riscv_vcreate_v_u16m1x7(
+          vrow0, vrow1, vrow2, vrow3, vrow4, vrow5, vrow6);
+      if (rsat == 7) {
+        __riscv_vsseg7e16_v_u16m1x7(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg7e16_v_u16m1x7(out_tile, output_seg_bstride, vrows, vl);
+      }
+      in_tile += vl;
+      out_tile += vl * rsat;
+    }
+    break;
+  }
+  default:
+    break;
+  }
+}
+
+SKL_FUNC_PRIVATE bool skl_transpose_e16_is_mvec(size_t m, size_t n) {
+  size_t vlmax = __riscv_vsetvlmax_e16m1();
+  if (m > n || m >= vlmax) {
+    return true;
+  }
+  return false;
+}
+
+SKL_FUNC_PRIVATE void
+skl_transpose_e16_zve32x(size_t m, size_t n, const uint16_t *SKL_RESTRICT a,
+                         size_t rsa, uint16_t *SKL_RESTRICT at, size_t rsat) {
+  if (skl_transpose_e16_is_mvec(m, n)) {
+    skl_transpose_mvec_e16_zve32x(m, n, a, rsa, at, rsat);
+  } else {
+    skl_transpose_nvec_e16_zve32x(m, n, a, rsa, at, rsat);
+  }
+}
+
+/**
+ * @brief Transpose a matrix and pad the output matrix with a constant value in
+ * the M dimension.
+ *
+ * @param m_padded - Number of columns in output matrix (Must be greater than or
+ * equal to m)
+ * @param m - Number of rows in input matrix
+ * @param n - Number of columns in input matrix and rows in output matrix.
+ * @param a - Pointer to input matrix
+ * @param rsa - Row stride of input matrix in elements.
+ * @param at - Pointer to output matrix.
+ * @param rsat - Row stride of output matrix in elements.
+ * @param pad - Value to use for padding.
+ *
+ * Transposes an m×n matrix and pads the transposed output in the M dimension.
+ *
+ * Transformation:
+ *   Input:  m×n matrix (m rows, n columns)
+ *   Output: n×m_padded matrix (n rows, m_padded columns), where m_padded >= m
+ */
+SKL_FUNC_PRIVATE void skl_transpose_padded_m_e16_zve32x(
+    size_t m_padded, size_t m, size_t n, const uint16_t *SKL_RESTRICT a,
+    size_t rsa, uint16_t *SKL_RESTRICT at, size_t rsat, uint16_t pad) {
+
+  if (m_padded == m) {
+    skl_transpose_e16_zve32x(m, n, a, rsa, at, rsat);
+    return;
+  }
+  size_t m_align8 = m / 8 * 8;
+  size_t m_ceil8 = (m + 7) / 8 * 8;
+  size_t m_mod8 = m % 8;
+
+  if (m_align8) {
+    skl_transpose_e16_zve32x(m_align8, n, a, rsa, at, rsat);
+  }
+  const uint16_t *in_tile = a + m_align8 * rsa;
+  uint16_t *out_tile = at + m_align8;
+  if (m_mod8) {
+    /* m_transition: Number of rows to process in the current tile (transpose +
+     * pad). Range: [2, 8]
+     *   - At least 2: minimum 1 remaining data row + 1 padding row
+     *   - At most 8: limited by tile size
+     */
+    size_t m_transition = m_padded - m_align8 > 8 ? 8 : m_padded - m_align8;
+    vuint16m8_t pad_vec = __riscv_vmv_v_x_u16m8(pad, __riscv_vsetvlmax_e16m8());
+
+    switch (m_transition) {
+    case 2: {
+      for (size_t vl = 0, avl = n; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m4(avl);
+        vuint16m4x2_t pad_vec_group2 =
+            __riscv_vcreate_v_u16m4x2(__riscv_vle16_v_u16m4(in_tile, vl),
+                                      __riscv_vget_v_u16m8_u16m4(pad_vec, 1));
+        if (rsat == 2) {
+          __riscv_vsseg2e16_v_u16m4x2(out_tile, pad_vec_group2, vl);
+        } else {
+          __riscv_vssseg2e16_v_u16m4x2(out_tile,
+                                       (ptrdiff_t)(rsat * sizeof(uint16_t)),
+                                       pad_vec_group2, vl);
+        }
+        in_tile += vl;
+        out_tile += vl * rsat;
+      }
+      break;
+    }
+    case 3: {
+      vuint16m2x3_t pad_vec_group3 =
+          __riscv_vcreate_v_u16m2x3(__riscv_vget_v_u16m8_u16m2(pad_vec, 0),
+                                    __riscv_vget_v_u16m8_u16m2(pad_vec, 1),
+                                    __riscv_vget_v_u16m8_u16m2(pad_vec, 2));
+      for (size_t vl = 0, avl = n; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m2(avl);
+        switch (m_mod8) {
+        case 2:
+          pad_vec_group3 = __riscv_vset_v_u16m2_u16m2x3(
+              pad_vec_group3, 1, __riscv_vle16_v_u16m2(in_tile + 1 * rsa, vl));
+          __attribute__((fallthrough));
+        case 1:
+          pad_vec_group3 = __riscv_vset_v_u16m2_u16m2x3(
+              pad_vec_group3, 0, __riscv_vle16_v_u16m2(in_tile, vl));
+          __attribute__((fallthrough));
+        default:
+          break;
+        }
+        if (rsat == 3) {
+          __riscv_vsseg3e16_v_u16m2x3(out_tile, pad_vec_group3, vl);
+        } else {
+          __riscv_vssseg3e16_v_u16m2x3(out_tile,
+                                       (ptrdiff_t)(rsat * sizeof(uint16_t)),
+                                       pad_vec_group3, vl);
+        }
+        in_tile += vl;
+        out_tile += vl * rsat;
+      }
+      break;
+    }
+    case 4: {
+      vuint16m2x4_t pad_vec_group4 =
+          __riscv_vcreate_v_u16m2x4(__riscv_vget_v_u16m8_u16m2(pad_vec, 0),
+                                    __riscv_vget_v_u16m8_u16m2(pad_vec, 1),
+                                    __riscv_vget_v_u16m8_u16m2(pad_vec, 2),
+                                    __riscv_vget_v_u16m8_u16m2(pad_vec, 3));
+      for (size_t vl = 0, avl = n; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m2(avl);
+        switch (m_mod8) {
+        case 3:
+          pad_vec_group4 = __riscv_vset_v_u16m2_u16m2x4(
+              pad_vec_group4, 2, __riscv_vle16_v_u16m2(in_tile + 2 * rsa, vl));
+          __attribute__((fallthrough));
+        case 2:
+          pad_vec_group4 = __riscv_vset_v_u16m2_u16m2x4(
+              pad_vec_group4, 1, __riscv_vle16_v_u16m2(in_tile + 1 * rsa, vl));
+          __attribute__((fallthrough));
+        case 1:
+          pad_vec_group4 = __riscv_vset_v_u16m2_u16m2x4(
+              pad_vec_group4, 0, __riscv_vle16_v_u16m2(in_tile, vl));
+          __attribute__((fallthrough));
+        default:
+          break;
+        }
+        if (rsat == 4) {
+          __riscv_vsseg4e16_v_u16m2x4(out_tile, pad_vec_group4, vl);
+        } else {
+          __riscv_vssseg4e16_v_u16m2x4(out_tile,
+                                       (ptrdiff_t)(rsat * sizeof(uint16_t)),
+                                       pad_vec_group4, vl);
+        }
+        in_tile += vl;
+        out_tile += vl * rsat;
+      }
+      break;
+    }
+    case 5: {
+      vuint16m1x5_t pad_vec_group5 =
+          __riscv_vcreate_v_u16m1x5(__riscv_vget_v_u16m8_u16m1(pad_vec, 0),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 1),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 2),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 3),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 4));
+      for (size_t vl = 0, avl = n; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m1(avl);
+        switch (m_mod8) {
+        case 4:
+          pad_vec_group5 = __riscv_vset_v_u16m1_u16m1x5(
+              pad_vec_group5, 3, __riscv_vle16_v_u16m1(in_tile + 3 * rsa, vl));
+          __attribute__((fallthrough));
+        case 3:
+          pad_vec_group5 = __riscv_vset_v_u16m1_u16m1x5(
+              pad_vec_group5, 2, __riscv_vle16_v_u16m1(in_tile + 2 * rsa, vl));
+          __attribute__((fallthrough));
+        case 2:
+          pad_vec_group5 = __riscv_vset_v_u16m1_u16m1x5(
+              pad_vec_group5, 1, __riscv_vle16_v_u16m1(in_tile + 1 * rsa, vl));
+          __attribute__((fallthrough));
+        case 1:
+          pad_vec_group5 = __riscv_vset_v_u16m1_u16m1x5(
+              pad_vec_group5, 0, __riscv_vle16_v_u16m1(in_tile, vl));
+          __attribute__((fallthrough));
+        default:
+          break;
+        }
+        if (rsat == 5) {
+          __riscv_vsseg5e16_v_u16m1x5(out_tile, pad_vec_group5, vl);
+        } else {
+          __riscv_vssseg5e16_v_u16m1x5(out_tile,
+                                       (ptrdiff_t)(rsat * sizeof(uint16_t)),
+                                       pad_vec_group5, vl);
+        }
+        in_tile += vl;
+        out_tile += vl * rsat;
+      }
+      break;
+    }
+    case 6: {
+      vuint16m1x6_t pad_vec_group6 =
+          __riscv_vcreate_v_u16m1x6(__riscv_vget_v_u16m8_u16m1(pad_vec, 0),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 1),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 2),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 3),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 4),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 5));
+      for (size_t vl = 0, avl = n; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m1(avl);
+        switch (m_mod8) {
+        case 5:
+          pad_vec_group6 = __riscv_vset_v_u16m1_u16m1x6(
+              pad_vec_group6, 4, __riscv_vle16_v_u16m1(in_tile + 4 * rsa, vl));
+          __attribute__((fallthrough));
+        case 4:
+          pad_vec_group6 = __riscv_vset_v_u16m1_u16m1x6(
+              pad_vec_group6, 3, __riscv_vle16_v_u16m1(in_tile + 3 * rsa, vl));
+          __attribute__((fallthrough));
+        case 3:
+          pad_vec_group6 = __riscv_vset_v_u16m1_u16m1x6(
+              pad_vec_group6, 2, __riscv_vle16_v_u16m1(in_tile + 2 * rsa, vl));
+          __attribute__((fallthrough));
+        case 2:
+          pad_vec_group6 = __riscv_vset_v_u16m1_u16m1x6(
+              pad_vec_group6, 1, __riscv_vle16_v_u16m1(in_tile + 1 * rsa, vl));
+          __attribute__((fallthrough));
+        case 1:
+          pad_vec_group6 = __riscv_vset_v_u16m1_u16m1x6(
+              pad_vec_group6, 0, __riscv_vle16_v_u16m1(in_tile, vl));
+          __attribute__((fallthrough));
+        default:
+          break;
+        }
+        if (rsat == 6) {
+          __riscv_vsseg6e16_v_u16m1x6(out_tile, pad_vec_group6, vl);
+        } else {
+          __riscv_vssseg6e16_v_u16m1x6(out_tile,
+                                       (ptrdiff_t)(rsat * sizeof(uint16_t)),
+                                       pad_vec_group6, vl);
+        }
+        in_tile += vl;
+        out_tile += vl * rsat;
+      }
+      break;
+    }
+    case 7: {
+      vuint16m1x7_t pad_vec_group7 =
+          __riscv_vcreate_v_u16m1x7(__riscv_vget_v_u16m8_u16m1(pad_vec, 0),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 1),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 2),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 3),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 4),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 5),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 6));
+      for (size_t vl = 0, avl = n; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m1(avl);
+        switch (m_mod8) {
+        case 6:
+          pad_vec_group7 = __riscv_vset_v_u16m1_u16m1x7(
+              pad_vec_group7, 5, __riscv_vle16_v_u16m1(in_tile + 5 * rsa, vl));
+          __attribute__((fallthrough));
+        case 5:
+          pad_vec_group7 = __riscv_vset_v_u16m1_u16m1x7(
+              pad_vec_group7, 4, __riscv_vle16_v_u16m1(in_tile + 4 * rsa, vl));
+          __attribute__((fallthrough));
+        case 4:
+          pad_vec_group7 = __riscv_vset_v_u16m1_u16m1x7(
+              pad_vec_group7, 3, __riscv_vle16_v_u16m1(in_tile + 3 * rsa, vl));
+          __attribute__((fallthrough));
+        case 3:
+          pad_vec_group7 = __riscv_vset_v_u16m1_u16m1x7(
+              pad_vec_group7, 2, __riscv_vle16_v_u16m1(in_tile + 2 * rsa, vl));
+          __attribute__((fallthrough));
+        case 2:
+          pad_vec_group7 = __riscv_vset_v_u16m1_u16m1x7(
+              pad_vec_group7, 1, __riscv_vle16_v_u16m1(in_tile + 1 * rsa, vl));
+          __attribute__((fallthrough));
+        case 1:
+          pad_vec_group7 = __riscv_vset_v_u16m1_u16m1x7(
+              pad_vec_group7, 0, __riscv_vle16_v_u16m1(in_tile, vl));
+          __attribute__((fallthrough));
+        default:
+          break;
+        }
+        if (rsat == 7) {
+          __riscv_vsseg7e16_v_u16m1x7(out_tile, pad_vec_group7, vl);
+        } else {
+          __riscv_vssseg7e16_v_u16m1x7(out_tile,
+                                       (ptrdiff_t)(rsat * sizeof(uint16_t)),
+                                       pad_vec_group7, vl);
+        }
+        in_tile += vl;
+        out_tile += vl * rsat;
+      }
+      break;
+    }
+    case 8: {
+      vuint16m1x8_t pad_vec_group8 =
+          __riscv_vcreate_v_u16m1x8(__riscv_vget_v_u16m8_u16m1(pad_vec, 0),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 1),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 2),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 3),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 4),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 5),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 6),
+                                    __riscv_vget_v_u16m8_u16m1(pad_vec, 7));
+      for (size_t vl = 0, avl = n; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e16m1(avl);
+        switch (m_mod8) {
+        case 7:
+          pad_vec_group8 = __riscv_vset_v_u16m1_u16m1x8(
+              pad_vec_group8, 6, __riscv_vle16_v_u16m1(in_tile + 6 * rsa, vl));
+          __attribute__((fallthrough));
+        case 6:
+          pad_vec_group8 = __riscv_vset_v_u16m1_u16m1x8(
+              pad_vec_group8, 5, __riscv_vle16_v_u16m1(in_tile + 5 * rsa, vl));
+          __attribute__((fallthrough));
+        case 5:
+          pad_vec_group8 = __riscv_vset_v_u16m1_u16m1x8(
+              pad_vec_group8, 4, __riscv_vle16_v_u16m1(in_tile + 4 * rsa, vl));
+          __attribute__((fallthrough));
+        case 4:
+          pad_vec_group8 = __riscv_vset_v_u16m1_u16m1x8(
+              pad_vec_group8, 3, __riscv_vle16_v_u16m1(in_tile + 3 * rsa, vl));
+          __attribute__((fallthrough));
+        case 3:
+          pad_vec_group8 = __riscv_vset_v_u16m1_u16m1x8(
+              pad_vec_group8, 2, __riscv_vle16_v_u16m1(in_tile + 2 * rsa, vl));
+          __attribute__((fallthrough));
+        case 2:
+          pad_vec_group8 = __riscv_vset_v_u16m1_u16m1x8(
+              pad_vec_group8, 1, __riscv_vle16_v_u16m1(in_tile + 1 * rsa, vl));
+          __attribute__((fallthrough));
+        case 1:
+          pad_vec_group8 = __riscv_vset_v_u16m1_u16m1x8(
+              pad_vec_group8, 0, __riscv_vle16_v_u16m1(in_tile, vl));
+          __attribute__((fallthrough));
+        default:
+          break;
+        }
+        if (rsat == 8) {
+          __riscv_vsseg8e16_v_u16m1x8(out_tile, pad_vec_group8, vl);
+        } else {
+          __riscv_vssseg8e16_v_u16m1x8(out_tile,
+                                       (ptrdiff_t)(rsat * sizeof(uint16_t)),
+                                       pad_vec_group8, vl);
+        }
+        in_tile += vl;
+        out_tile += vl * rsat;
+      }
+      break;
+    }
+    default:
+      break;
+    }
+  } // if (m_mod8)
+
+  if (m_padded > m_ceil8) {
+    out_tile = at + m_ceil8;
+    skl_set_2d_e16_zve32x(out_tile, rsat, pad, n, m_padded - m_ceil8);
+  }
+}
+
+SKL_FUNC_PRIVATE void skl_pack_e16_e16rcprc_zve32x(
+    size_t m, size_t n, const uint16_t *SKL_RESTRICT src, size_t rs, size_t m0,
+    size_t n0, uint16_t *SKL_RESTRICT dst, size_t rs0, size_t cs0, size_t rs1,
+    size_t cs1, uint16_t pad) {
+
+  // Handle division by zero
+  if (m0 == 0 || n0 == 0) {
+    return;
+  }
+
+  size_t m1 = (m + m0 - 1) / m0; // Num. block-rows in output matrix
+  size_t n1 = (n + n0 - 1) / n0; // Num. block-columns in output matrix
+
+  /* Column panels */
+  if (rs0 == 1 && n0 == 1) {
+    if (m0 == rs1) {
+      /* column-major block ordering */
+      skl_transpose_padded_m_e16_zve32x(m0 * m1, m, n, src, rs, dst, cs1, pad);
+    } else {
+      /* row-major block ordering */
+      const uint16_t *src_block = src;
+      uint16_t *dst_block = dst;
+      for (size_t ii1 = 0; ii1 < m1 - 1; ++ii1) {
+        skl_transpose_e16_zve32x(m0, n, src_block, rs, dst_block, cs1);
+        src_block += m0 * rs;
+        dst_block += rs1;
+      }
+      size_t m_tail = m - m0 * (m1 - 1);
+      skl_transpose_padded_m_e16_zve32x(m0, m_tail, n, src_block, rs, dst_block,
+                                        cs1, pad);
+    }
+    return;
+  }
+
+  /* intra-block: column-major, inter-block: row-major */
+  if ((cs0 * n0 == cs1) && rs0 == 1) {
+    const uint16_t *src_block = src;
+    uint16_t *dst_block = dst;
+    for (size_t ii1 = 0; ii1 < m1 - 1; ++ii1) {
+      skl_transpose_e16_zve32x(m0, n, src_block, rs, dst_block, cs0);
+      if (n % n0) {
+        // pad right
+        skl_set_2d_e16_zve32x(dst_block + cs1 * (n1 - 1) + cs0 * (n % n0), cs0,
+                              pad, n0 - n % n0, m0);
+      }
+      src_block += m0 * rs;
+      dst_block += rs1;
+    }
+    size_t m_tail = m - m0 * (m1 - 1);
+    skl_transpose_padded_m_e16_zve32x(m0, m_tail, n, src_block, rs, dst_block,
+                                      cs0, pad);
+    if (n % n0) {
+      // pad right
+      skl_set_2d_e16_zve32x(dst_block + cs1 * (n1 - 1) + cs0 * (n % n0), cs0,
+                            pad, n0 - n % n0, m0);
+    }
+    return;
+  }
+
+  /* Row panels */
+  if (cs0 == 1 && m0 == 1) {
+    if (n0 == cs1) {
+      /* row-major block ordering */
+      skl_copy_2d_e16_zve32x(m, n, src, rs, dst, rs1);
+      // pad right
+      if (n % n0) {
+        skl_set_2d_e16_zve32x(dst + n, rs1, pad, m, n0 - n % n0);
+      }
+
+    } else {
+      /* column-major block ordering */
+      const uint16_t *src_block = src;
+      uint16_t *dst_block = dst;
+
+      for (size_t jj1 = 0; jj1 < n1 - 1; ++jj1) {
+        skl_copy_2d_e16_zve32x(m, n0, src_block, rs, dst_block, rs1);
+        src_block += n0;
+        dst_block += cs1;
+      }
+      size_t n_tail = n - n0 * (n1 - 1);
+      skl_copy_2d_e16_zve32x(m, n_tail, src_block, rs, dst_block, rs1);
+      // pad right: pad (n0 - n_tail) elements in each of m rows
+      skl_set_2d_e16_zve32x(dst_block + n_tail, rs1, pad, m, n0 - n_tail);
+    }
+    return;
+  }
+
+  /* intra-block: row-major, inter-block: column-major */
+  if ((rs0 * m0 == rs1) && cs0 == 1) {
+    const uint16_t *src_block = src;
+    uint16_t *dst_block = dst;
+    for (size_t jj1 = 0; jj1 < n1 - 1; ++jj1) {
+      skl_copy_2d_e16_zve32x(m, n0, src_block, rs, dst_block, rs0);
+      if (m % m0) {
+        // pad bottom
+        skl_set_2d_e16_zve32x(dst_block + m * rs0, rs0, pad, m0 - m % m0, n0);
+      }
+      src_block += n0;
+      dst_block += cs1;
+    }
+    size_t n_tail = n - n0 * (n1 - 1);
+    skl_copy_2d_e16_zve32x(m, n_tail, src_block, rs, dst_block, rs0);
+    if (m % m0) {
+      // pad bottom
+      skl_set_2d_e16_zve32x(dst_block + m * rs0, rs0, pad, m0 - m % m0, n0);
+    }
+    // pad right: pad (n0 - n_tail) elements in each of m rows
+    skl_set_2d_e16_zve32x(dst_block + n_tail, rs0, pad, m, n0 - n_tail);
+    return;
+  }
+
+  for (size_t ii1 = 0; ii1 < m1; ++ii1) {
+    size_t m_length = m0 < m - ii1 * m0 ? m0 : m - ii1 * m0;
+    for (size_t jj1 = 0; jj1 < n1; ++jj1) {
+      const uint16_t *src_block = src + ii1 * m0 * rs + jj1 * n0;
+      uint16_t *dst_block = dst + ii1 * rs1 + jj1 * cs1;
+      size_t n_length = n0 < n - jj1 * n0 ? n0 : n - jj1 * n0;
+      if (rs0 == 1) {
+        skl_transpose_padded_m_e16_zve32x(m0, m_length, n_length, src_block, rs,
+                                          dst_block, cs0, pad);
+        // pad right
+        skl_set_2d_e16_zve32x(dst_block + cs0 * n_length, cs0, pad,
+                              n0 - n_length, m0);
+      } else if (cs0 == 1) {
+        skl_copy_2d_e16_zve32x(m_length, n_length, src_block, rs, dst_block,
+                               rs0);
+        // pad right: pad (n0 - n_length) elements in each of m_length rows
+        skl_set_2d_e16_zve32x(dst_block + n_length, rs0, pad, m_length,
+                              n0 - n_length);
+        // pad bottom: pad (m0 - m_length) rows, each with n0 elements
+        skl_set_2d_e16_zve32x(dst_block + m_length * rs0, rs0, pad,
+                              m0 - m_length, n0);
+      } else {
+        for (size_t ii0 = 0; ii0 < m0; ++ii0) {
+          for (size_t jj0 = 0; jj0 < n0; ++jj0) {
+            if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
+              dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0];
+            } else {
+              // Pad with zeros
+              dst_block[ii0 * rs0 + jj0 * cs0] = pad;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+SKL_FUNC void skl_pack_e16rc_e16rcprc_zve32x(
+    size_t m, size_t n, const uint16_t *SKL_RESTRICT src, size_t rs, size_t cs,
+    size_t m0, size_t n0, uint16_t *SKL_RESTRICT dst, size_t rs0, size_t cs0,
+    size_t rs1, size_t cs1, uint16_t pad) {
+
+  if (cs == 1) {
+    skl_pack_e16_e16rcprc_zve32x(m, n, src, rs, m0, n0, dst, rs0, cs0, rs1, cs1,
+                                 pad);
+  } else if (rs == 1) {
+    // When input is column-major (rs==1), transpose both dimensions and strides
+    skl_pack_e16_e16rcprc_zve32x(n, m, src, cs, n0, m0, dst, cs0, rs0, cs1, rs1,
+                                 pad);
+  } else {
+    size_t m1 = (m + m0 - 1) / m0; // Num. block-rows in output matrix
+    size_t n1 = (n + n0 - 1) / n0; // Num. block-columns in output matrix
+    for (size_t ii1 = 0; ii1 < m1; ++ii1) {
+      for (size_t jj1 = 0; jj1 < n1; ++jj1) {
+        const uint16_t *src_block = src + ii1 * m0 * rs + jj1 * n0 * cs;
+        uint16_t *dst_block = dst + ii1 * rs1 + jj1 * cs1;
+        for (size_t ii0 = 0; ii0 < m0; ++ii0) {
+          for (size_t jj0 = 0; jj0 < n0; ++jj0) {
+            if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
+              dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0 * cs];
+            } else {
+              // Pad with zeros
+              dst_block[ii0 * rs0 + jj0 * cs0] = pad;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/pack/rvv/skl_pack_e16_zve32x.c
+++ b/src/pack/rvv/skl_pack_e16_zve32x.c
@@ -18,14 +18,12 @@ SKL_FUNC_PRIVATE void skl_set_e16_zve32x(uint16_t *dst, uint16_t value,
                                          size_t n) {
   size_t vl = __riscv_vsetvl_e16m8(n);
   vuint16m8_t v_value = __riscv_vmv_v_x_u16m8(value, vl);
-  __riscv_vse16_v_u16m8(dst, v_value, vl);
-  n -= vl;
 
   while (n) {
-    dst += vl;
     vl = __riscv_vsetvl_e16m8(n);
     __riscv_vse16_v_u16m8(dst, v_value, vl);
     n -= vl;
+    dst += vl;
   }
 }
 
@@ -201,6 +199,58 @@ skl_copy_2d_e16_zve32x(size_t m, size_t n, const uint16_t *SKL_RESTRICT a,
   }
   for (size_t i = 0; i < m; ++i) {
     skl_copy_e16_zve32x(b + i * rsb, a + i * rsa, n);
+  }
+}
+
+/**
+ * @brief Copy a 2D matrix and pad the output matrix with a constant value in
+ * the N dimension.
+ *
+ * @param n_padded - Number of columns in output matrix
+ * @param m - Number of rows in input matrix and output matrix
+ * @param n - Number of columns in input matrix
+ * @param a - Pointer to input matrix
+ * @param rsa - Row stride of input matrix in elements.
+ * @param b - Pointer to output matrix.
+ * @param rsb - Row stride of output matrix in elements.
+ * @param pad - Value to use for padding.
+ *
+ */
+SKL_FUNC_PRIVATE void skl_copy_2d_padded_n_e16_zve32x(
+    size_t n_padded, size_t m, size_t n, const uint16_t *SKL_RESTRICT a,
+    size_t rsa, uint16_t *SKL_RESTRICT b, size_t rsb, uint16_t pad) {
+  if (n_padded == n) {
+    skl_copy_2d_e16_zve32x(m, n, a, rsa, b, rsb);
+    return;
+  }
+  /* Process N dimension in 3 parts:
+   * - head: Full vlmax-element chunks (direct copy)
+   * - transition: Partial vlmax chunk with data + padding
+   * - tail: Pure padding beyond transition
+   */
+  size_t vlmax = __riscv_vsetvlmax_e16m8();
+  size_t n_head = n / vlmax * vlmax;
+  if (n_head) {
+    skl_copy_2d_e16_zve32x(m, n_head, a, rsa, b, rsb);
+    a += n_head;
+    b += n_head;
+  }
+
+  size_t n_transition = 0;
+  if (n % vlmax) {
+    n_transition = n_padded - n_head > vlmax ? vlmax : n_padded - n_head;
+    vuint16m8_t pad_vec = __riscv_vmv_v_x_u16m8(pad, n_transition);
+    size_t n_load = n - n_head;
+    for (size_t i = 0; i < m; ++i) {
+      pad_vec = __riscv_vle16_v_u16m8_tu(pad_vec, a + i * rsa, n_load);
+      __riscv_vse16_v_u16m8(b + i * rsb, pad_vec, n_transition);
+    }
+    b += n_transition;
+  }
+
+  size_t n_tail = n_padded - n_head - n_transition;
+  if (n_tail) {
+    skl_set_2d_e16_zve32x(b, rsb, pad, m, n_tail);
   }
 }
 
@@ -1183,12 +1233,7 @@ SKL_FUNC_PRIVATE void skl_pack_e16_e16rcprc_zve32x(
   if (cs0 == 1 && m0 == 1) {
     if (n0 == cs1) {
       /* row-major block ordering */
-      skl_copy_2d_e16_zve32x(m, n, src, rs, dst, rs1);
-      // pad right
-      if (n % n0) {
-        skl_set_2d_e16_zve32x(dst + n, rs1, pad, m, n0 - n % n0);
-      }
-
+      skl_copy_2d_padded_n_e16_zve32x(n0 * n1, m, n, src, rs, dst, rs1, pad);
     } else {
       /* column-major block ordering */
       const uint16_t *src_block = src;
@@ -1200,9 +1245,8 @@ SKL_FUNC_PRIVATE void skl_pack_e16_e16rcprc_zve32x(
         dst_block += cs1;
       }
       size_t n_tail = n - n0 * (n1 - 1);
-      skl_copy_2d_e16_zve32x(m, n_tail, src_block, rs, dst_block, rs1);
-      // pad right: pad (n0 - n_tail) elements in each of m rows
-      skl_set_2d_e16_zve32x(dst_block + n_tail, rs1, pad, m, n0 - n_tail);
+      skl_copy_2d_padded_n_e16_zve32x(n0, m, n_tail, src_block, rs, dst_block,
+                                      rs1, pad);
     }
     return;
   }
@@ -1221,13 +1265,12 @@ SKL_FUNC_PRIVATE void skl_pack_e16_e16rcprc_zve32x(
       dst_block += cs1;
     }
     size_t n_tail = n - n0 * (n1 - 1);
-    skl_copy_2d_e16_zve32x(m, n_tail, src_block, rs, dst_block, rs0);
+    skl_copy_2d_padded_n_e16_zve32x(n0, m, n_tail, src_block, rs, dst_block,
+                                    rs0, pad);
     if (m % m0) {
       // pad bottom
       skl_set_2d_e16_zve32x(dst_block + m * rs0, rs0, pad, m0 - m % m0, n0);
     }
-    // pad right: pad (n0 - n_tail) elements in each of m rows
-    skl_set_2d_e16_zve32x(dst_block + n_tail, rs0, pad, m, n0 - n_tail);
     return;
   }
 
@@ -1244,11 +1287,8 @@ SKL_FUNC_PRIVATE void skl_pack_e16_e16rcprc_zve32x(
         skl_set_2d_e16_zve32x(dst_block + cs0 * n_length, cs0, pad,
                               n0 - n_length, m0);
       } else if (cs0 == 1) {
-        skl_copy_2d_e16_zve32x(m_length, n_length, src_block, rs, dst_block,
-                               rs0);
-        // pad right: pad (n0 - n_length) elements in each of m_length rows
-        skl_set_2d_e16_zve32x(dst_block + n_length, rs0, pad, m_length,
-                              n0 - n_length);
+        skl_copy_2d_padded_n_e16_zve32x(n0, m_length, n_length, src_block, rs,
+                                        dst_block, rs0, pad);
         // pad bottom: pad (m0 - m_length) rows, each with n0 elements
         skl_set_2d_e16_zve32x(dst_block + m_length * rs0, rs0, pad,
                               m0 - m_length, n0);

--- a/src/pack/rvv/skl_pack_e16_zve32x.c
+++ b/src/pack/rvv/skl_pack_e16_zve32x.c
@@ -1164,8 +1164,7 @@ SKL_FUNC_PRIVATE void skl_pack_e16_e16rcprc_zve32x(
       skl_transpose_e16_zve32x(m0, n, src_block, rs, dst_block, cs0);
       if (n % n0) {
         // pad right
-        skl_set_2d_e16_zve32x(dst_block + cs1 * (n1 - 1) + cs0 * (n % n0), cs0,
-                              pad, n0 - n % n0, m0);
+        skl_set_2d_e16_zve32x(dst_block + cs0 * n, cs0, pad, n0 - n % n0, m0);
       }
       src_block += m0 * rs;
       dst_block += rs1;
@@ -1175,8 +1174,7 @@ SKL_FUNC_PRIVATE void skl_pack_e16_e16rcprc_zve32x(
                                       cs0, pad);
     if (n % n0) {
       // pad right
-      skl_set_2d_e16_zve32x(dst_block + cs1 * (n1 - 1) + cs0 * (n % n0), cs0,
-                            pad, n0 - n % n0, m0);
+      skl_set_2d_e16_zve32x(dst_block + cs0 * n, cs0, pad, n0 - n % n0, m0);
     }
     return;
   }

--- a/src/pack/rvv/skl_pack_e16_zve32x.c
+++ b/src/pack/rvv/skl_pack_e16_zve32x.c
@@ -213,62 +213,13 @@ skl_transpose_mvec_e16_zve32x(size_t m, size_t n,
                               uint16_t *SKL_RESTRICT at, size_t rsat) {
 
   size_t vl = 0;
-  size_t n_multiple_8 = n / 8 * 8;
   const ptrdiff_t input_seg_bstride = (ptrdiff_t)(rsa * sizeof(uint16_t));
 
-  if (n_multiple_8) {
-    for (size_t ii = 0; ii + 7 < n_multiple_8; ii += 8) {
-      // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
-      vuint16m1x8_t vcols = __riscv_vundefined_u16m1x8();
-      // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+  const uint16_t *in_tile = a;
+  uint16_t *out_tile = at;
+  size_t n_mod8 = n % 8;
 
-      const uint16_t *in_tile = a + ii;
-      uint16_t *out_tile = at + ii * rsat;
-      for (size_t jj = 0; jj < m; jj += vl) {
-        vl = __riscv_vsetvl_e16m1(m - jj);
-
-        if (rsa == 8) {
-          vcols = __riscv_vlseg8e16_v_u16m1x8(in_tile, vl);
-        } else {
-          vcols = __riscv_vlsseg8e16_v_u16m1x8(in_tile, input_seg_bstride, vl);
-        }
-
-        uint16_t *write_ptr = out_tile;
-        // store each segment continuously along m
-        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 0),
-                              vl);
-        write_ptr += rsat;
-        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 1),
-                              vl);
-        write_ptr += rsat;
-        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 2),
-                              vl);
-        write_ptr += rsat;
-        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 3),
-                              vl);
-        write_ptr += rsat;
-        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 4),
-                              vl);
-        write_ptr += rsat;
-        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 5),
-                              vl);
-        write_ptr += rsat;
-        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 6),
-                              vl);
-        write_ptr += rsat;
-        __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 7),
-                              vl);
-
-        in_tile += vl * rsa;
-        out_tile += vl;
-      }
-    }
-  }
-
-  const uint16_t *in_tile = a + n_multiple_8;
-  uint16_t *out_tile = at + n_multiple_8 * rsat;
-
-  switch (n % 8) {
+  switch (n_mod8) {
   case 1: {
     // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
     vuint16m8_t vcol = __riscv_vundefined_u16m8();
@@ -494,6 +445,57 @@ skl_transpose_mvec_e16_zve32x(size_t m, size_t n,
   default:
     break;
   }
+
+  n -= n_mod8;
+  a += n_mod8;
+  at += n_mod8 * rsat;
+
+  for (size_t ii = 0; ii < n; ii += 8) {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint16m1x8_t vcols = __riscv_vundefined_u16m1x8();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    const uint16_t *in_tile = a + ii;
+    uint16_t *out_tile = at + ii * rsat;
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e16m1(m - jj);
+
+      if (rsa == 8) {
+        vcols = __riscv_vlseg8e16_v_u16m1x8(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg8e16_v_u16m1x8(in_tile, input_seg_bstride, vl);
+      }
+
+      uint16_t *write_ptr = out_tile;
+      // store each segment continuously along m
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 0),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 1),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 2),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 3),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 4),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 5),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 6),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse16_v_u16m1(write_ptr, __riscv_vget_v_u16m1x8_u16m1(vcols, 7),
+                            vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+  }
 }
 
 /* Transposes an M x N row-major matrix (pointed by `a`) to an N x M row-major
@@ -505,58 +507,13 @@ skl_transpose_nvec_e16_zve32x(size_t m, size_t n,
                               uint16_t *SKL_RESTRICT at, size_t rsat) {
 
   size_t vl = 0;
-  size_t m_align8 = m / 8 * 8;
   const ptrdiff_t output_seg_bstride = (ptrdiff_t)(rsat * sizeof(uint16_t));
 
-  if (m_align8) {
-    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
-    vuint16m1_t vrow0 = __riscv_vundefined_u16m1();
-    vuint16m1_t vrow1 = __riscv_vundefined_u16m1();
-    vuint16m1_t vrow2 = __riscv_vundefined_u16m1();
-    vuint16m1_t vrow3 = __riscv_vundefined_u16m1();
-    vuint16m1_t vrow4 = __riscv_vundefined_u16m1();
-    vuint16m1_t vrow5 = __riscv_vundefined_u16m1();
-    vuint16m1_t vrow6 = __riscv_vundefined_u16m1();
-    vuint16m1_t vrow7 = __riscv_vundefined_u16m1();
-    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+  size_t m_mod8 = m % 8;
+  const uint16_t *in_tile = a;
+  uint16_t *out_tile = at;
 
-    for (size_t ii = 0; ii + 7 < m_align8; ii += 8) {
-      for (size_t jj = 0; jj < n; jj += vl) {
-        const uint16_t *read_ptr = a + ii * rsa + jj;
-        vl = __riscv_vsetvl_e16m1(n - jj);
-
-        vrow0 = __riscv_vle16_v_u16m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow1 = __riscv_vle16_v_u16m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow2 = __riscv_vle16_v_u16m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow3 = __riscv_vle16_v_u16m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow4 = __riscv_vle16_v_u16m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow5 = __riscv_vle16_v_u16m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow6 = __riscv_vle16_v_u16m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow7 = __riscv_vle16_v_u16m1(read_ptr, vl);
-
-        vuint16m1x8_t vrows = __riscv_vcreate_v_u16m1x8(
-            vrow0, vrow1, vrow2, vrow3, vrow4, vrow5, vrow6, vrow7);
-        if (rsat == 8) {
-          __riscv_vsseg8e16_v_u16m1x8(at + (jj * rsat) + ii, vrows, vl);
-        } else {
-          __riscv_vssseg8e16_v_u16m1x8(at + (jj * rsat) + ii,
-                                       output_seg_bstride, vrows, vl);
-        }
-      }
-    }
-  }
-
-  const uint16_t *in_tile = a + m_align8 * rsa;
-  uint16_t *out_tile = at + m_align8;
-
-  switch (m % 8) {
+  switch (m_mod8) {
   case 1: {
     // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
     vuint16m8_t vrow = __riscv_vundefined_u16m8();
@@ -760,6 +717,53 @@ skl_transpose_nvec_e16_zve32x(size_t m, size_t n,
   }
   default:
     break;
+  }
+
+  m -= m_mod8;
+  a += m_mod8 * rsa;
+  at += m_mod8;
+
+  // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+  vuint16m1_t vrow0 = __riscv_vundefined_u16m1();
+  vuint16m1_t vrow1 = __riscv_vundefined_u16m1();
+  vuint16m1_t vrow2 = __riscv_vundefined_u16m1();
+  vuint16m1_t vrow3 = __riscv_vundefined_u16m1();
+  vuint16m1_t vrow4 = __riscv_vundefined_u16m1();
+  vuint16m1_t vrow5 = __riscv_vundefined_u16m1();
+  vuint16m1_t vrow6 = __riscv_vundefined_u16m1();
+  vuint16m1_t vrow7 = __riscv_vundefined_u16m1();
+  // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+  for (size_t ii = 0; ii < m; ii += 8) {
+    for (size_t jj = 0; jj < n; jj += vl) {
+      const uint16_t *read_ptr = a + ii * rsa + jj;
+      vl = __riscv_vsetvl_e16m1(n - jj);
+
+      vrow0 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow2 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow3 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow4 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow5 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow6 = __riscv_vle16_v_u16m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow7 = __riscv_vle16_v_u16m1(read_ptr, vl);
+
+      vuint16m1x8_t vrows = __riscv_vcreate_v_u16m1x8(
+          vrow0, vrow1, vrow2, vrow3, vrow4, vrow5, vrow6, vrow7);
+      if (rsat == 8) {
+        __riscv_vsseg8e16_v_u16m1x8(at + (jj * rsat) + ii, vrows, vl);
+      } else {
+        __riscv_vssseg8e16_v_u16m1x8(at + (jj * rsat) + ii, output_seg_bstride,
+                                     vrows, vl);
+      }
+    }
   }
 }
 

--- a/src/pack/rvv/skl_pack_e16_zve32x.h
+++ b/src/pack/rvv/skl_pack_e16_zve32x.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#if !defined(__riscv_zve32x)
+#error This file requires the Zve32x extension
+#endif
+
+#include "skl-common.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * @brief RVV-based 16-bit general matrix pack kernel (2D to blocked 4D layout).
+ *
+ * @param m - Num. rows in input matrix
+ * @param n - Num. columns in input matrix
+ * @param src - Input matrix
+ * @param rs - Stride between rows of input matrix
+ * @param cs - Stride between columns of input matrix
+ * @param m0 - Num. rows in a block of output matrix
+ * @param n0 - Num. columns in a block of output matrix
+ * @param dst - Packed output matrix [ceil(m/m0) x ceil(n/n0) x (m0 x n0)]
+ * @param rs0 - Row stride within a block of output matrix
+ * @param cs0 - Column stride within a block of output matrix
+ * @param rs1 - Row stride between blocks of output matrix
+ * @param cs1 - Column stride between blocks of output matrix
+ * @param pad - Value to insert for padded elements (usually 0)
+ *
+ * Transforms a 2D matrix into a blocked 4D layout.
+ *
+ * The output layout consists of m1 × n1 blocks, where:
+ *   - m1 = ceil(m / m0) = (m + m0 - 1) / m0  (number of block-rows)
+ *   - n1 = ceil(n / n0) = (n + n0 - 1) / n0  (number of block-columns)
+ *
+ * Each block has dimensions m0 × n0. If m is not a multiple of m0 or n is not
+ * a multiple of n0, the incomplete blocks are padded with the specified padding
+ * value.
+ *
+ * @note Input and output matrices must not overlap.
+ */
+void skl_pack_e16rc_e16rcprc_zve32x(size_t m, size_t n,
+                                    const uint16_t *SKL_RESTRICT src, size_t rs,
+                                    size_t cs, size_t m0, size_t n0,
+                                    uint16_t *SKL_RESTRICT dst, size_t rs0,
+                                    size_t cs0, size_t rs1, size_t cs1,
+                                    uint16_t pad);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif

--- a/src/pack/rvv/skl_pack_e32_zve32x.c
+++ b/src/pack/rvv/skl_pack_e32_zve32x.c
@@ -213,62 +213,13 @@ skl_transpose_mvec_e32_zve32x(size_t m, size_t n,
                               uint32_t *SKL_RESTRICT at, size_t rsat) {
 
   size_t vl = 0;
-  size_t n_multiple_8 = n / 8 * 8;
   const ptrdiff_t input_seg_bstride = (ptrdiff_t)(rsa * sizeof(uint32_t));
 
-  if (n_multiple_8) {
-    for (size_t ii = 0; ii + 7 < n_multiple_8; ii += 8) {
-      // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
-      vuint32m1x8_t vcols = __riscv_vundefined_u32m1x8();
-      // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+  const uint32_t *in_tile = a;
+  uint32_t *out_tile = at;
+  size_t n_mod8 = n % 8;
 
-      const uint32_t *in_tile = a + ii;
-      uint32_t *out_tile = at + ii * rsat;
-      for (size_t jj = 0; jj < m; jj += vl) {
-        vl = __riscv_vsetvl_e32m1(m - jj);
-
-        if (rsa == 8) {
-          vcols = __riscv_vlseg8e32_v_u32m1x8(in_tile, vl);
-        } else {
-          vcols = __riscv_vlsseg8e32_v_u32m1x8(in_tile, input_seg_bstride, vl);
-        }
-
-        uint32_t *write_ptr = out_tile;
-        // store each segment continuously along m
-        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 0),
-                              vl);
-        write_ptr += rsat;
-        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 1),
-                              vl);
-        write_ptr += rsat;
-        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 2),
-                              vl);
-        write_ptr += rsat;
-        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 3),
-                              vl);
-        write_ptr += rsat;
-        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 4),
-                              vl);
-        write_ptr += rsat;
-        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 5),
-                              vl);
-        write_ptr += rsat;
-        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 6),
-                              vl);
-        write_ptr += rsat;
-        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 7),
-                              vl);
-
-        in_tile += vl * rsa;
-        out_tile += vl;
-      }
-    }
-  }
-
-  const uint32_t *in_tile = a + n_multiple_8;
-  uint32_t *out_tile = at + n_multiple_8 * rsat;
-
-  switch (n % 8) {
+  switch (n_mod8) {
   case 1: {
     // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
     vuint32m8_t vcol = __riscv_vundefined_u32m8();
@@ -494,6 +445,57 @@ skl_transpose_mvec_e32_zve32x(size_t m, size_t n,
   default:
     break;
   }
+
+  n -= n_mod8;
+  a += n_mod8;
+  at += n_mod8 * rsat;
+
+  for (size_t ii = 0; ii < n; ii += 8) {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m1x8_t vcols = __riscv_vundefined_u32m1x8();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    const uint32_t *in_tile = a + ii;
+    uint32_t *out_tile = at + ii * rsat;
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e32m1(m - jj);
+
+      if (rsa == 8) {
+        vcols = __riscv_vlseg8e32_v_u32m1x8(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg8e32_v_u32m1x8(in_tile, input_seg_bstride, vl);
+      }
+
+      uint32_t *write_ptr = out_tile;
+      // store each segment continuously along m
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 0),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 1),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 2),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 3),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 4),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 5),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 6),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 7),
+                            vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+  }
 }
 
 /* Transposes an M x N row-major matrix (pointed by `a`) to an N x M row-major
@@ -505,58 +507,13 @@ skl_transpose_nvec_e32_zve32x(size_t m, size_t n,
                               uint32_t *SKL_RESTRICT at, size_t rsat) {
 
   size_t vl = 0;
-  size_t m_align8 = m / 8 * 8;
   const ptrdiff_t output_seg_bstride = (ptrdiff_t)(rsat * sizeof(uint32_t));
 
-  if (m_align8) {
-    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
-    vuint32m1_t vrow0 = __riscv_vundefined_u32m1();
-    vuint32m1_t vrow1 = __riscv_vundefined_u32m1();
-    vuint32m1_t vrow2 = __riscv_vundefined_u32m1();
-    vuint32m1_t vrow3 = __riscv_vundefined_u32m1();
-    vuint32m1_t vrow4 = __riscv_vundefined_u32m1();
-    vuint32m1_t vrow5 = __riscv_vundefined_u32m1();
-    vuint32m1_t vrow6 = __riscv_vundefined_u32m1();
-    vuint32m1_t vrow7 = __riscv_vundefined_u32m1();
-    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+  size_t m_mod8 = m % 8;
+  const uint32_t *in_tile = a;
+  uint32_t *out_tile = at;
 
-    for (size_t ii = 0; ii + 7 < m_align8; ii += 8) {
-      for (size_t jj = 0; jj < n; jj += vl) {
-        const uint32_t *read_ptr = a + ii * rsa + jj;
-        vl = __riscv_vsetvl_e32m1(n - jj);
-
-        vrow0 = __riscv_vle32_v_u32m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow1 = __riscv_vle32_v_u32m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow2 = __riscv_vle32_v_u32m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow3 = __riscv_vle32_v_u32m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow4 = __riscv_vle32_v_u32m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow5 = __riscv_vle32_v_u32m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow6 = __riscv_vle32_v_u32m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow7 = __riscv_vle32_v_u32m1(read_ptr, vl);
-
-        vuint32m1x8_t vrows = __riscv_vcreate_v_u32m1x8(
-            vrow0, vrow1, vrow2, vrow3, vrow4, vrow5, vrow6, vrow7);
-        if (rsat == 8) {
-          __riscv_vsseg8e32_v_u32m1x8(at + (jj * rsat) + ii, vrows, vl);
-        } else {
-          __riscv_vssseg8e32_v_u32m1x8(at + (jj * rsat) + ii,
-                                       output_seg_bstride, vrows, vl);
-        }
-      }
-    }
-  }
-
-  const uint32_t *in_tile = a + m_align8 * rsa;
-  uint32_t *out_tile = at + m_align8;
-
-  switch (m % 8) {
+  switch (m_mod8) {
   case 1: {
     // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
     vuint32m8_t vrow = __riscv_vundefined_u32m8();
@@ -760,6 +717,53 @@ skl_transpose_nvec_e32_zve32x(size_t m, size_t n,
   }
   default:
     break;
+  }
+
+  m -= m_mod8;
+  a += m_mod8 * rsa;
+  at += m_mod8;
+
+  // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+  vuint32m1_t vrow0 = __riscv_vundefined_u32m1();
+  vuint32m1_t vrow1 = __riscv_vundefined_u32m1();
+  vuint32m1_t vrow2 = __riscv_vundefined_u32m1();
+  vuint32m1_t vrow3 = __riscv_vundefined_u32m1();
+  vuint32m1_t vrow4 = __riscv_vundefined_u32m1();
+  vuint32m1_t vrow5 = __riscv_vundefined_u32m1();
+  vuint32m1_t vrow6 = __riscv_vundefined_u32m1();
+  vuint32m1_t vrow7 = __riscv_vundefined_u32m1();
+  // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+  for (size_t ii = 0; ii < m; ii += 8) {
+    for (size_t jj = 0; jj < n; jj += vl) {
+      const uint32_t *read_ptr = a + ii * rsa + jj;
+      vl = __riscv_vsetvl_e32m1(n - jj);
+
+      vrow0 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow2 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow3 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow4 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow5 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow6 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow7 = __riscv_vle32_v_u32m1(read_ptr, vl);
+
+      vuint32m1x8_t vrows = __riscv_vcreate_v_u32m1x8(
+          vrow0, vrow1, vrow2, vrow3, vrow4, vrow5, vrow6, vrow7);
+      if (rsat == 8) {
+        __riscv_vsseg8e32_v_u32m1x8(at + (jj * rsat) + ii, vrows, vl);
+      } else {
+        __riscv_vssseg8e32_v_u32m1x8(at + (jj * rsat) + ii, output_seg_bstride,
+                                     vrows, vl);
+      }
+    }
   }
 }
 

--- a/src/pack/rvv/skl_pack_e32_zve32x.c
+++ b/src/pack/rvv/skl_pack_e32_zve32x.c
@@ -1,0 +1,1301 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#if !defined(__riscv_zve32x)
+#error This file requires the Zve32x extension
+#endif
+
+#include <riscv_vector.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "skl-common.h"
+
+SKL_FUNC_PRIVATE void skl_set_e32_zve32x(uint32_t *dst, uint32_t value,
+                                         size_t n) {
+  size_t vl = __riscv_vsetvl_e32m8(n);
+  vuint32m8_t v_value = __riscv_vmv_v_x_u32m8(value, vl);
+  __riscv_vse32_v_u32m8(dst, v_value, vl);
+  n -= vl;
+
+  while (n) {
+    dst += vl;
+    vl = __riscv_vsetvl_e32m8(n);
+    __riscv_vse32_v_u32m8(dst, v_value, vl);
+    n -= vl;
+  }
+}
+
+SKL_FUNC_PRIVATE void skl_copy_e32_zve32x(uint32_t *SKL_RESTRICT dst,
+                                          const uint32_t *SKL_RESTRICT src,
+                                          size_t n) {
+  size_t vl = 0;
+  for (size_t i = 0; i < n; i += vl) {
+    vl = __riscv_vsetvl_e32m8(n - i);
+    vuint32m8_t v_src = __riscv_vle32_v_u32m8(src + i, vl);
+    __riscv_vse32_v_u32m8(dst + i, v_src, vl);
+  }
+}
+
+/**
+ * @brief Set a 2D region of elements to a constant value.
+ *
+ * @param dst - Pointer to the start of the 2D region.
+ * @param rs - Row stride of the 2D region in elements.
+ * @param value - Value to set each element to.
+ * @param m - Number of rows in the 2D region.
+ * @param n - Number of columns in the 2D region.
+ *
+ * This function sets each element in the 2D region to the specified value.
+ */
+SKL_FUNC_PRIVATE void skl_set_2d_e32_zve32x(uint32_t *dst, size_t rs,
+                                            uint32_t value, size_t m,
+                                            size_t n) {
+  if (n == 0 || m == 0) {
+    return;
+  }
+  if (n == rs) {
+    skl_set_e32_zve32x(dst, value, n * m);
+    return;
+  }
+  if (n <= 8) {
+
+    vuint32m8_t pad_vec =
+        __riscv_vmv_v_x_u32m8(value, __riscv_vsetvlmax_e32m8());
+
+    switch (n) {
+    case 1: {
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m8(avl);
+        __riscv_vsse32_v_u32m8(dst, (ptrdiff_t)(rs * sizeof(uint32_t)), pad_vec,
+                               vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    case 2: {
+      vuint32m4x2_t pad_vec_group2 =
+          __riscv_vcreate_v_u32m4x2(__riscv_vget_v_u32m8_u32m4(pad_vec, 0),
+                                    __riscv_vget_v_u32m8_u32m4(pad_vec, 1));
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m4(avl);
+        __riscv_vssseg2e32_v_u32m4x2(dst, (ptrdiff_t)(rs * sizeof(uint32_t)),
+                                     pad_vec_group2, vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    case 3: {
+      vuint32m2x3_t pad_vec_group3 =
+          __riscv_vcreate_v_u32m2x3(__riscv_vget_v_u32m8_u32m2(pad_vec, 0),
+                                    __riscv_vget_v_u32m8_u32m2(pad_vec, 1),
+                                    __riscv_vget_v_u32m8_u32m2(pad_vec, 2));
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m2(avl);
+        __riscv_vssseg3e32_v_u32m2x3(dst, (ptrdiff_t)(rs * sizeof(uint32_t)),
+                                     pad_vec_group3, vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    case 4: {
+      vuint32m2x4_t pad_vec_group4 =
+          __riscv_vcreate_v_u32m2x4(__riscv_vget_v_u32m8_u32m2(pad_vec, 0),
+                                    __riscv_vget_v_u32m8_u32m2(pad_vec, 1),
+                                    __riscv_vget_v_u32m8_u32m2(pad_vec, 2),
+                                    __riscv_vget_v_u32m8_u32m2(pad_vec, 3));
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m2(avl);
+        __riscv_vssseg4e32_v_u32m2x4(dst, (ptrdiff_t)(rs * sizeof(uint32_t)),
+                                     pad_vec_group4, vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    case 5: {
+      vuint32m1x5_t pad_vec_group5 =
+          __riscv_vcreate_v_u32m1x5(__riscv_vget_v_u32m8_u32m1(pad_vec, 0),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 1),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 2),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 3),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 4));
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m1(avl);
+        __riscv_vssseg5e32_v_u32m1x5(dst, (ptrdiff_t)(rs * sizeof(uint32_t)),
+                                     pad_vec_group5, vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    case 6: {
+      vuint32m1x6_t pad_vec_group6 =
+          __riscv_vcreate_v_u32m1x6(__riscv_vget_v_u32m8_u32m1(pad_vec, 0),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 1),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 2),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 3),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 4),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 5));
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m1(avl);
+        __riscv_vssseg6e32_v_u32m1x6(dst, (ptrdiff_t)(rs * sizeof(uint32_t)),
+                                     pad_vec_group6, vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    case 7: {
+      vuint32m1x7_t pad_vec_group7 =
+          __riscv_vcreate_v_u32m1x7(__riscv_vget_v_u32m8_u32m1(pad_vec, 0),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 1),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 2),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 3),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 4),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 5),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 6));
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m1(avl);
+        __riscv_vssseg7e32_v_u32m1x7(dst, (ptrdiff_t)(rs * sizeof(uint32_t)),
+                                     pad_vec_group7, vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    case 8: {
+      vuint32m1x8_t pad_vec_group8 =
+          __riscv_vcreate_v_u32m1x8(__riscv_vget_v_u32m8_u32m1(pad_vec, 0),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 1),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 2),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 3),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 4),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 5),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 6),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 7));
+      for (size_t vl = 0, avl = m; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m1(avl);
+        __riscv_vssseg8e32_v_u32m1x8(dst, (ptrdiff_t)(rs * sizeof(uint32_t)),
+                                     pad_vec_group8, vl);
+        dst += vl * rs;
+      }
+      break;
+    }
+    default:
+      break;
+    }
+  } else {
+    for (size_t i = 0; i < m; ++i) {
+      skl_set_e32_zve32x(dst, value, n);
+      dst += rs;
+    }
+  }
+}
+
+SKL_FUNC_PRIVATE void
+skl_copy_2d_e32_zve32x(size_t m, size_t n, const uint32_t *SKL_RESTRICT a,
+                       size_t rsa, uint32_t *SKL_RESTRICT b, size_t rsb) {
+  if (rsa == n && rsb == n) {
+    skl_copy_e32_zve32x(b, a, m * n);
+    return;
+  }
+  for (size_t i = 0; i < m; ++i) {
+    skl_copy_e32_zve32x(b + i * rsb, a + i * rsa, n);
+  }
+}
+
+/* Transposes an M x N row-major matrix (pointed by `a`) to an N x M row-major
+ * matrix (pointed by `at`) with vectorization along the M dimension.
+ */
+SKL_FUNC_PRIVATE void
+skl_transpose_mvec_e32_zve32x(size_t m, size_t n,
+                              const uint32_t *SKL_RESTRICT a, size_t rsa,
+                              uint32_t *SKL_RESTRICT at, size_t rsat) {
+
+  size_t vl = 0;
+  size_t n_multiple_8 = n / 8 * 8;
+  const ptrdiff_t input_seg_bstride = (ptrdiff_t)(rsa * sizeof(uint32_t));
+
+  if (n_multiple_8) {
+    for (size_t ii = 0; ii + 7 < n_multiple_8; ii += 8) {
+      // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+      vuint32m1x8_t vcols = __riscv_vundefined_u32m1x8();
+      // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+      const uint32_t *in_tile = a + ii;
+      uint32_t *out_tile = at + ii * rsat;
+      for (size_t jj = 0; jj < m; jj += vl) {
+        vl = __riscv_vsetvl_e32m1(m - jj);
+
+        if (rsa == 8) {
+          vcols = __riscv_vlseg8e32_v_u32m1x8(in_tile, vl);
+        } else {
+          vcols = __riscv_vlsseg8e32_v_u32m1x8(in_tile, input_seg_bstride, vl);
+        }
+
+        uint32_t *write_ptr = out_tile;
+        // store each segment continuously along m
+        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 0),
+                              vl);
+        write_ptr += rsat;
+        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 1),
+                              vl);
+        write_ptr += rsat;
+        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 2),
+                              vl);
+        write_ptr += rsat;
+        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 3),
+                              vl);
+        write_ptr += rsat;
+        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 4),
+                              vl);
+        write_ptr += rsat;
+        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 5),
+                              vl);
+        write_ptr += rsat;
+        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 6),
+                              vl);
+        write_ptr += rsat;
+        __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x8_u32m1(vcols, 7),
+                              vl);
+
+        in_tile += vl * rsa;
+        out_tile += vl;
+      }
+    }
+  }
+
+  const uint32_t *in_tile = a + n_multiple_8;
+  uint32_t *out_tile = at + n_multiple_8 * rsat;
+
+  switch (n % 8) {
+  case 1: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m8_t vcol = __riscv_vundefined_u32m8();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e32m8(m - jj);
+
+      vcol = __riscv_vlse32_v_u32m8(in_tile, input_seg_bstride, vl);
+
+      // store extently along m
+      __riscv_vse32_v_u32m8(out_tile, vcol, vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+    break;
+  }
+  case 2: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m4x2_t vcols = __riscv_vundefined_u32m4x2();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e32m4(m - jj);
+
+      if (rsa == 2) {
+        vcols = __riscv_vlseg2e32_v_u32m4x2(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg2e32_v_u32m4x2(in_tile, input_seg_bstride, vl);
+      }
+
+      uint32_t *write_ptr = out_tile;
+      // store each segment extently along m
+      __riscv_vse32_v_u32m4(write_ptr, __riscv_vget_v_u32m4x2_u32m4(vcols, 0),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m4(write_ptr, __riscv_vget_v_u32m4x2_u32m4(vcols, 1),
+                            vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+    break;
+  }
+  case 3: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m2x3_t vcols = __riscv_vundefined_u32m2x3();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e32m2(m - jj);
+
+      if (rsa == 3) {
+        vcols = __riscv_vlseg3e32_v_u32m2x3(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg3e32_v_u32m2x3(in_tile, input_seg_bstride, vl);
+      }
+
+      uint32_t *write_ptr = out_tile;
+      // store each segment extently along m
+      __riscv_vse32_v_u32m2(write_ptr, __riscv_vget_v_u32m2x3_u32m2(vcols, 0),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m2(write_ptr, __riscv_vget_v_u32m2x3_u32m2(vcols, 1),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m2(write_ptr, __riscv_vget_v_u32m2x3_u32m2(vcols, 2),
+                            vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+    break;
+  }
+  case 4: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m2x4_t vcols = __riscv_vundefined_u32m2x4();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e32m2(m - jj);
+
+      if (rsa == 4) {
+        vcols = __riscv_vlseg4e32_v_u32m2x4(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg4e32_v_u32m2x4(in_tile, input_seg_bstride, vl);
+      }
+
+      uint32_t *write_ptr = out_tile;
+      // store each segment extently along m
+      __riscv_vse32_v_u32m2(write_ptr, __riscv_vget_v_u32m2x4_u32m2(vcols, 0),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m2(write_ptr, __riscv_vget_v_u32m2x4_u32m2(vcols, 1),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m2(write_ptr, __riscv_vget_v_u32m2x4_u32m2(vcols, 2),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m2(write_ptr, __riscv_vget_v_u32m2x4_u32m2(vcols, 3),
+                            vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+    break;
+  }
+  case 5: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m1x5_t vcols = __riscv_vundefined_u32m1x5();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e32m1(m - jj);
+
+      if (rsa == 5) {
+        vcols = __riscv_vlseg5e32_v_u32m1x5(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg5e32_v_u32m1x5(in_tile, input_seg_bstride, vl);
+      }
+
+      uint32_t *write_ptr = out_tile;
+      // store each segment extently along m
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x5_u32m1(vcols, 0),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x5_u32m1(vcols, 1),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x5_u32m1(vcols, 2),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x5_u32m1(vcols, 3),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x5_u32m1(vcols, 4),
+                            vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+    break;
+  }
+  case 6: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m1x6_t vcols = __riscv_vundefined_u32m1x6();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e32m1(m - jj);
+
+      if (rsa == 6) {
+        vcols = __riscv_vlseg6e32_v_u32m1x6(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg6e32_v_u32m1x6(in_tile, input_seg_bstride, vl);
+      }
+
+      uint32_t *write_ptr = out_tile;
+      // store each segment extently along m
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x6_u32m1(vcols, 0),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x6_u32m1(vcols, 1),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x6_u32m1(vcols, 2),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x6_u32m1(vcols, 3),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x6_u32m1(vcols, 4),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x6_u32m1(vcols, 5),
+                            vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+    break;
+  }
+  case 7: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m1x7_t vcols = __riscv_vundefined_u32m1x7();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e32m1(m - jj);
+
+      if (rsa == 7) {
+        vcols = __riscv_vlseg7e32_v_u32m1x7(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg7e32_v_u32m1x7(in_tile, input_seg_bstride, vl);
+      }
+
+      uint32_t *write_ptr = out_tile;
+      // store each segment extently along m
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x7_u32m1(vcols, 0),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x7_u32m1(vcols, 1),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x7_u32m1(vcols, 2),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x7_u32m1(vcols, 3),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x7_u32m1(vcols, 4),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x7_u32m1(vcols, 5),
+                            vl);
+      write_ptr += rsat;
+      __riscv_vse32_v_u32m1(write_ptr, __riscv_vget_v_u32m1x7_u32m1(vcols, 6),
+                            vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+    break;
+  }
+  default:
+    break;
+  }
+}
+
+/* Transposes an M x N row-major matrix (pointed by `a`) to an N x M row-major
+ * matrix (pointed by `at`) with vectorization along the N dimension.
+ */
+SKL_FUNC_PRIVATE void
+skl_transpose_nvec_e32_zve32x(size_t m, size_t n,
+                              const uint32_t *SKL_RESTRICT a, size_t rsa,
+                              uint32_t *SKL_RESTRICT at, size_t rsat) {
+
+  size_t vl = 0;
+  size_t m_align8 = m / 8 * 8;
+  const ptrdiff_t output_seg_bstride = (ptrdiff_t)(rsat * sizeof(uint32_t));
+
+  if (m_align8) {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m1_t vrow0 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow1 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow2 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow3 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow4 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow5 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow6 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow7 = __riscv_vundefined_u32m1();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t ii = 0; ii + 7 < m_align8; ii += 8) {
+      for (size_t jj = 0; jj < n; jj += vl) {
+        const uint32_t *read_ptr = a + ii * rsa + jj;
+        vl = __riscv_vsetvl_e32m1(n - jj);
+
+        vrow0 = __riscv_vle32_v_u32m1(read_ptr, vl);
+        read_ptr += rsa;
+        vrow1 = __riscv_vle32_v_u32m1(read_ptr, vl);
+        read_ptr += rsa;
+        vrow2 = __riscv_vle32_v_u32m1(read_ptr, vl);
+        read_ptr += rsa;
+        vrow3 = __riscv_vle32_v_u32m1(read_ptr, vl);
+        read_ptr += rsa;
+        vrow4 = __riscv_vle32_v_u32m1(read_ptr, vl);
+        read_ptr += rsa;
+        vrow5 = __riscv_vle32_v_u32m1(read_ptr, vl);
+        read_ptr += rsa;
+        vrow6 = __riscv_vle32_v_u32m1(read_ptr, vl);
+        read_ptr += rsa;
+        vrow7 = __riscv_vle32_v_u32m1(read_ptr, vl);
+
+        vuint32m1x8_t vrows = __riscv_vcreate_v_u32m1x8(
+            vrow0, vrow1, vrow2, vrow3, vrow4, vrow5, vrow6, vrow7);
+        if (rsat == 8) {
+          __riscv_vsseg8e32_v_u32m1x8(at + (jj * rsat) + ii, vrows, vl);
+        } else {
+          __riscv_vssseg8e32_v_u32m1x8(at + (jj * rsat) + ii,
+                                       output_seg_bstride, vrows, vl);
+        }
+      }
+    }
+  }
+
+  const uint32_t *in_tile = a + m_align8 * rsa;
+  uint32_t *out_tile = at + m_align8;
+
+  switch (m % 8) {
+  case 1: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m8_t vrow = __riscv_vundefined_u32m8();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+    for (size_t jj = 0; jj < n; jj += vl) {
+      vl = __riscv_vsetvl_e32m8(n - jj);
+      vrow = __riscv_vle32_v_u32m8(in_tile, vl);
+      __riscv_vsse32_v_u32m8(out_tile, output_seg_bstride, vrow, vl);
+
+      in_tile += vl;
+      out_tile += vl * rsat;
+    }
+    break;
+  }
+  case 2: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m4_t vrow0 = __riscv_vundefined_u32m4();
+    vuint32m4_t vrow1 = __riscv_vundefined_u32m4();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < n; jj += vl) {
+      vl = __riscv_vsetvl_e32m4(n - jj);
+      const uint32_t *read_ptr = in_tile;
+      vrow0 = __riscv_vle32_v_u32m4(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle32_v_u32m4(read_ptr, vl);
+      vuint32m4x2_t vrows = __riscv_vcreate_v_u32m4x2(vrow0, vrow1);
+      if (rsat == 2) {
+        __riscv_vsseg2e32_v_u32m4x2(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg2e32_v_u32m4x2(out_tile, output_seg_bstride, vrows, vl);
+      }
+      in_tile += vl;
+      out_tile += vl * rsat;
+    }
+    break;
+  }
+  case 3: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m2_t vrow0 = __riscv_vundefined_u32m2();
+    vuint32m2_t vrow1 = __riscv_vundefined_u32m2();
+    vuint32m2_t vrow2 = __riscv_vundefined_u32m2();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < n; jj += vl) {
+      vl = __riscv_vsetvl_e32m2(n - jj);
+      const uint32_t *read_ptr = in_tile;
+      vrow0 = __riscv_vle32_v_u32m2(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle32_v_u32m2(read_ptr, vl);
+      read_ptr += rsa;
+      vrow2 = __riscv_vle32_v_u32m2(read_ptr, vl);
+      vuint32m2x3_t vrows = __riscv_vcreate_v_u32m2x3(vrow0, vrow1, vrow2);
+      if (rsat == 3) {
+        __riscv_vsseg3e32_v_u32m2x3(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg3e32_v_u32m2x3(out_tile, output_seg_bstride, vrows, vl);
+      }
+      in_tile += vl;
+      out_tile += vl * rsat;
+    }
+    break;
+  }
+  case 4: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m2_t vrow0 = __riscv_vundefined_u32m2();
+    vuint32m2_t vrow1 = __riscv_vundefined_u32m2();
+    vuint32m2_t vrow2 = __riscv_vundefined_u32m2();
+    vuint32m2_t vrow3 = __riscv_vundefined_u32m2();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < n; jj += vl) {
+      vl = __riscv_vsetvl_e32m2(n - jj);
+      const uint32_t *read_ptr = in_tile;
+      vrow0 = __riscv_vle32_v_u32m2(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle32_v_u32m2(read_ptr, vl);
+      read_ptr += rsa;
+      vrow2 = __riscv_vle32_v_u32m2(read_ptr, vl);
+      read_ptr += rsa;
+      vrow3 = __riscv_vle32_v_u32m2(read_ptr, vl);
+      vuint32m2x4_t vrows =
+          __riscv_vcreate_v_u32m2x4(vrow0, vrow1, vrow2, vrow3);
+      if (rsat == 4) {
+        __riscv_vsseg4e32_v_u32m2x4(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg4e32_v_u32m2x4(out_tile, output_seg_bstride, vrows, vl);
+      }
+      in_tile += vl;
+      out_tile += vl * rsat;
+    }
+    break;
+  }
+  case 5: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m1_t vrow0 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow1 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow2 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow3 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow4 = __riscv_vundefined_u32m1();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < n; jj += vl) {
+      vl = __riscv_vsetvl_e32m1(n - jj);
+      const uint32_t *read_ptr = in_tile;
+      vrow0 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow2 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow3 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow4 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      vuint32m1x5_t vrows =
+          __riscv_vcreate_v_u32m1x5(vrow0, vrow1, vrow2, vrow3, vrow4);
+      if (rsat == 5) {
+        __riscv_vsseg5e32_v_u32m1x5(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg5e32_v_u32m1x5(out_tile, output_seg_bstride, vrows, vl);
+      }
+      in_tile += vl;
+      out_tile += vl * rsat;
+    }
+    break;
+  }
+  case 6: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m1_t vrow0 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow1 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow2 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow3 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow4 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow5 = __riscv_vundefined_u32m1();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < n; jj += vl) {
+      vl = __riscv_vsetvl_e32m1(n - jj);
+      const uint32_t *read_ptr = in_tile;
+      vrow0 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow2 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow3 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow4 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow5 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      vuint32m1x6_t vrows =
+          __riscv_vcreate_v_u32m1x6(vrow0, vrow1, vrow2, vrow3, vrow4, vrow5);
+      if (rsat == 6) {
+        __riscv_vsseg6e32_v_u32m1x6(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg6e32_v_u32m1x6(out_tile, output_seg_bstride, vrows, vl);
+      }
+      in_tile += vl;
+      out_tile += vl * rsat;
+    }
+    break;
+  }
+  case 7: {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint32m1_t vrow0 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow1 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow2 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow3 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow4 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow5 = __riscv_vundefined_u32m1();
+    vuint32m1_t vrow6 = __riscv_vundefined_u32m1();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    for (size_t jj = 0; jj < n; jj += vl) {
+      vl = __riscv_vsetvl_e32m1(n - jj);
+      const uint32_t *read_ptr = in_tile;
+      vrow0 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow2 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow3 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow4 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow5 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow6 = __riscv_vle32_v_u32m1(read_ptr, vl);
+      vuint32m1x7_t vrows = __riscv_vcreate_v_u32m1x7(
+          vrow0, vrow1, vrow2, vrow3, vrow4, vrow5, vrow6);
+      if (rsat == 7) {
+        __riscv_vsseg7e32_v_u32m1x7(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg7e32_v_u32m1x7(out_tile, output_seg_bstride, vrows, vl);
+      }
+      in_tile += vl;
+      out_tile += vl * rsat;
+    }
+    break;
+  }
+  default:
+    break;
+  }
+}
+
+SKL_FUNC_PRIVATE bool skl_transpose_e32_is_mvec(size_t m, size_t n) {
+  size_t vlmax = __riscv_vsetvlmax_e32m1();
+  if (m > n || m >= vlmax) {
+    return true;
+  }
+  return false;
+}
+
+SKL_FUNC_PRIVATE void
+skl_transpose_e32_zve32x(size_t m, size_t n, const uint32_t *SKL_RESTRICT a,
+                         size_t rsa, uint32_t *SKL_RESTRICT at, size_t rsat) {
+  if (skl_transpose_e32_is_mvec(m, n)) {
+    skl_transpose_mvec_e32_zve32x(m, n, a, rsa, at, rsat);
+  } else {
+    skl_transpose_nvec_e32_zve32x(m, n, a, rsa, at, rsat);
+  }
+}
+
+/**
+ * @brief Transpose a matrix and pad the output matrix with a constant value in
+ * the M dimension.
+ *
+ * @param m_padded - Number of columns in output matrix (Must be greater than or
+ * equal to m)
+ * @param m - Number of rows in input matrix
+ * @param n - Number of columns in input matrix and rows in output matrix.
+ * @param a - Pointer to input matrix
+ * @param rsa - Row stride of input matrix in elements.
+ * @param at - Pointer to output matrix.
+ * @param rsat - Row stride of output matrix in elements.
+ * @param pad - Value to use for padding.
+ *
+ * Transposes an m×n matrix and pads the transposed output in the M dimension.
+ *
+ * Transformation:
+ *   Input:  m×n matrix (m rows, n columns)
+ *   Output: n×m_padded matrix (n rows, m_padded columns), where m_padded >= m
+ */
+SKL_FUNC_PRIVATE void skl_transpose_padded_m_e32_zve32x(
+    size_t m_padded, size_t m, size_t n, const uint32_t *SKL_RESTRICT a,
+    size_t rsa, uint32_t *SKL_RESTRICT at, size_t rsat, uint32_t pad) {
+
+  if (m_padded == m) {
+    skl_transpose_e32_zve32x(m, n, a, rsa, at, rsat);
+    return;
+  }
+  size_t m_align8 = m / 8 * 8;
+  size_t m_ceil8 = (m + 7) / 8 * 8;
+  size_t m_mod8 = m % 8;
+
+  if (m_align8) {
+    skl_transpose_e32_zve32x(m_align8, n, a, rsa, at, rsat);
+  }
+  const uint32_t *in_tile = a + m_align8 * rsa;
+  uint32_t *out_tile = at + m_align8;
+  if (m_mod8) {
+    /* m_transition: Number of rows to process in the current tile (transpose +
+     * pad). Range: [2, 8]
+     *   - At least 2: minimum 1 remaining data row + 1 padding row
+     *   - At most 8: limited by tile size
+     */
+    size_t m_transition = m_padded - m_align8 > 8 ? 8 : m_padded - m_align8;
+    vuint32m8_t pad_vec = __riscv_vmv_v_x_u32m8(pad, __riscv_vsetvlmax_e32m8());
+
+    switch (m_transition) {
+    case 2: {
+      for (size_t vl = 0, avl = n; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m4(avl);
+        vuint32m4x2_t pad_vec_group2 =
+            __riscv_vcreate_v_u32m4x2(__riscv_vle32_v_u32m4(in_tile, vl),
+                                      __riscv_vget_v_u32m8_u32m4(pad_vec, 1));
+        if (rsat == 2) {
+          __riscv_vsseg2e32_v_u32m4x2(out_tile, pad_vec_group2, vl);
+        } else {
+          __riscv_vssseg2e32_v_u32m4x2(out_tile,
+                                       (ptrdiff_t)(rsat * sizeof(uint32_t)),
+                                       pad_vec_group2, vl);
+        }
+        in_tile += vl;
+        out_tile += vl * rsat;
+      }
+      break;
+    }
+    case 3: {
+      vuint32m2x3_t pad_vec_group3 =
+          __riscv_vcreate_v_u32m2x3(__riscv_vget_v_u32m8_u32m2(pad_vec, 0),
+                                    __riscv_vget_v_u32m8_u32m2(pad_vec, 1),
+                                    __riscv_vget_v_u32m8_u32m2(pad_vec, 2));
+      for (size_t vl = 0, avl = n; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m2(avl);
+        switch (m_mod8) {
+        case 2:
+          pad_vec_group3 = __riscv_vset_v_u32m2_u32m2x3(
+              pad_vec_group3, 1, __riscv_vle32_v_u32m2(in_tile + 1 * rsa, vl));
+          __attribute__((fallthrough));
+        case 1:
+          pad_vec_group3 = __riscv_vset_v_u32m2_u32m2x3(
+              pad_vec_group3, 0, __riscv_vle32_v_u32m2(in_tile, vl));
+          __attribute__((fallthrough));
+        default:
+          break;
+        }
+        if (rsat == 3) {
+          __riscv_vsseg3e32_v_u32m2x3(out_tile, pad_vec_group3, vl);
+        } else {
+          __riscv_vssseg3e32_v_u32m2x3(out_tile,
+                                       (ptrdiff_t)(rsat * sizeof(uint32_t)),
+                                       pad_vec_group3, vl);
+        }
+        in_tile += vl;
+        out_tile += vl * rsat;
+      }
+      break;
+    }
+    case 4: {
+      vuint32m2x4_t pad_vec_group4 =
+          __riscv_vcreate_v_u32m2x4(__riscv_vget_v_u32m8_u32m2(pad_vec, 0),
+                                    __riscv_vget_v_u32m8_u32m2(pad_vec, 1),
+                                    __riscv_vget_v_u32m8_u32m2(pad_vec, 2),
+                                    __riscv_vget_v_u32m8_u32m2(pad_vec, 3));
+      for (size_t vl = 0, avl = n; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m2(avl);
+        switch (m_mod8) {
+        case 3:
+          pad_vec_group4 = __riscv_vset_v_u32m2_u32m2x4(
+              pad_vec_group4, 2, __riscv_vle32_v_u32m2(in_tile + 2 * rsa, vl));
+          __attribute__((fallthrough));
+        case 2:
+          pad_vec_group4 = __riscv_vset_v_u32m2_u32m2x4(
+              pad_vec_group4, 1, __riscv_vle32_v_u32m2(in_tile + 1 * rsa, vl));
+          __attribute__((fallthrough));
+        case 1:
+          pad_vec_group4 = __riscv_vset_v_u32m2_u32m2x4(
+              pad_vec_group4, 0, __riscv_vle32_v_u32m2(in_tile, vl));
+          __attribute__((fallthrough));
+        default:
+          break;
+        }
+        if (rsat == 4) {
+          __riscv_vsseg4e32_v_u32m2x4(out_tile, pad_vec_group4, vl);
+        } else {
+          __riscv_vssseg4e32_v_u32m2x4(out_tile,
+                                       (ptrdiff_t)(rsat * sizeof(uint32_t)),
+                                       pad_vec_group4, vl);
+        }
+        in_tile += vl;
+        out_tile += vl * rsat;
+      }
+      break;
+    }
+    case 5: {
+      vuint32m1x5_t pad_vec_group5 =
+          __riscv_vcreate_v_u32m1x5(__riscv_vget_v_u32m8_u32m1(pad_vec, 0),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 1),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 2),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 3),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 4));
+      for (size_t vl = 0, avl = n; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m1(avl);
+        switch (m_mod8) {
+        case 4:
+          pad_vec_group5 = __riscv_vset_v_u32m1_u32m1x5(
+              pad_vec_group5, 3, __riscv_vle32_v_u32m1(in_tile + 3 * rsa, vl));
+          __attribute__((fallthrough));
+        case 3:
+          pad_vec_group5 = __riscv_vset_v_u32m1_u32m1x5(
+              pad_vec_group5, 2, __riscv_vle32_v_u32m1(in_tile + 2 * rsa, vl));
+          __attribute__((fallthrough));
+        case 2:
+          pad_vec_group5 = __riscv_vset_v_u32m1_u32m1x5(
+              pad_vec_group5, 1, __riscv_vle32_v_u32m1(in_tile + 1 * rsa, vl));
+          __attribute__((fallthrough));
+        case 1:
+          pad_vec_group5 = __riscv_vset_v_u32m1_u32m1x5(
+              pad_vec_group5, 0, __riscv_vle32_v_u32m1(in_tile, vl));
+          __attribute__((fallthrough));
+        default:
+          break;
+        }
+        if (rsat == 5) {
+          __riscv_vsseg5e32_v_u32m1x5(out_tile, pad_vec_group5, vl);
+        } else {
+          __riscv_vssseg5e32_v_u32m1x5(out_tile,
+                                       (ptrdiff_t)(rsat * sizeof(uint32_t)),
+                                       pad_vec_group5, vl);
+        }
+        in_tile += vl;
+        out_tile += vl * rsat;
+      }
+      break;
+    }
+    case 6: {
+      vuint32m1x6_t pad_vec_group6 =
+          __riscv_vcreate_v_u32m1x6(__riscv_vget_v_u32m8_u32m1(pad_vec, 0),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 1),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 2),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 3),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 4),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 5));
+      for (size_t vl = 0, avl = n; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m1(avl);
+        switch (m_mod8) {
+        case 5:
+          pad_vec_group6 = __riscv_vset_v_u32m1_u32m1x6(
+              pad_vec_group6, 4, __riscv_vle32_v_u32m1(in_tile + 4 * rsa, vl));
+          __attribute__((fallthrough));
+        case 4:
+          pad_vec_group6 = __riscv_vset_v_u32m1_u32m1x6(
+              pad_vec_group6, 3, __riscv_vle32_v_u32m1(in_tile + 3 * rsa, vl));
+          __attribute__((fallthrough));
+        case 3:
+          pad_vec_group6 = __riscv_vset_v_u32m1_u32m1x6(
+              pad_vec_group6, 2, __riscv_vle32_v_u32m1(in_tile + 2 * rsa, vl));
+          __attribute__((fallthrough));
+        case 2:
+          pad_vec_group6 = __riscv_vset_v_u32m1_u32m1x6(
+              pad_vec_group6, 1, __riscv_vle32_v_u32m1(in_tile + 1 * rsa, vl));
+          __attribute__((fallthrough));
+        case 1:
+          pad_vec_group6 = __riscv_vset_v_u32m1_u32m1x6(
+              pad_vec_group6, 0, __riscv_vle32_v_u32m1(in_tile, vl));
+          __attribute__((fallthrough));
+        default:
+          break;
+        }
+        if (rsat == 6) {
+          __riscv_vsseg6e32_v_u32m1x6(out_tile, pad_vec_group6, vl);
+        } else {
+          __riscv_vssseg6e32_v_u32m1x6(out_tile,
+                                       (ptrdiff_t)(rsat * sizeof(uint32_t)),
+                                       pad_vec_group6, vl);
+        }
+        in_tile += vl;
+        out_tile += vl * rsat;
+      }
+      break;
+    }
+    case 7: {
+      vuint32m1x7_t pad_vec_group7 =
+          __riscv_vcreate_v_u32m1x7(__riscv_vget_v_u32m8_u32m1(pad_vec, 0),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 1),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 2),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 3),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 4),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 5),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 6));
+      for (size_t vl = 0, avl = n; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m1(avl);
+        switch (m_mod8) {
+        case 6:
+          pad_vec_group7 = __riscv_vset_v_u32m1_u32m1x7(
+              pad_vec_group7, 5, __riscv_vle32_v_u32m1(in_tile + 5 * rsa, vl));
+          __attribute__((fallthrough));
+        case 5:
+          pad_vec_group7 = __riscv_vset_v_u32m1_u32m1x7(
+              pad_vec_group7, 4, __riscv_vle32_v_u32m1(in_tile + 4 * rsa, vl));
+          __attribute__((fallthrough));
+        case 4:
+          pad_vec_group7 = __riscv_vset_v_u32m1_u32m1x7(
+              pad_vec_group7, 3, __riscv_vle32_v_u32m1(in_tile + 3 * rsa, vl));
+          __attribute__((fallthrough));
+        case 3:
+          pad_vec_group7 = __riscv_vset_v_u32m1_u32m1x7(
+              pad_vec_group7, 2, __riscv_vle32_v_u32m1(in_tile + 2 * rsa, vl));
+          __attribute__((fallthrough));
+        case 2:
+          pad_vec_group7 = __riscv_vset_v_u32m1_u32m1x7(
+              pad_vec_group7, 1, __riscv_vle32_v_u32m1(in_tile + 1 * rsa, vl));
+          __attribute__((fallthrough));
+        case 1:
+          pad_vec_group7 = __riscv_vset_v_u32m1_u32m1x7(
+              pad_vec_group7, 0, __riscv_vle32_v_u32m1(in_tile, vl));
+          __attribute__((fallthrough));
+        default:
+          break;
+        }
+        if (rsat == 7) {
+          __riscv_vsseg7e32_v_u32m1x7(out_tile, pad_vec_group7, vl);
+        } else {
+          __riscv_vssseg7e32_v_u32m1x7(out_tile,
+                                       (ptrdiff_t)(rsat * sizeof(uint32_t)),
+                                       pad_vec_group7, vl);
+        }
+        in_tile += vl;
+        out_tile += vl * rsat;
+      }
+      break;
+    }
+    case 8: {
+      vuint32m1x8_t pad_vec_group8 =
+          __riscv_vcreate_v_u32m1x8(__riscv_vget_v_u32m8_u32m1(pad_vec, 0),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 1),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 2),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 3),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 4),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 5),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 6),
+                                    __riscv_vget_v_u32m8_u32m1(pad_vec, 7));
+      for (size_t vl = 0, avl = n; avl > 0; avl -= vl) {
+        vl = __riscv_vsetvl_e32m1(avl);
+        switch (m_mod8) {
+        case 7:
+          pad_vec_group8 = __riscv_vset_v_u32m1_u32m1x8(
+              pad_vec_group8, 6, __riscv_vle32_v_u32m1(in_tile + 6 * rsa, vl));
+          __attribute__((fallthrough));
+        case 6:
+          pad_vec_group8 = __riscv_vset_v_u32m1_u32m1x8(
+              pad_vec_group8, 5, __riscv_vle32_v_u32m1(in_tile + 5 * rsa, vl));
+          __attribute__((fallthrough));
+        case 5:
+          pad_vec_group8 = __riscv_vset_v_u32m1_u32m1x8(
+              pad_vec_group8, 4, __riscv_vle32_v_u32m1(in_tile + 4 * rsa, vl));
+          __attribute__((fallthrough));
+        case 4:
+          pad_vec_group8 = __riscv_vset_v_u32m1_u32m1x8(
+              pad_vec_group8, 3, __riscv_vle32_v_u32m1(in_tile + 3 * rsa, vl));
+          __attribute__((fallthrough));
+        case 3:
+          pad_vec_group8 = __riscv_vset_v_u32m1_u32m1x8(
+              pad_vec_group8, 2, __riscv_vle32_v_u32m1(in_tile + 2 * rsa, vl));
+          __attribute__((fallthrough));
+        case 2:
+          pad_vec_group8 = __riscv_vset_v_u32m1_u32m1x8(
+              pad_vec_group8, 1, __riscv_vle32_v_u32m1(in_tile + 1 * rsa, vl));
+          __attribute__((fallthrough));
+        case 1:
+          pad_vec_group8 = __riscv_vset_v_u32m1_u32m1x8(
+              pad_vec_group8, 0, __riscv_vle32_v_u32m1(in_tile, vl));
+          __attribute__((fallthrough));
+        default:
+          break;
+        }
+        if (rsat == 8) {
+          __riscv_vsseg8e32_v_u32m1x8(out_tile, pad_vec_group8, vl);
+        } else {
+          __riscv_vssseg8e32_v_u32m1x8(out_tile,
+                                       (ptrdiff_t)(rsat * sizeof(uint32_t)),
+                                       pad_vec_group8, vl);
+        }
+        in_tile += vl;
+        out_tile += vl * rsat;
+      }
+      break;
+    }
+    default:
+      break;
+    }
+  } // if (m_mod8)
+
+  if (m_padded > m_ceil8) {
+    out_tile = at + m_ceil8;
+    skl_set_2d_e32_zve32x(out_tile, rsat, pad, n, m_padded - m_ceil8);
+  }
+}
+
+SKL_FUNC_PRIVATE void skl_pack_e32_e32rcprc_zve32x(
+    size_t m, size_t n, const uint32_t *SKL_RESTRICT src, size_t rs, size_t m0,
+    size_t n0, uint32_t *SKL_RESTRICT dst, size_t rs0, size_t cs0, size_t rs1,
+    size_t cs1, uint32_t pad) {
+
+  // Handle division by zero
+  if (m0 == 0 || n0 == 0) {
+    return;
+  }
+
+  size_t m1 = (m + m0 - 1) / m0; // Num. block-rows in output matrix
+  size_t n1 = (n + n0 - 1) / n0; // Num. block-columns in output matrix
+
+  /* Column panels */
+  if (rs0 == 1 && n0 == 1) {
+    if (m0 == rs1) {
+      /* column-major block ordering */
+      skl_transpose_padded_m_e32_zve32x(m0 * m1, m, n, src, rs, dst, cs1, pad);
+    } else {
+      /* row-major block ordering */
+      const uint32_t *src_block = src;
+      uint32_t *dst_block = dst;
+      for (size_t ii1 = 0; ii1 < m1 - 1; ++ii1) {
+        skl_transpose_e32_zve32x(m0, n, src_block, rs, dst_block, cs1);
+        src_block += m0 * rs;
+        dst_block += rs1;
+      }
+      size_t m_tail = m - m0 * (m1 - 1);
+      skl_transpose_padded_m_e32_zve32x(m0, m_tail, n, src_block, rs, dst_block,
+                                        cs1, pad);
+    }
+    return;
+  }
+
+  /* intra-block: column-major, inter-block: row-major */
+  if ((cs0 * n0 == cs1) && rs0 == 1) {
+    const uint32_t *src_block = src;
+    uint32_t *dst_block = dst;
+    for (size_t ii1 = 0; ii1 < m1 - 1; ++ii1) {
+      skl_transpose_e32_zve32x(m0, n, src_block, rs, dst_block, cs0);
+      if (n % n0) {
+        // pad right
+        skl_set_2d_e32_zve32x(dst_block + cs1 * (n1 - 1) + cs0 * (n % n0), cs0,
+                              pad, n0 - n % n0, m0);
+      }
+      src_block += m0 * rs;
+      dst_block += rs1;
+    }
+    size_t m_tail = m - m0 * (m1 - 1);
+    skl_transpose_padded_m_e32_zve32x(m0, m_tail, n, src_block, rs, dst_block,
+                                      cs0, pad);
+    if (n % n0) {
+      // pad right
+      skl_set_2d_e32_zve32x(dst_block + cs1 * (n1 - 1) + cs0 * (n % n0), cs0,
+                            pad, n0 - n % n0, m0);
+    }
+    return;
+  }
+
+  /* Row panels */
+  if (cs0 == 1 && m0 == 1) {
+    if (n0 == cs1) {
+      /* row-major block ordering */
+      skl_copy_2d_e32_zve32x(m, n, src, rs, dst, rs1);
+      // pad right
+      if (n % n0) {
+        skl_set_2d_e32_zve32x(dst + n, rs1, pad, m, n0 - n % n0);
+      }
+
+    } else {
+      /* column-major block ordering */
+      const uint32_t *src_block = src;
+      uint32_t *dst_block = dst;
+
+      for (size_t jj1 = 0; jj1 < n1 - 1; ++jj1) {
+        skl_copy_2d_e32_zve32x(m, n0, src_block, rs, dst_block, rs1);
+        src_block += n0;
+        dst_block += cs1;
+      }
+      size_t n_tail = n - n0 * (n1 - 1);
+      skl_copy_2d_e32_zve32x(m, n_tail, src_block, rs, dst_block, rs1);
+      // pad right: pad (n0 - n_tail) elements in each of m rows
+      skl_set_2d_e32_zve32x(dst_block + n_tail, rs1, pad, m, n0 - n_tail);
+    }
+    return;
+  }
+
+  /* intra-block: row-major, inter-block: column-major */
+  if ((rs0 * m0 == rs1) && cs0 == 1) {
+    const uint32_t *src_block = src;
+    uint32_t *dst_block = dst;
+    for (size_t jj1 = 0; jj1 < n1 - 1; ++jj1) {
+      skl_copy_2d_e32_zve32x(m, n0, src_block, rs, dst_block, rs0);
+      if (m % m0) {
+        // pad bottom
+        skl_set_2d_e32_zve32x(dst_block + m * rs0, rs0, pad, m0 - m % m0, n0);
+      }
+      src_block += n0;
+      dst_block += cs1;
+    }
+    size_t n_tail = n - n0 * (n1 - 1);
+    skl_copy_2d_e32_zve32x(m, n_tail, src_block, rs, dst_block, rs0);
+    if (m % m0) {
+      // pad bottom
+      skl_set_2d_e32_zve32x(dst_block + m * rs0, rs0, pad, m0 - m % m0, n0);
+    }
+    // pad right: pad (n0 - n_tail) elements in each of m rows
+    skl_set_2d_e32_zve32x(dst_block + n_tail, rs0, pad, m, n0 - n_tail);
+    return;
+  }
+
+  for (size_t ii1 = 0; ii1 < m1; ++ii1) {
+    size_t m_length = m0 < m - ii1 * m0 ? m0 : m - ii1 * m0;
+    for (size_t jj1 = 0; jj1 < n1; ++jj1) {
+      const uint32_t *src_block = src + ii1 * m0 * rs + jj1 * n0;
+      uint32_t *dst_block = dst + ii1 * rs1 + jj1 * cs1;
+      size_t n_length = n0 < n - jj1 * n0 ? n0 : n - jj1 * n0;
+      if (rs0 == 1) {
+        skl_transpose_padded_m_e32_zve32x(m0, m_length, n_length, src_block, rs,
+                                          dst_block, cs0, pad);
+        // pad right
+        skl_set_2d_e32_zve32x(dst_block + cs0 * n_length, cs0, pad,
+                              n0 - n_length, m0);
+      } else if (cs0 == 1) {
+        skl_copy_2d_e32_zve32x(m_length, n_length, src_block, rs, dst_block,
+                               rs0);
+        // pad right: pad (n0 - n_length) elements in each of m_length rows
+        skl_set_2d_e32_zve32x(dst_block + n_length, rs0, pad, m_length,
+                              n0 - n_length);
+        // pad bottom: pad (m0 - m_length) rows, each with n0 elements
+        skl_set_2d_e32_zve32x(dst_block + m_length * rs0, rs0, pad,
+                              m0 - m_length, n0);
+      } else {
+        for (size_t ii0 = 0; ii0 < m0; ++ii0) {
+          for (size_t jj0 = 0; jj0 < n0; ++jj0) {
+            if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
+              dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0];
+            } else {
+              // Pad with zeros
+              dst_block[ii0 * rs0 + jj0 * cs0] = pad;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+SKL_FUNC void skl_pack_e32rc_e32rcprc_zve32x(
+    size_t m, size_t n, const uint32_t *SKL_RESTRICT src, size_t rs, size_t cs,
+    size_t m0, size_t n0, uint32_t *SKL_RESTRICT dst, size_t rs0, size_t cs0,
+    size_t rs1, size_t cs1, uint32_t pad) {
+
+  if (cs == 1) {
+    skl_pack_e32_e32rcprc_zve32x(m, n, src, rs, m0, n0, dst, rs0, cs0, rs1, cs1,
+                                 pad);
+  } else if (rs == 1) {
+    // When input is column-major (rs==1), transpose both dimensions and strides
+    skl_pack_e32_e32rcprc_zve32x(n, m, src, cs, n0, m0, dst, cs0, rs0, cs1, rs1,
+                                 pad);
+  } else {
+    size_t m1 = (m + m0 - 1) / m0; // Num. block-rows in output matrix
+    size_t n1 = (n + n0 - 1) / n0; // Num. block-columns in output matrix
+    for (size_t ii1 = 0; ii1 < m1; ++ii1) {
+      for (size_t jj1 = 0; jj1 < n1; ++jj1) {
+        const uint32_t *src_block = src + ii1 * m0 * rs + jj1 * n0 * cs;
+        uint32_t *dst_block = dst + ii1 * rs1 + jj1 * cs1;
+        for (size_t ii0 = 0; ii0 < m0; ++ii0) {
+          for (size_t jj0 = 0; jj0 < n0; ++jj0) {
+            if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
+              dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0 * cs];
+            } else {
+              // Pad with zeros
+              dst_block[ii0 * rs0 + jj0 * cs0] = pad;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/pack/rvv/skl_pack_e32_zve32x.c
+++ b/src/pack/rvv/skl_pack_e32_zve32x.c
@@ -1256,7 +1256,6 @@ SKL_FUNC_PRIVATE void skl_pack_e32_e32rcprc_zve32x(
             if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
               dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0];
             } else {
-              // Pad with zeros
               dst_block[ii0 * rs0 + jj0 * cs0] = pad;
             }
           }
@@ -1290,7 +1289,6 @@ SKL_FUNC void skl_pack_e32rc_e32rcprc_zve32x(
             if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
               dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0 * cs];
             } else {
-              // Pad with zeros
               dst_block[ii0 * rs0 + jj0 * cs0] = pad;
             }
           }

--- a/src/pack/rvv/skl_pack_e32_zve32x.c
+++ b/src/pack/rvv/skl_pack_e32_zve32x.c
@@ -1164,8 +1164,7 @@ SKL_FUNC_PRIVATE void skl_pack_e32_e32rcprc_zve32x(
       skl_transpose_e32_zve32x(m0, n, src_block, rs, dst_block, cs0);
       if (n % n0) {
         // pad right
-        skl_set_2d_e32_zve32x(dst_block + cs1 * (n1 - 1) + cs0 * (n % n0), cs0,
-                              pad, n0 - n % n0, m0);
+        skl_set_2d_e32_zve32x(dst_block + cs0 * n, cs0, pad, n0 - n % n0, m0);
       }
       src_block += m0 * rs;
       dst_block += rs1;
@@ -1175,8 +1174,7 @@ SKL_FUNC_PRIVATE void skl_pack_e32_e32rcprc_zve32x(
                                       cs0, pad);
     if (n % n0) {
       // pad right
-      skl_set_2d_e32_zve32x(dst_block + cs1 * (n1 - 1) + cs0 * (n % n0), cs0,
-                            pad, n0 - n % n0, m0);
+      skl_set_2d_e32_zve32x(dst_block + cs0 * n, cs0, pad, n0 - n % n0, m0);
     }
     return;
   }

--- a/src/pack/rvv/skl_pack_e32_zve32x.c
+++ b/src/pack/rvv/skl_pack_e32_zve32x.c
@@ -18,14 +18,12 @@ SKL_FUNC_PRIVATE void skl_set_e32_zve32x(uint32_t *dst, uint32_t value,
                                          size_t n) {
   size_t vl = __riscv_vsetvl_e32m8(n);
   vuint32m8_t v_value = __riscv_vmv_v_x_u32m8(value, vl);
-  __riscv_vse32_v_u32m8(dst, v_value, vl);
-  n -= vl;
 
   while (n) {
-    dst += vl;
     vl = __riscv_vsetvl_e32m8(n);
     __riscv_vse32_v_u32m8(dst, v_value, vl);
     n -= vl;
+    dst += vl;
   }
 }
 
@@ -201,6 +199,58 @@ skl_copy_2d_e32_zve32x(size_t m, size_t n, const uint32_t *SKL_RESTRICT a,
   }
   for (size_t i = 0; i < m; ++i) {
     skl_copy_e32_zve32x(b + i * rsb, a + i * rsa, n);
+  }
+}
+
+/**
+ * @brief Copy a 2D matrix and pad the output matrix with a constant value in
+ * the N dimension.
+ *
+ * @param n_padded - Number of columns in output matrix
+ * @param m - Number of rows in input matrix and output matrix
+ * @param n - Number of columns in input matrix
+ * @param a - Pointer to input matrix
+ * @param rsa - Row stride of input matrix in elements.
+ * @param b - Pointer to output matrix.
+ * @param rsb - Row stride of output matrix in elements.
+ * @param pad - Value to use for padding.
+ *
+ */
+SKL_FUNC_PRIVATE void skl_copy_2d_padded_n_e32_zve32x(
+    size_t n_padded, size_t m, size_t n, const uint32_t *SKL_RESTRICT a,
+    size_t rsa, uint32_t *SKL_RESTRICT b, size_t rsb, uint32_t pad) {
+  if (n_padded == n) {
+    skl_copy_2d_e32_zve32x(m, n, a, rsa, b, rsb);
+    return;
+  }
+  /* Process N dimension in 3 parts:
+   * - head: Full vlmax-element chunks (direct copy)
+   * - transition: Partial vlmax chunk with data + padding
+   * - tail: Pure padding beyond transition
+   */
+  size_t vlmax = __riscv_vsetvlmax_e32m8();
+  size_t n_head = n / vlmax * vlmax;
+  if (n_head) {
+    skl_copy_2d_e32_zve32x(m, n_head, a, rsa, b, rsb);
+    a += n_head;
+    b += n_head;
+  }
+
+  size_t n_transition = 0;
+  if (n % vlmax) {
+    n_transition = n_padded - n_head > vlmax ? vlmax : n_padded - n_head;
+    vuint32m8_t pad_vec = __riscv_vmv_v_x_u32m8(pad, n_transition);
+    size_t n_load = n - n_head;
+    for (size_t i = 0; i < m; ++i) {
+      pad_vec = __riscv_vle32_v_u32m8_tu(pad_vec, a + i * rsa, n_load);
+      __riscv_vse32_v_u32m8(b + i * rsb, pad_vec, n_transition);
+    }
+    b += n_transition;
+  }
+
+  size_t n_tail = n_padded - n_head - n_transition;
+  if (n_tail) {
+    skl_set_2d_e32_zve32x(b, rsb, pad, m, n_tail);
   }
 }
 
@@ -1183,12 +1233,7 @@ SKL_FUNC_PRIVATE void skl_pack_e32_e32rcprc_zve32x(
   if (cs0 == 1 && m0 == 1) {
     if (n0 == cs1) {
       /* row-major block ordering */
-      skl_copy_2d_e32_zve32x(m, n, src, rs, dst, rs1);
-      // pad right
-      if (n % n0) {
-        skl_set_2d_e32_zve32x(dst + n, rs1, pad, m, n0 - n % n0);
-      }
-
+      skl_copy_2d_padded_n_e32_zve32x(n0 * n1, m, n, src, rs, dst, rs1, pad);
     } else {
       /* column-major block ordering */
       const uint32_t *src_block = src;
@@ -1200,9 +1245,8 @@ SKL_FUNC_PRIVATE void skl_pack_e32_e32rcprc_zve32x(
         dst_block += cs1;
       }
       size_t n_tail = n - n0 * (n1 - 1);
-      skl_copy_2d_e32_zve32x(m, n_tail, src_block, rs, dst_block, rs1);
-      // pad right: pad (n0 - n_tail) elements in each of m rows
-      skl_set_2d_e32_zve32x(dst_block + n_tail, rs1, pad, m, n0 - n_tail);
+      skl_copy_2d_padded_n_e32_zve32x(n0, m, n_tail, src_block, rs, dst_block,
+                                      rs1, pad);
     }
     return;
   }
@@ -1221,13 +1265,12 @@ SKL_FUNC_PRIVATE void skl_pack_e32_e32rcprc_zve32x(
       dst_block += cs1;
     }
     size_t n_tail = n - n0 * (n1 - 1);
-    skl_copy_2d_e32_zve32x(m, n_tail, src_block, rs, dst_block, rs0);
+    skl_copy_2d_padded_n_e32_zve32x(n0, m, n_tail, src_block, rs, dst_block,
+                                    rs0, pad);
     if (m % m0) {
       // pad bottom
       skl_set_2d_e32_zve32x(dst_block + m * rs0, rs0, pad, m0 - m % m0, n0);
     }
-    // pad right: pad (n0 - n_tail) elements in each of m rows
-    skl_set_2d_e32_zve32x(dst_block + n_tail, rs0, pad, m, n0 - n_tail);
     return;
   }
 
@@ -1244,11 +1287,8 @@ SKL_FUNC_PRIVATE void skl_pack_e32_e32rcprc_zve32x(
         skl_set_2d_e32_zve32x(dst_block + cs0 * n_length, cs0, pad,
                               n0 - n_length, m0);
       } else if (cs0 == 1) {
-        skl_copy_2d_e32_zve32x(m_length, n_length, src_block, rs, dst_block,
-                               rs0);
-        // pad right: pad (n0 - n_length) elements in each of m_length rows
-        skl_set_2d_e32_zve32x(dst_block + n_length, rs0, pad, m_length,
-                              n0 - n_length);
+        skl_copy_2d_padded_n_e32_zve32x(n0, m_length, n_length, src_block, rs,
+                                        dst_block, rs0, pad);
         // pad bottom: pad (m0 - m_length) rows, each with n0 elements
         skl_set_2d_e32_zve32x(dst_block + m_length * rs0, rs0, pad,
                               m0 - m_length, n0);

--- a/src/pack/rvv/skl_pack_e32_zve32x.h
+++ b/src/pack/rvv/skl_pack_e32_zve32x.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#if !defined(__riscv_zve32x)
+#error This file requires the Zve32x extension
+#endif
+
+#include "skl-common.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * @brief RVV-based 32-bit general matrix pack kernel (2D to blocked 4D layout).
+ *
+ * @param m - Num. rows in input matrix
+ * @param n - Num. columns in input matrix
+ * @param src - Input matrix
+ * @param rs - Stride between rows of input matrix
+ * @param cs - Stride between columns of input matrix
+ * @param m0 - Num. rows in a block of output matrix
+ * @param n0 - Num. columns in a block of output matrix
+ * @param dst - Packed output matrix [ceil(m/m0) x ceil(n/n0) x (m0 x n0)]
+ * @param rs0 - Row stride within a block of output matrix
+ * @param cs0 - Column stride within a block of output matrix
+ * @param rs1 - Row stride between blocks of output matrix
+ * @param cs1 - Column stride between blocks of output matrix
+ * @param pad - Value to insert for padded elements (usually 0)
+ *
+ * Transforms a 2D matrix into a blocked 4D layout.
+ *
+ * The output layout consists of m1 × n1 blocks, where:
+ *   - m1 = ceil(m / m0) = (m + m0 - 1) / m0  (number of block-rows)
+ *   - n1 = ceil(n / n0) = (n + n0 - 1) / n0  (number of block-columns)
+ *
+ * Each block has dimensions m0 × n0. If m is not a multiple of m0 or n is not
+ * a multiple of n0, the incomplete blocks are padded with the specified padding
+ * value.
+ *
+ * @note Input and output matrices must not overlap.
+ */
+void skl_pack_e32rc_e32rcprc_zve32x(size_t m, size_t n,
+                                    const uint32_t *SKL_RESTRICT src, size_t rs,
+                                    size_t cs, size_t m0, size_t n0,
+                                    uint32_t *SKL_RESTRICT dst, size_t rs0,
+                                    size_t cs0, size_t rs1, size_t cs1,
+                                    uint32_t pad);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif

--- a/src/pack/rvv/skl_pack_e8_zve32x.c
+++ b/src/pack/rvv/skl_pack_e8_zve32x.c
@@ -211,62 +211,13 @@ skl_transpose_mvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
                              size_t rsat) {
 
   size_t vl = 0;
-  size_t n_multiple_8 = n / 8 * 8;
   const ptrdiff_t input_seg_bstride = (ptrdiff_t)(rsa * sizeof(uint8_t));
 
-  if (n_multiple_8) {
-    for (size_t ii = 0; ii + 7 < n_multiple_8; ii += 8) {
-      // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
-      vuint8m1x8_t vcols = __riscv_vundefined_u8m1x8();
-      // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+  const uint8_t *in_tile = a;
+  uint8_t *out_tile = at;
+  size_t n_mod8 = n % 8;
 
-      const uint8_t *in_tile = a + ii;
-      uint8_t *out_tile = at + ii * rsat;
-      for (size_t jj = 0; jj < m; jj += vl) {
-        vl = __riscv_vsetvl_e8m1(m - jj);
-
-        if (rsa == 8) {
-          vcols = __riscv_vlseg8e8_v_u8m1x8(in_tile, vl);
-        } else {
-          vcols = __riscv_vlsseg8e8_v_u8m1x8(in_tile, input_seg_bstride, vl);
-        }
-
-        uint8_t *write_ptr = out_tile;
-        // store each segment continuously along m
-        __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 0),
-                            vl);
-        write_ptr += rsat;
-        __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 1),
-                            vl);
-        write_ptr += rsat;
-        __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 2),
-                            vl);
-        write_ptr += rsat;
-        __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 3),
-                            vl);
-        write_ptr += rsat;
-        __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 4),
-                            vl);
-        write_ptr += rsat;
-        __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 5),
-                            vl);
-        write_ptr += rsat;
-        __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 6),
-                            vl);
-        write_ptr += rsat;
-        __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 7),
-                            vl);
-
-        in_tile += vl * rsa;
-        out_tile += vl;
-      }
-    }
-  }
-
-  const uint8_t *in_tile = a + n_multiple_8;
-  uint8_t *out_tile = at + n_multiple_8 * rsat;
-
-  switch (n % 8) {
+  switch (n_mod8) {
   case 1: {
     // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
     vuint8m8_t vcol = __riscv_vundefined_u8m8();
@@ -465,6 +416,49 @@ skl_transpose_mvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
   default:
     break;
   }
+
+  n -= n_mod8;
+  a += n_mod8;
+  at += n_mod8 * rsat;
+
+  for (size_t ii = 0; ii < n; ii += 8) {
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vuint8m1x8_t vcols = __riscv_vundefined_u8m1x8();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+    const uint8_t *in_tile = a + ii;
+    uint8_t *out_tile = at + ii * rsat;
+    for (size_t jj = 0; jj < m; jj += vl) {
+      vl = __riscv_vsetvl_e8m1(m - jj);
+
+      if (rsa == 8) {
+        vcols = __riscv_vlseg8e8_v_u8m1x8(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg8e8_v_u8m1x8(in_tile, input_seg_bstride, vl);
+      }
+
+      uint8_t *write_ptr = out_tile;
+      // store each segment continuously along m
+      __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 0), vl);
+      write_ptr += rsat;
+      __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 1), vl);
+      write_ptr += rsat;
+      __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 2), vl);
+      write_ptr += rsat;
+      __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 3), vl);
+      write_ptr += rsat;
+      __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 4), vl);
+      write_ptr += rsat;
+      __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 5), vl);
+      write_ptr += rsat;
+      __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 6), vl);
+      write_ptr += rsat;
+      __riscv_vse8_v_u8m1(write_ptr, __riscv_vget_v_u8m1x8_u8m1(vcols, 7), vl);
+
+      in_tile += vl * rsa;
+      out_tile += vl;
+    }
+  }
 }
 
 /* Transposes an M x N row-major matrix (pointed by `a`) to an N x M row-major
@@ -476,58 +470,13 @@ skl_transpose_nvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
                              size_t rsat) {
 
   size_t vl = 0;
-  size_t m_align8 = m / 8 * 8;
   const ptrdiff_t output_seg_bstride = (ptrdiff_t)(rsat * sizeof(uint8_t));
 
-  if (m_align8) {
-    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
-    vuint8m1_t vrow0 = __riscv_vundefined_u8m1();
-    vuint8m1_t vrow1 = __riscv_vundefined_u8m1();
-    vuint8m1_t vrow2 = __riscv_vundefined_u8m1();
-    vuint8m1_t vrow3 = __riscv_vundefined_u8m1();
-    vuint8m1_t vrow4 = __riscv_vundefined_u8m1();
-    vuint8m1_t vrow5 = __riscv_vundefined_u8m1();
-    vuint8m1_t vrow6 = __riscv_vundefined_u8m1();
-    vuint8m1_t vrow7 = __riscv_vundefined_u8m1();
-    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+  size_t m_mod8 = m % 8;
+  const uint8_t *in_tile = a;
+  uint8_t *out_tile = at;
 
-    for (size_t ii = 0; ii + 7 < m_align8; ii += 8) {
-      for (size_t jj = 0; jj < n; jj += vl) {
-        const uint8_t *read_ptr = a + ii * rsa + jj;
-        vl = __riscv_vsetvl_e8m1(n - jj);
-
-        vrow0 = __riscv_vle8_v_u8m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow1 = __riscv_vle8_v_u8m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow2 = __riscv_vle8_v_u8m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow3 = __riscv_vle8_v_u8m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow4 = __riscv_vle8_v_u8m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow5 = __riscv_vle8_v_u8m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow6 = __riscv_vle8_v_u8m1(read_ptr, vl);
-        read_ptr += rsa;
-        vrow7 = __riscv_vle8_v_u8m1(read_ptr, vl);
-
-        vuint8m1x8_t vrows = __riscv_vcreate_v_u8m1x8(
-            vrow0, vrow1, vrow2, vrow3, vrow4, vrow5, vrow6, vrow7);
-        if (rsat == 8) {
-          __riscv_vsseg8e8_v_u8m1x8(at + (jj * rsat) + ii, vrows, vl);
-        } else {
-          __riscv_vssseg8e8_v_u8m1x8(at + (jj * rsat) + ii, output_seg_bstride,
-                                     vrows, vl);
-        }
-      }
-    }
-  }
-
-  const uint8_t *in_tile = a + m_align8 * rsa;
-  uint8_t *out_tile = at + m_align8;
-
-  switch (m % 8) {
+  switch (m_mod8) {
   case 1: {
     // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
     vuint8m8_t vrow = __riscv_vundefined_u8m8();
@@ -730,6 +679,53 @@ skl_transpose_nvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
   }
   default:
     break;
+  }
+
+  m -= m_mod8;
+  a += m_mod8 * rsa;
+  at += m_mod8;
+
+  // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+  vuint8m1_t vrow0 = __riscv_vundefined_u8m1();
+  vuint8m1_t vrow1 = __riscv_vundefined_u8m1();
+  vuint8m1_t vrow2 = __riscv_vundefined_u8m1();
+  vuint8m1_t vrow3 = __riscv_vundefined_u8m1();
+  vuint8m1_t vrow4 = __riscv_vundefined_u8m1();
+  vuint8m1_t vrow5 = __riscv_vundefined_u8m1();
+  vuint8m1_t vrow6 = __riscv_vundefined_u8m1();
+  vuint8m1_t vrow7 = __riscv_vundefined_u8m1();
+  // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+
+  for (size_t ii = 0; ii < m; ii += 8) {
+    for (size_t jj = 0; jj < n; jj += vl) {
+      const uint8_t *read_ptr = a + ii * rsa + jj;
+      vl = __riscv_vsetvl_e8m1(n - jj);
+
+      vrow0 = __riscv_vle8_v_u8m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow1 = __riscv_vle8_v_u8m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow2 = __riscv_vle8_v_u8m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow3 = __riscv_vle8_v_u8m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow4 = __riscv_vle8_v_u8m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow5 = __riscv_vle8_v_u8m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow6 = __riscv_vle8_v_u8m1(read_ptr, vl);
+      read_ptr += rsa;
+      vrow7 = __riscv_vle8_v_u8m1(read_ptr, vl);
+
+      vuint8m1x8_t vrows = __riscv_vcreate_v_u8m1x8(vrow0, vrow1, vrow2, vrow3,
+                                                    vrow4, vrow5, vrow6, vrow7);
+      if (rsat == 8) {
+        __riscv_vsseg8e8_v_u8m1x8(at + (jj * rsat) + ii, vrows, vl);
+      } else {
+        __riscv_vssseg8e8_v_u8m1x8(at + (jj * rsat) + ii, output_seg_bstride,
+                                   vrows, vl);
+      }
+    }
   }
 }
 

--- a/src/pack/rvv/skl_pack_e8_zve32x.c
+++ b/src/pack/rvv/skl_pack_e8_zve32x.c
@@ -1227,7 +1227,6 @@ skl_pack_e8_e8rcprc_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT src,
             if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
               dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0];
             } else {
-              // Pad with zeros
               dst_block[ii0 * rs0 + jj0 * cs0] = pad;
             }
           }
@@ -1263,7 +1262,6 @@ SKL_FUNC void skl_pack_e8rc_e8rcprc_zve32x(size_t m, size_t n,
             if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
               dst_block[ii0 * rs0 + jj0 * cs0] = src_block[ii0 * rs + jj0 * cs];
             } else {
-              // Pad with zeros
               dst_block[ii0 * rs0 + jj0 * cs0] = pad;
             }
           }

--- a/src/pack/rvv/skl_pack_e8_zve32x.c
+++ b/src/pack/rvv/skl_pack_e8_zve32x.c
@@ -17,14 +17,12 @@
 SKL_FUNC_PRIVATE void skl_set_e8_zve32x(uint8_t *dst, uint8_t value, size_t n) {
   size_t vl = __riscv_vsetvl_e8m8(n);
   vuint8m8_t v_value = __riscv_vmv_v_x_u8m8(value, vl);
-  __riscv_vse8_v_u8m8(dst, v_value, vl);
-  n -= vl;
 
   while (n) {
-    dst += vl;
     vl = __riscv_vsetvl_e8m8(n);
     __riscv_vse8_v_u8m8(dst, v_value, vl);
     n -= vl;
+    dst += vl;
   }
 }
 
@@ -199,6 +197,58 @@ SKL_FUNC_PRIVATE void skl_copy_2d_e8_zve32x(size_t m, size_t n,
   }
   for (size_t i = 0; i < m; ++i) {
     skl_copy_e8_zve32x(b + i * rsb, a + i * rsa, n);
+  }
+}
+
+/**
+ * @brief Copy a 2D matrix and pad the output matrix with a constant value in
+ * the N dimension.
+ *
+ * @param n_padded - Number of columns in output matrix
+ * @param m - Number of rows in input matrix and output matrix
+ * @param n - Number of columns in input matrix
+ * @param a - Pointer to input matrix
+ * @param rsa - Row stride of input matrix in elements.
+ * @param b - Pointer to output matrix.
+ * @param rsb - Row stride of output matrix in elements.
+ * @param pad - Value to use for padding.
+ *
+ */
+SKL_FUNC_PRIVATE void skl_copy_2d_padded_n_e8_zve32x(
+    size_t n_padded, size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
+    size_t rsa, uint8_t *SKL_RESTRICT b, size_t rsb, uint8_t pad) {
+  if (n_padded == n) {
+    skl_copy_2d_e8_zve32x(m, n, a, rsa, b, rsb);
+    return;
+  }
+  /* Process N dimension in 3 parts:
+   * - head: Full vlmax-element chunks (direct copy)
+   * - transition: Partial vlmax chunk with data + padding
+   * - tail: Pure padding beyond transition
+   */
+  size_t vlmax = __riscv_vsetvlmax_e8m8();
+  size_t n_head = n / vlmax * vlmax;
+  if (n_head) {
+    skl_copy_2d_e8_zve32x(m, n_head, a, rsa, b, rsb);
+    a += n_head;
+    b += n_head;
+  }
+
+  size_t n_transition = 0;
+  if (n % vlmax) {
+    n_transition = n_padded - n_head > vlmax ? vlmax : n_padded - n_head;
+    vuint8m8_t pad_vec = __riscv_vmv_v_x_u8m8(pad, n_transition);
+    size_t n_load = n - n_head;
+    for (size_t i = 0; i < m; ++i) {
+      pad_vec = __riscv_vle8_v_u8m8_tu(pad_vec, a + i * rsa, n_load);
+      __riscv_vse8_v_u8m8(b + i * rsb, pad_vec, n_transition);
+    }
+    b += n_transition;
+  }
+
+  size_t n_tail = n_padded - n_head - n_transition;
+  if (n_tail) {
+    skl_set_2d_e8_zve32x(b, rsb, pad, m, n_tail);
   }
 }
 
@@ -1146,12 +1196,7 @@ skl_pack_e8_e8rcprc_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT src,
   if (cs0 == 1 && m0 == 1) {
     if (n0 == cs1) {
       /* row-major block ordering */
-      skl_copy_2d_e8_zve32x(m, n, src, rs, dst, rs1);
-      // pad right
-      if (n % n0) {
-        skl_set_2d_e8_zve32x(dst + n, rs1, pad, m, n0 - n % n0);
-      }
-
+      skl_copy_2d_padded_n_e8_zve32x(n0 * n1, m, n, src, rs, dst, rs1, pad);
     } else {
       /* column-major block ordering */
       const uint8_t *src_block = src;
@@ -1163,9 +1208,8 @@ skl_pack_e8_e8rcprc_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT src,
         dst_block += cs1;
       }
       size_t n_tail = n - n0 * (n1 - 1);
-      skl_copy_2d_e8_zve32x(m, n_tail, src_block, rs, dst_block, rs1);
-      // pad right: pad (n0 - n_tail) elements in each of m rows
-      skl_set_2d_e8_zve32x(dst_block + n_tail, rs1, pad, m, n0 - n_tail);
+      skl_copy_2d_padded_n_e8_zve32x(n0, m, n_tail, src_block, rs, dst_block,
+                                     rs1, pad);
     }
     return;
   }
@@ -1184,13 +1228,12 @@ skl_pack_e8_e8rcprc_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT src,
       dst_block += cs1;
     }
     size_t n_tail = n - n0 * (n1 - 1);
-    skl_copy_2d_e8_zve32x(m, n_tail, src_block, rs, dst_block, rs0);
+    skl_copy_2d_padded_n_e8_zve32x(n0, m, n_tail, src_block, rs, dst_block, rs0,
+                                   pad);
     if (m % m0) {
       // pad bottom
       skl_set_2d_e8_zve32x(dst_block + m * rs0, rs0, pad, m0 - m % m0, n0);
     }
-    // pad right: pad (n0 - n_tail) elements in each of m rows
-    skl_set_2d_e8_zve32x(dst_block + n_tail, rs0, pad, m, n0 - n_tail);
     return;
   }
 
@@ -1207,11 +1250,8 @@ skl_pack_e8_e8rcprc_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT src,
         skl_set_2d_e8_zve32x(dst_block + cs0 * n_length, cs0, pad,
                              n0 - n_length, m0);
       } else if (cs0 == 1) {
-        skl_copy_2d_e8_zve32x(m_length, n_length, src_block, rs, dst_block,
-                              rs0);
-        // pad right: pad (n0 - n_length) elements in each of m_length rows
-        skl_set_2d_e8_zve32x(dst_block + n_length, rs0, pad, m_length,
-                             n0 - n_length);
+        skl_copy_2d_padded_n_e8_zve32x(n0, m_length, n_length, src_block, rs,
+                                       dst_block, rs0, pad);
         // pad bottom: pad (m0 - m_length) rows, each with n0 elements
         skl_set_2d_e8_zve32x(dst_block + m_length * rs0, rs0, pad,
                              m0 - m_length, n0);

--- a/src/pack/rvv/skl_pack_e8_zve32x.c
+++ b/src/pack/rvv/skl_pack_e8_zve32x.c
@@ -1127,8 +1127,7 @@ skl_pack_e8_e8rcprc_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT src,
       skl_transpose_e8_zve32x(m0, n, src_block, rs, dst_block, cs0);
       if (n % n0) {
         // pad right
-        skl_set_2d_e8_zve32x(dst_block + cs1 * (n1 - 1) + cs0 * (n % n0), cs0,
-                             pad, n0 - n % n0, m0);
+        skl_set_2d_e8_zve32x(dst_block + cs0 * n, cs0, pad, n0 - n % n0, m0);
       }
       src_block += m0 * rs;
       dst_block += rs1;
@@ -1138,8 +1137,7 @@ skl_pack_e8_e8rcprc_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT src,
                                      cs0, pad);
     if (n % n0) {
       // pad right
-      skl_set_2d_e8_zve32x(dst_block + cs1 * (n1 - 1) + cs0 * (n % n0), cs0,
-                           pad, n0 - n % n0, m0);
+      skl_set_2d_e8_zve32x(dst_block + cs0 * n, cs0, pad, n0 - n % n0, m0);
     }
     return;
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -354,6 +354,13 @@ skl_add_test(
   ""
 )
 skl_add_test(
+  skl_pack_e32_zve32x
+  pack/pack_e32rc_e32rcprc.c
+  pack/rvv/skl_pack_e32_zve32x.c
+  "zve32x"
+  ""
+)
+skl_add_test(
   skl_pack_e8_zve32x
   pack/pack_e8rc_e8rcprc.c
   pack/rvv/skl_pack_e8_zve32x.c

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -347,23 +347,23 @@ skl_add_test(
   ""
 )
 skl_add_test(
-  skl_pack_e16_zve32x
+  skl_pack_e16rc_e16rcprc_zve32x
   pack/pack_e16rc_e16rcprc.c
-  pack/rvv/skl_pack_e16_zve32x.c
+  pack/rvv/skl_pack_e16rc_e16rcprc_zve32x.c
   "zve32x"
   ""
 )
 skl_add_test(
-  skl_pack_e32_zve32x
+  skl_pack_e32rc_e32rcprc_zve32x
   pack/pack_e32rc_e32rcprc.c
-  pack/rvv/skl_pack_e32_zve32x.c
+  pack/rvv/skl_pack_e32rc_e32rcprc_zve32x.c
   "zve32x"
   ""
 )
 skl_add_test(
-  skl_pack_e8_zve32x
+  skl_pack_e8rc_e8rcprc_zve32x
   pack/pack_e8rc_e8rcprc.c
-  pack/rvv/skl_pack_e8_zve32x.c
+  pack/rvv/skl_pack_e8rc_e8rcprc_zve32x.c
   "zve32x"
   ""
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -347,6 +347,13 @@ skl_add_test(
   ""
 )
 skl_add_test(
+  skl_pack_e16_zve32x
+  pack/pack_e16rc_e16rcprc.c
+  pack/rvv/skl_pack_e16_zve32x.c
+  "zve32x"
+  ""
+)
+skl_add_test(
   skl_pack_e8_zve32x
   pack/pack_e8rc_e8rcprc.c
   pack/rvv/skl_pack_e8_zve32x.c

--- a/test/pack/pack_e16rc_e16rcprc.c
+++ b/test/pack/pack_e16rc_e16rcprc.c
@@ -80,8 +80,8 @@ void pack_e16rc_e16rcprc_verify(skl_test_t *t) {
   // Verify result
   for (size_t i = 0; i < h->dst.len; ++i) {
     if (dst[i] != ref_dst[i]) {
-      SKL_TEST_LOG(t, SKL_TEST_LOG_ERROR, "position [%zu]: %hhu != ref %hhu\n",
-                   i, dst[i], ref_dst[i]);
+      SKL_TEST_LOG(t, SKL_TEST_LOG_ERROR, "position [%zu]: %hu != ref %hu\n", i,
+                   dst[i], ref_dst[i]);
       t->status.verify_status = SKL_TEST_FAIL;
       return;
     }

--- a/test/pack/pack_e16rc_e16rcprc.c
+++ b/test/pack/pack_e16rc_e16rcprc.c
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @brief Implementation of the pack_e16rc_e16rcprc test harness.
+ *
+ * This file defines all harness functions _except_ `execute`, which is
+ * defined in the test file (e.g. rvv/skl_pack_e16_zve32x.c).
+ */
+
+#include "pack_e16rc_e16rcprc.h"
+#include "skl-ref.h"
+#include "skl-test-driver.h"
+#include "skl_test_pack.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+void pack_e16rc_e16rcprc_init(skl_test_t *t) {
+  pack_e16rc_e16rcprc_t *h = (pack_e16rc_e16rcprc_t *)t->harness;
+
+  size_t m = h->m;
+  size_t n = h->n;
+  size_t rs = h->rs;
+  size_t cs = h->cs;
+  size_t m0 = h->m0;
+  size_t n0 = h->n0;
+  size_t m1 = (m + m0 - 1) / m0;
+  size_t n1 = (n + n0 - 1) / n0;
+  size_t rs0 = h->rs0;
+  size_t cs0 = h->cs0;
+  size_t rs1 = h->rs1;
+  size_t cs1 = h->cs1;
+
+  skl_test_check_matrix_params_rcprc(t, 1, 1, m, n, 1, 1, rs, cs);
+  skl_test_check_matrix_params_rcprc(t, m0, n0, m1, n1, rs0, cs0, rs1, cs1);
+
+  if (t->status.init_status != SKL_TEST_PASS) {
+    return;
+  }
+
+  if (m == 0 || n == 0) {
+    h->src.len = 0;
+  } else {
+    h->src.len = (m - 1) * rs + (n - 1) * cs + 1;
+  }
+
+  if (m1 == 0 || n1 == 0) {
+    h->dst.len = 0;
+  } else {
+    h->dst.len =
+        (m1 - 1) * rs1 + (n1 - 1) * cs1 + (m0 - 1) * rs0 + (n0 - 1) * cs0 + 1;
+  }
+
+  SKL_TEST_BUF_CREATE(t, uint16_t, &h->src);
+  SKL_TEST_BUF_CREATE(t, uint16_t, &h->dst);
+  if (h->steps.verify && h->dst.len) {
+    h->ctx.ref_dst = malloc(h->dst.len * sizeof(uint16_t));
+
+    // Copy original `dst` contents into ref to check for clobbered data later.
+    memcpy(h->ctx.ref_dst, h->dst.data, h->dst.len * sizeof(uint16_t));
+  }
+}
+
+void pack_e16rc_e16rcprc_verify(skl_test_t *t) {
+  pack_e16rc_e16rcprc_t *h = (pack_e16rc_e16rcprc_t *)t->harness;
+
+  const uint16_t *dst = h->dst.data;
+  uint16_t *ref_dst = h->ctx.ref_dst;
+
+  // Compute reference value
+  skl_pack_e16rc_e16rcprc_ref(h->m, h->n, h->src.data, h->rs, h->cs, h->m0,
+                              h->n0, ref_dst, h->rs0, h->cs0, h->rs1, h->cs1,
+                              h->pad);
+
+  // Verify result
+  for (size_t i = 0; i < h->dst.len; ++i) {
+    if (dst[i] != ref_dst[i]) {
+      SKL_TEST_LOG(t, SKL_TEST_LOG_ERROR, "position [%zu]: %hhu != ref %hhu\n",
+                   i, dst[i], ref_dst[i]);
+      t->status.verify_status = SKL_TEST_FAIL;
+      return;
+    }
+  }
+}
+
+void pack_e16rc_e16rcprc_test_report(skl_test_t *t) {
+  pack_e16rc_e16rcprc_t *h = (pack_e16rc_e16rcprc_t *)t->harness;
+  pack_rc_rcprc_report_param(t, h->m, h->n, h->rs, h->cs, h->m0, h->n0, h->rs0,
+                             h->cs0, h->rs1, h->cs1);
+}
+
+void pack_e16rc_e16rcprc_benchmark_report(skl_test_t *t) {
+  pack_e16rc_e16rcprc_t *h = (pack_e16rc_e16rcprc_t *)t->harness;
+  pack_e16rc_e16rcprc_test_report(t);
+  size_t m1 = (h->m + h->m0 - 1) / h->m0;
+  size_t n1 = (h->n + h->n0 - 1) / h->n0;
+  size_t output_elements = m1 * n1 * h->m0 * h->n0;
+  pack_rc_rcprc_report_perf(t, h->steps.warmup, output_elements);
+}
+
+void pack_e16rc_e16rcprc_cleanup(skl_test_t *t) {
+  pack_e16rc_e16rcprc_t *h = (pack_e16rc_e16rcprc_t *)t->harness;
+
+  SKL_TEST_BUF_FREE(t, &h->src);
+  SKL_TEST_BUF_FREE(t, &h->dst);
+  if (h->steps.verify && h->dst.len) {
+    free(h->ctx.ref_dst);
+  }
+}

--- a/test/pack/pack_e16rc_e16rcprc.h
+++ b/test/pack/pack_e16rc_e16rcprc.h
@@ -48,7 +48,7 @@ typedef struct {
 
 #define PACK_E16RC_E16RCPRC_DEFAULTS                                           \
   .src = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM},                      \
-  .dst = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM}, .pad = 255
+  .dst = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM}, .pad = 0xBEEF
 
 void pack_e16rc_e16rcprc_init(skl_test_t *t);
 void pack_e16rc_e16rcprc_verify(skl_test_t *t);

--- a/test/pack/pack_e16rc_e16rcprc.h
+++ b/test/pack/pack_e16rc_e16rcprc.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @brief Test and benchmark for Pack
+ *
+ * This test uses a table-driven approach where test configurations are defined
+ * in the `tests` array. Each test specifies:
+ *  - Input matrix dimensions m, n
+ *  - Input matrix strides rs, cs
+ *  - Block dimensions m0, n0
+ *  - Output block strides rs0, cs0 (within block), rs1, cs1 (between blocks)
+ *  - Padding value
+ */
+
+#pragma once
+
+#include "skl-test-driver.h"
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+  // Test function pointers for various steps
+  // *** This field must be placed first within this struct ***
+  skl_test_steps_t steps;
+
+  // Input matrix dimensions
+  size_t m, n;
+  // Input matrix strides
+  size_t rs, cs;
+  // Block dimensions
+  size_t m0, n0;
+  // Output block strides
+  size_t rs0, cs0; // within block
+  size_t rs1, cs1; // between blocks
+
+  uint16_t pad;
+  // Buffer generation settings
+  SKL_TEST_BUFFER(uint16_t) src, dst;
+
+  // Derived parameters & buffers (private to the test harness)
+  struct {
+    uint16_t *ref_dst;
+  } ctx;
+} pack_e16rc_e16rcprc_t;
+
+#define PACK_E16RC_E16RCPRC_DEFAULTS                                           \
+  .src = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM},                      \
+  .dst = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM}, .pad = 255
+
+void pack_e16rc_e16rcprc_init(skl_test_t *t);
+void pack_e16rc_e16rcprc_verify(skl_test_t *t);
+void pack_e16rc_e16rcprc_test_report(skl_test_t *t);
+void pack_e16rc_e16rcprc_benchmark_report(skl_test_t *t);
+void pack_e16rc_e16rcprc_cleanup(skl_test_t *t);

--- a/test/pack/pack_e32rc_e32rcprc.c
+++ b/test/pack/pack_e32rc_e32rcprc.c
@@ -80,8 +80,8 @@ void pack_e32rc_e32rcprc_verify(skl_test_t *t) {
   // Verify result
   for (size_t i = 0; i < h->dst.len; ++i) {
     if (dst[i] != ref_dst[i]) {
-      SKL_TEST_LOG(t, SKL_TEST_LOG_ERROR, "position [%zu]: %hhu != ref %hhu\n",
-                   i, dst[i], ref_dst[i]);
+      SKL_TEST_LOG(t, SKL_TEST_LOG_ERROR, "position [%zu]: %u != ref %u\n", i,
+                   dst[i], ref_dst[i]);
       t->status.verify_status = SKL_TEST_FAIL;
       return;
     }

--- a/test/pack/pack_e32rc_e32rcprc.c
+++ b/test/pack/pack_e32rc_e32rcprc.c
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @brief Implementation of the pack_e32rc_e32rcprc test harness.
+ *
+ * This file defines all harness functions _except_ `execute`, which is
+ * defined in the test file (e.g. rvv/skl_pack_e32_zve32x.c).
+ */
+
+#include "pack_e32rc_e32rcprc.h"
+#include "skl-ref.h"
+#include "skl-test-driver.h"
+#include "skl_test_pack.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+void pack_e32rc_e32rcprc_init(skl_test_t *t) {
+  pack_e32rc_e32rcprc_t *h = (pack_e32rc_e32rcprc_t *)t->harness;
+
+  size_t m = h->m;
+  size_t n = h->n;
+  size_t rs = h->rs;
+  size_t cs = h->cs;
+  size_t m0 = h->m0;
+  size_t n0 = h->n0;
+  size_t m1 = (m + m0 - 1) / m0;
+  size_t n1 = (n + n0 - 1) / n0;
+  size_t rs0 = h->rs0;
+  size_t cs0 = h->cs0;
+  size_t rs1 = h->rs1;
+  size_t cs1 = h->cs1;
+
+  skl_test_check_matrix_params_rcprc(t, 1, 1, m, n, 1, 1, rs, cs);
+  skl_test_check_matrix_params_rcprc(t, m0, n0, m1, n1, rs0, cs0, rs1, cs1);
+
+  if (t->status.init_status != SKL_TEST_PASS) {
+    return;
+  }
+
+  if (m == 0 || n == 0) {
+    h->src.len = 0;
+  } else {
+    h->src.len = (m - 1) * rs + (n - 1) * cs + 1;
+  }
+
+  if (m1 == 0 || n1 == 0) {
+    h->dst.len = 0;
+  } else {
+    h->dst.len =
+        (m1 - 1) * rs1 + (n1 - 1) * cs1 + (m0 - 1) * rs0 + (n0 - 1) * cs0 + 1;
+  }
+
+  SKL_TEST_BUF_CREATE(t, uint32_t, &h->src);
+  SKL_TEST_BUF_CREATE(t, uint32_t, &h->dst);
+  if (h->steps.verify && h->dst.len) {
+    h->ctx.ref_dst = malloc(h->dst.len * sizeof(uint32_t));
+
+    // Copy original `dst` contents into ref to check for clobbered data later.
+    memcpy(h->ctx.ref_dst, h->dst.data, h->dst.len * sizeof(uint32_t));
+  }
+}
+
+void pack_e32rc_e32rcprc_verify(skl_test_t *t) {
+  pack_e32rc_e32rcprc_t *h = (pack_e32rc_e32rcprc_t *)t->harness;
+
+  const uint32_t *dst = h->dst.data;
+  uint32_t *ref_dst = h->ctx.ref_dst;
+
+  // Compute reference value
+  skl_pack_e32rc_e32rcprc_ref(h->m, h->n, h->src.data, h->rs, h->cs, h->m0,
+                              h->n0, ref_dst, h->rs0, h->cs0, h->rs1, h->cs1,
+                              h->pad);
+
+  // Verify result
+  for (size_t i = 0; i < h->dst.len; ++i) {
+    if (dst[i] != ref_dst[i]) {
+      SKL_TEST_LOG(t, SKL_TEST_LOG_ERROR, "position [%zu]: %hhu != ref %hhu\n",
+                   i, dst[i], ref_dst[i]);
+      t->status.verify_status = SKL_TEST_FAIL;
+      return;
+    }
+  }
+}
+
+void pack_e32rc_e32rcprc_test_report(skl_test_t *t) {
+  pack_e32rc_e32rcprc_t *h = (pack_e32rc_e32rcprc_t *)t->harness;
+  pack_rc_rcprc_report_param(t, h->m, h->n, h->rs, h->cs, h->m0, h->n0, h->rs0,
+                             h->cs0, h->rs1, h->cs1);
+}
+
+void pack_e32rc_e32rcprc_benchmark_report(skl_test_t *t) {
+  pack_e32rc_e32rcprc_t *h = (pack_e32rc_e32rcprc_t *)t->harness;
+  pack_e32rc_e32rcprc_test_report(t);
+  size_t m1 = (h->m + h->m0 - 1) / h->m0;
+  size_t n1 = (h->n + h->n0 - 1) / h->n0;
+  size_t output_elements = m1 * n1 * h->m0 * h->n0;
+  pack_rc_rcprc_report_perf(t, h->steps.warmup, output_elements);
+}
+
+void pack_e32rc_e32rcprc_cleanup(skl_test_t *t) {
+  pack_e32rc_e32rcprc_t *h = (pack_e32rc_e32rcprc_t *)t->harness;
+
+  SKL_TEST_BUF_FREE(t, &h->src);
+  SKL_TEST_BUF_FREE(t, &h->dst);
+  if (h->steps.verify && h->dst.len) {
+    free(h->ctx.ref_dst);
+  }
+}

--- a/test/pack/pack_e32rc_e32rcprc.h
+++ b/test/pack/pack_e32rc_e32rcprc.h
@@ -48,7 +48,7 @@ typedef struct {
 
 #define PACK_E32RC_E32RCPRC_DEFAULTS                                           \
   .src = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM},                      \
-  .dst = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM}, .pad = 255
+  .dst = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM}, .pad = 0xDEADBEEF
 
 void pack_e32rc_e32rcprc_init(skl_test_t *t);
 void pack_e32rc_e32rcprc_verify(skl_test_t *t);

--- a/test/pack/pack_e32rc_e32rcprc.h
+++ b/test/pack/pack_e32rc_e32rcprc.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @brief Test and benchmark for Pack
+ *
+ * This test uses a table-driven approach where test configurations are defined
+ * in the `tests` array. Each test specifies:
+ *  - Input matrix dimensions m, n
+ *  - Input matrix strides rs, cs
+ *  - Block dimensions m0, n0
+ *  - Output block strides rs0, cs0 (within block), rs1, cs1 (between blocks)
+ *  - Padding value
+ */
+
+#pragma once
+
+#include "skl-test-driver.h"
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+  // Test function pointers for various steps
+  // *** This field must be placed first within this struct ***
+  skl_test_steps_t steps;
+
+  // Input matrix dimensions
+  size_t m, n;
+  // Input matrix strides
+  size_t rs, cs;
+  // Block dimensions
+  size_t m0, n0;
+  // Output block strides
+  size_t rs0, cs0; // within block
+  size_t rs1, cs1; // between blocks
+
+  uint32_t pad;
+  // Buffer generation settings
+  SKL_TEST_BUFFER(uint32_t) src, dst;
+
+  // Derived parameters & buffers (private to the test harness)
+  struct {
+    uint32_t *ref_dst;
+  } ctx;
+} pack_e32rc_e32rcprc_t;
+
+#define PACK_E32RC_E32RCPRC_DEFAULTS                                           \
+  .src = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM},                      \
+  .dst = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM}, .pad = 255
+
+void pack_e32rc_e32rcprc_init(skl_test_t *t);
+void pack_e32rc_e32rcprc_verify(skl_test_t *t);
+void pack_e32rc_e32rcprc_test_report(skl_test_t *t);
+void pack_e32rc_e32rcprc_benchmark_report(skl_test_t *t);
+void pack_e32rc_e32rcprc_cleanup(skl_test_t *t);

--- a/test/pack/pack_e8rc_e8rcprc.h
+++ b/test/pack/pack_e8rc_e8rcprc.h
@@ -48,7 +48,7 @@ typedef struct {
 
 #define PACK_E8RC_E8RCPRC_DEFAULTS                                             \
   .src = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM},                      \
-  .dst = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM}, .pad = 255
+  .dst = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM}, .pad = 0xFF
 
 void pack_e8rc_e8rcprc_init(skl_test_t *t);
 void pack_e8rc_e8rcprc_verify(skl_test_t *t);

--- a/test/pack/rvv/skl_pack_e16_zve32x.c
+++ b/test/pack/rvv/skl_pack_e16_zve32x.c
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#include "pack/pack_e16rc_e16rcprc.h"
+#include "skl-test-driver.h"
+#include "skl.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if !defined(__riscv_zve32x)
+#error This file requires the Zve32x extension
+#endif
+
+/**
+ * @brief Test cases for pack with Zve32x extension.
+ *
+ * This test uses the pack_e16rc_e16rcprc harness.
+ */
+
+#define TEST                                                                   \
+  PACK_E16RC_E16RCPRC_DEFAULTS, .steps = {                                     \
+                                    .init = pack_e16rc_e16rcprc_init,          \
+                                    .warmup = NULL,                            \
+                                    .execute = execute,                        \
+                                    .verify = pack_e16rc_e16rcprc_verify,      \
+                                    .report = pack_e16rc_e16rcprc_test_report, \
+                                    .cleanup = pack_e16rc_e16rcprc_cleanup,    \
+  }
+
+#define BENCH                                                                  \
+  PACK_E16RC_E16RCPRC_DEFAULTS,                                                \
+      .steps = {                                                               \
+          .init = pack_e16rc_e16rcprc_init,                                    \
+          .warmup = execute,                                                   \
+          .execute = execute,                                                  \
+          .verify = NULL,                                                      \
+          .report = pack_e16rc_e16rcprc_benchmark_report,                      \
+          .cleanup = pack_e16rc_e16rcprc_cleanup,                              \
+  }
+
+static void execute(skl_test_t *t);
+
+// clang-format off
+pack_e16rc_e16rcprc_t tests[] = {
+#ifdef SKL_ENABLE_BENCHMARKS
+  // Benchmark tests
+  {BENCH, .m = 128, .n = 128, .rs = 128, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 1024, .cs1 = 64},
+#endif
+
+#ifdef SKL_ENABLE_TESTS
+  // Verification tests
+
+  /* Small matrices (one-block case)*/
+  {TEST, .m = 2, .n = 3, .rs = 3, .cs = 1, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 4, .rs1 = 16, .cs1 = 16},
+  {TEST, .m = 2, .n = 3, .rs = 1, .cs = 2, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 4, .rs1 = 16, .cs1 = 16},
+  {TEST, .m = 2, .n = 3, .rs = 3, .cs = 1, .m0 = 4, .n0 = 4,
+   .rs0 = 4, .cs0 = 1, .rs1 = 16, .cs1 = 16},
+  {TEST, .m = 2, .n = 3, .rs = 1, .cs = 2, .m0 = 4, .n0 = 4,
+   .rs0 = 4, .cs0 = 1, .rs1 = 16, .cs1 = 16},
+
+  /* Non-multiple of block size */
+  {TEST, .m = 5, .n = 5, .rs = 5, .cs = 1, .m0 = 4, .n0 = 8,
+   .rs0 = 1, .cs0 = 4, .rs1 = 64, .cs1 = 32},
+  {TEST, .m = 10, .n = 10, .rs = 10, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 128, .cs1 = 64},
+  {TEST, .m = 7, .n = 9, .rs = 9, .cs = 1, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 4, .rs1 = 48, .cs1 = 16},
+  {TEST, .m = 9, .n = 8, .rs = 8, .cs = 1, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 4, .rs1 = 32, .cs1 = 16},
+  {TEST, .m = 20, .n = 16, .rs = 16, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 128, .cs1 = 64},
+
+  {TEST, .m = 5, .n = 5, .rs = 1, .cs = 5, .m0 = 4, .n0 = 8,
+   .rs0 = 1, .cs0 = 4, .rs1 = 64, .cs1 = 32},
+  {TEST, .m = 10, .n = 10, .rs = 1, .cs = 10, .m0 = 8, .n0 = 8,
+   .rs0 = 8, .cs0 = 1, .rs1 = 128, .cs1 = 64},
+  {TEST, .m = 7, .n = 9, .rs = 1, .cs = 7, .m0 = 4, .n0 = 4,
+   .rs0 = 4, .cs0 = 1, .rs1 = 48, .cs1 = 16},
+  {TEST, .m = 9, .n = 8, .rs = 1, .cs = 9, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 4, .rs1 = 32, .cs1 = 16},
+  {TEST, .m = 20, .n = 16, .rs = 1, .cs = 20, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 128, .cs1 = 64},
+
+
+  /* Multiple of block size  */
+  {TEST, .m = 8, .n = 8, .rs = 16, .cs = 1, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 8, .rs1 = 64, .cs1 = 32},
+  {TEST, .m = 12, .n = 12, .rs = 12, .cs = 1, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 4, .rs1 = 48, .cs1 = 16},
+  {TEST, .m = 16, .n = 16, .rs = 16, .cs = 1, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 4, .rs1 = 64, .cs1 = 16},
+  {TEST, .m = 16, .n = 16, .rs = 16, .cs = 1, .m0 = 4, .n0 = 8,
+   .rs0 = 1, .cs0 = 4, .rs1 = 64, .cs1 = 32},
+  {TEST, .m = 16, .n = 16, .rs = 16, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 128, .cs1 = 64},
+  {TEST, .m = 16, .n = 16, .rs = 16, .cs = 1, .m0 = 16, .n0 = 16,
+   .rs0 = 1, .cs0 = 16, .rs1 = 256, .cs1 = 256},
+  {TEST, .m = 32, .n = 8, .rs = 8, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 64, .cs1 = 64},
+  {TEST, .m = 8, .n = 32, .rs = 32, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 256, .cs1 = 64},
+
+  /* Specialization 1: (cs0 * n0 == cs1) && rs0 == 1 */
+  {TEST, .m = 16, .n = 12, .rs = 12, .cs = 1, .m0 = 4, .n0 = 3,
+   .rs0 = 1, .cs0 = 4, .rs1 = 48, .cs1 = 12},
+  {TEST, .m = 10, .n = 8, .rs = 8, .cs = 1, .m0 = 4, .n0 = 3,
+   .rs0 = 1, .cs0 = 4, .rs1 = 36, .cs1 = 12},
+  {TEST, .m = 10, .n = 18, .rs = 18, .cs = 1, .m0 = 4, .n0 = 1,
+   .rs0 = 1, .cs0 = 4, .rs1 = 72, .cs1 = 4},
+
+  /* Specialization 2: (rs0 * m0 == rs1) && cs0 == 1 */
+  {TEST, .m = 12, .n = 16, .rs = 16, .cs = 1, .m0 = 4, .n0 = 8,
+   .rs0 = 8, .cs0 = 1, .rs1 = 32, .cs1 = 96},
+  {TEST, .m = 16, .n = 12, .rs = 12, .cs = 1, .m0 = 2, .n0 = 5,
+   .rs0 = 5, .cs0 = 1, .rs1 = 10, .cs1 = 80},
+  {TEST, .m = 10, .n = 8, .rs = 8, .cs = 1, .m0 = 4, .n0 = 8,
+   .rs0 = 8, .cs0 = 1, .rs1 = 32, .cs1 = 32},
+
+  /* Specialization 3: rs0 == 1 && n0 == 1 && m0 == rs1 - Column panel transpose */
+  {TEST, .m = 12, .n = 8, .rs = 8, .cs = 1, .m0 = 4, .n0 = 1,
+   .rs0 = 1, .cs0 = 4, .rs1 = 4, .cs1 = 12},
+  {TEST, .m = 20, .n = 16, .rs = 16, .cs = 1, .m0 = 8, .n0 = 1,
+   .rs0 = 1, .cs0 = 8, .rs1 = 8, .cs1 = 24},
+
+  /* Specialization 4: cs0 == 1 && m0 == 1 && n0 == cs1 - Row panel copy */
+  {TEST, .m = 8, .n = 12, .rs = 12, .cs = 1, .m0 = 1, .n0 = 4,
+   .rs0 = 4, .cs0 = 1, .rs1 = 12, .cs1 = 4},
+  {TEST, .m = 12, .n = 10, .rs = 10, .cs = 1, .m0 = 1, .n0 = 4,
+   .rs0 = 4, .cs0 = 1, .rs1 = 12, .cs1 = 4},
+
+  /* Larger matrices */
+  {TEST, .m = 64, .n = 64, .rs = 64, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 512, .cs1 = 64},
+  {TEST, .m = 128, .n = 128, .rs = 128, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 1024, .cs1 = 64},
+
+  {TEST, .m = 300, .n = 200, .rs = 200, .cs = 1, .m0 = 64, .n0 = 16,
+   .rs0 = 16, .cs0 = 1, .rs1 = 13312, .cs1 = 1024},
+  {TEST, .m = 300, .n = 200, .rs = 200, .cs = 1, .m0 = 64, .n0 = 16,
+   .rs0 = 16, .cs0 = 1, .rs1 = 1024, .cs1 = 5120},
+  {TEST, .m = 300, .n = 200, .rs = 200, .cs = 1, .m0 = 64, .n0 = 16,
+   .rs0 = 1, .cs0 = 64, .rs1 = 13312, .cs1 = 1024},
+  {TEST, .m = 300, .n = 200, .rs = 200, .cs = 1, .m0 = 64, .n0 = 16,
+   .rs0 = 1, .cs0 = 64, .rs1 = 1024, .cs1 = 5120},
+
+  {TEST, .m = 300, .n = 200, .rs = 1, .cs = 300, .m0 = 64, .n0 = 16,
+   .rs0 = 16, .cs0 = 1, .rs1 = 13312, .cs1 = 1024},
+  {TEST, .m = 300, .n = 200, .rs = 1, .cs = 300, .m0 = 64, .n0 = 16,
+   .rs0 = 16, .cs0 = 1, .rs1 = 1024, .cs1 = 5120},
+  {TEST, .m = 300, .n = 200, .rs = 1, .cs = 300, .m0 = 64, .n0 = 16,
+   .rs0 = 1, .cs0 = 64, .rs1 = 13312, .cs1 = 1024},
+  {TEST, .m = 300, .n = 200, .rs = 1, .cs = 300, .m0 = 64, .n0 = 16,
+   .rs0 = 1, .cs0 = 64, .rs1 = 1024, .cs1 = 5120},
+#endif
+};
+// clang-format on
+
+static skl_test_suite_t suite = {.name = "skl_pack_e16_zve32x",
+                                 .num_tests = sizeof(tests) / sizeof(tests[0]),
+                                 .test_size = sizeof(pack_e16rc_e16rcprc_t),
+                                 .tests = tests};
+
+static void execute(skl_test_t *t) {
+  const pack_e16rc_e16rcprc_t *h = (pack_e16rc_e16rcprc_t *)t->harness;
+
+  skl_pack_e16rc_e16rcprc_zve32x(h->m, h->n, h->src.data, h->rs, h->cs, h->m0,
+                                 h->n0, h->dst.data, h->rs0, h->cs0, h->rs1,
+                                 h->cs1, h->pad);
+}
+
+int main(void) { return skl_test_driver_run_suite(&suite); }

--- a/test/pack/rvv/skl_pack_e16rc_e16rcprc_zve32x.c
+++ b/test/pack/rvv/skl_pack_e16rc_e16rcprc_zve32x.c
@@ -3,7 +3,7 @@
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT
 
-#include "pack/pack_e32rc_e32rcprc.h"
+#include "pack/pack_e16rc_e16rcprc.h"
 #include "skl-test-driver.h"
 #include "skl.h"
 
@@ -17,34 +17,34 @@
 /**
  * @brief Test cases for pack with Zve32x extension.
  *
- * This test uses the pack_e32rc_e32rcprc harness.
+ * This test uses the pack_e16rc_e16rcprc harness.
  */
 
 #define TEST                                                                   \
-  PACK_E32RC_E32RCPRC_DEFAULTS, .steps = {                                     \
-                                    .init = pack_e32rc_e32rcprc_init,          \
+  PACK_E16RC_E16RCPRC_DEFAULTS, .steps = {                                     \
+                                    .init = pack_e16rc_e16rcprc_init,          \
                                     .warmup = NULL,                            \
                                     .execute = execute,                        \
-                                    .verify = pack_e32rc_e32rcprc_verify,      \
-                                    .report = pack_e32rc_e32rcprc_test_report, \
-                                    .cleanup = pack_e32rc_e32rcprc_cleanup,    \
+                                    .verify = pack_e16rc_e16rcprc_verify,      \
+                                    .report = pack_e16rc_e16rcprc_test_report, \
+                                    .cleanup = pack_e16rc_e16rcprc_cleanup,    \
   }
 
 #define BENCH                                                                  \
-  PACK_E32RC_E32RCPRC_DEFAULTS,                                                \
+  PACK_E16RC_E16RCPRC_DEFAULTS,                                                \
       .steps = {                                                               \
-          .init = pack_e32rc_e32rcprc_init,                                    \
+          .init = pack_e16rc_e16rcprc_init,                                    \
           .warmup = execute,                                                   \
           .execute = execute,                                                  \
           .verify = NULL,                                                      \
-          .report = pack_e32rc_e32rcprc_benchmark_report,                      \
-          .cleanup = pack_e32rc_e32rcprc_cleanup,                              \
+          .report = pack_e16rc_e16rcprc_benchmark_report,                      \
+          .cleanup = pack_e16rc_e16rcprc_cleanup,                              \
   }
 
 static void execute(skl_test_t *t);
 
 // clang-format off
-pack_e32rc_e32rcprc_t tests[] = {
+pack_e16rc_e16rcprc_t tests[] = {
 #ifdef SKL_ENABLE_BENCHMARKS
   // Benchmark tests
   {BENCH, .m = 128, .n = 128, .rs = 128, .cs = 1, .m0 = 8, .n0 = 8,
@@ -161,15 +161,15 @@ pack_e32rc_e32rcprc_t tests[] = {
 };
 // clang-format on
 
-static skl_test_suite_t suite = {.name = "skl_pack_e32_zve32x",
+static skl_test_suite_t suite = {.name = "skl_pack_e16rc_e16rcprc_zve32x",
                                  .num_tests = sizeof(tests) / sizeof(tests[0]),
-                                 .test_size = sizeof(pack_e32rc_e32rcprc_t),
+                                 .test_size = sizeof(pack_e16rc_e16rcprc_t),
                                  .tests = tests};
 
 static void execute(skl_test_t *t) {
-  const pack_e32rc_e32rcprc_t *h = (pack_e32rc_e32rcprc_t *)t->harness;
+  const pack_e16rc_e16rcprc_t *h = (pack_e16rc_e16rcprc_t *)t->harness;
 
-  skl_pack_e32rc_e32rcprc_zve32x(h->m, h->n, h->src.data, h->rs, h->cs, h->m0,
+  skl_pack_e16rc_e16rcprc_zve32x(h->m, h->n, h->src.data, h->rs, h->cs, h->m0,
                                  h->n0, h->dst.data, h->rs0, h->cs0, h->rs1,
                                  h->cs1, h->pad);
 }

--- a/test/pack/rvv/skl_pack_e32_zve32x.c
+++ b/test/pack/rvv/skl_pack_e32_zve32x.c
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#include "pack/pack_e32rc_e32rcprc.h"
+#include "skl-test-driver.h"
+#include "skl.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if !defined(__riscv_zve32x)
+#error This file requires the Zve32x extension
+#endif
+
+/**
+ * @brief Test cases for pack with Zve32x extension.
+ *
+ * This test uses the pack_e32rc_e32rcprc harness.
+ */
+
+#define TEST                                                                   \
+  PACK_E32RC_E32RCPRC_DEFAULTS, .steps = {                                     \
+                                    .init = pack_e32rc_e32rcprc_init,          \
+                                    .warmup = NULL,                            \
+                                    .execute = execute,                        \
+                                    .verify = pack_e32rc_e32rcprc_verify,      \
+                                    .report = pack_e32rc_e32rcprc_test_report, \
+                                    .cleanup = pack_e32rc_e32rcprc_cleanup,    \
+  }
+
+#define BENCH                                                                  \
+  PACK_E32RC_E32RCPRC_DEFAULTS,                                                \
+      .steps = {                                                               \
+          .init = pack_e32rc_e32rcprc_init,                                    \
+          .warmup = execute,                                                   \
+          .execute = execute,                                                  \
+          .verify = NULL,                                                      \
+          .report = pack_e32rc_e32rcprc_benchmark_report,                      \
+          .cleanup = pack_e32rc_e32rcprc_cleanup,                              \
+  }
+
+static void execute(skl_test_t *t);
+
+// clang-format off
+pack_e32rc_e32rcprc_t tests[] = {
+#ifdef SKL_ENABLE_BENCHMARKS
+  // Benchmark tests
+  {BENCH, .m = 128, .n = 128, .rs = 128, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 1024, .cs1 = 64},
+#endif
+
+#ifdef SKL_ENABLE_TESTS
+  // Verification tests
+
+  /* Small matrices (one-block case)*/
+  {TEST, .m = 2, .n = 3, .rs = 3, .cs = 1, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 4, .rs1 = 16, .cs1 = 16},
+  {TEST, .m = 2, .n = 3, .rs = 1, .cs = 2, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 4, .rs1 = 16, .cs1 = 16},
+  {TEST, .m = 2, .n = 3, .rs = 3, .cs = 1, .m0 = 4, .n0 = 4,
+   .rs0 = 4, .cs0 = 1, .rs1 = 16, .cs1 = 16},
+  {TEST, .m = 2, .n = 3, .rs = 1, .cs = 2, .m0 = 4, .n0 = 4,
+   .rs0 = 4, .cs0 = 1, .rs1 = 16, .cs1 = 16},
+
+  /* Non-multiple of block size */
+  {TEST, .m = 5, .n = 5, .rs = 5, .cs = 1, .m0 = 4, .n0 = 8,
+   .rs0 = 1, .cs0 = 4, .rs1 = 64, .cs1 = 32},
+  {TEST, .m = 10, .n = 10, .rs = 10, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 128, .cs1 = 64},
+  {TEST, .m = 7, .n = 9, .rs = 9, .cs = 1, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 4, .rs1 = 48, .cs1 = 16},
+  {TEST, .m = 9, .n = 8, .rs = 8, .cs = 1, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 4, .rs1 = 32, .cs1 = 16},
+  {TEST, .m = 20, .n = 16, .rs = 16, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 128, .cs1 = 64},
+
+  {TEST, .m = 5, .n = 5, .rs = 1, .cs = 5, .m0 = 4, .n0 = 8,
+   .rs0 = 1, .cs0 = 4, .rs1 = 64, .cs1 = 32},
+  {TEST, .m = 10, .n = 10, .rs = 1, .cs = 10, .m0 = 8, .n0 = 8,
+   .rs0 = 8, .cs0 = 1, .rs1 = 128, .cs1 = 64},
+  {TEST, .m = 7, .n = 9, .rs = 1, .cs = 7, .m0 = 4, .n0 = 4,
+   .rs0 = 4, .cs0 = 1, .rs1 = 48, .cs1 = 16},
+  {TEST, .m = 9, .n = 8, .rs = 1, .cs = 9, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 4, .rs1 = 32, .cs1 = 16},
+  {TEST, .m = 20, .n = 16, .rs = 1, .cs = 20, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 128, .cs1 = 64},
+
+
+  /* Multiple of block size  */
+  {TEST, .m = 8, .n = 8, .rs = 16, .cs = 1, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 8, .rs1 = 64, .cs1 = 32},
+  {TEST, .m = 12, .n = 12, .rs = 12, .cs = 1, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 4, .rs1 = 48, .cs1 = 16},
+  {TEST, .m = 16, .n = 16, .rs = 16, .cs = 1, .m0 = 4, .n0 = 4,
+   .rs0 = 1, .cs0 = 4, .rs1 = 64, .cs1 = 16},
+  {TEST, .m = 16, .n = 16, .rs = 16, .cs = 1, .m0 = 4, .n0 = 8,
+   .rs0 = 1, .cs0 = 4, .rs1 = 64, .cs1 = 32},
+  {TEST, .m = 16, .n = 16, .rs = 16, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 128, .cs1 = 64},
+  {TEST, .m = 16, .n = 16, .rs = 16, .cs = 1, .m0 = 16, .n0 = 16,
+   .rs0 = 1, .cs0 = 16, .rs1 = 256, .cs1 = 256},
+  {TEST, .m = 32, .n = 8, .rs = 8, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 64, .cs1 = 64},
+  {TEST, .m = 8, .n = 32, .rs = 32, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 256, .cs1 = 64},
+
+  /* Specialization 1: (cs0 * n0 == cs1) && rs0 == 1 */
+  {TEST, .m = 16, .n = 12, .rs = 12, .cs = 1, .m0 = 4, .n0 = 3,
+   .rs0 = 1, .cs0 = 4, .rs1 = 48, .cs1 = 12},
+  {TEST, .m = 10, .n = 8, .rs = 8, .cs = 1, .m0 = 4, .n0 = 3,
+   .rs0 = 1, .cs0 = 4, .rs1 = 36, .cs1 = 12},
+  {TEST, .m = 10, .n = 18, .rs = 18, .cs = 1, .m0 = 4, .n0 = 1,
+   .rs0 = 1, .cs0 = 4, .rs1 = 72, .cs1 = 4},
+
+  /* Specialization 2: (rs0 * m0 == rs1) && cs0 == 1 */
+  {TEST, .m = 12, .n = 16, .rs = 16, .cs = 1, .m0 = 4, .n0 = 8,
+   .rs0 = 8, .cs0 = 1, .rs1 = 32, .cs1 = 96},
+  {TEST, .m = 16, .n = 12, .rs = 12, .cs = 1, .m0 = 2, .n0 = 5,
+   .rs0 = 5, .cs0 = 1, .rs1 = 10, .cs1 = 80},
+  {TEST, .m = 10, .n = 8, .rs = 8, .cs = 1, .m0 = 4, .n0 = 8,
+   .rs0 = 8, .cs0 = 1, .rs1 = 32, .cs1 = 32},
+
+  /* Specialization 3: rs0 == 1 && n0 == 1 && m0 == rs1 - Column panel transpose */
+  {TEST, .m = 12, .n = 8, .rs = 8, .cs = 1, .m0 = 4, .n0 = 1,
+   .rs0 = 1, .cs0 = 4, .rs1 = 4, .cs1 = 12},
+  {TEST, .m = 20, .n = 16, .rs = 16, .cs = 1, .m0 = 8, .n0 = 1,
+   .rs0 = 1, .cs0 = 8, .rs1 = 8, .cs1 = 24},
+
+  /* Specialization 4: cs0 == 1 && m0 == 1 && n0 == cs1 - Row panel copy */
+  {TEST, .m = 8, .n = 12, .rs = 12, .cs = 1, .m0 = 1, .n0 = 4,
+   .rs0 = 4, .cs0 = 1, .rs1 = 12, .cs1 = 4},
+  {TEST, .m = 12, .n = 10, .rs = 10, .cs = 1, .m0 = 1, .n0 = 4,
+   .rs0 = 4, .cs0 = 1, .rs1 = 12, .cs1 = 4},
+
+  /* Larger matrices */
+  {TEST, .m = 64, .n = 64, .rs = 64, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 512, .cs1 = 64},
+  {TEST, .m = 128, .n = 128, .rs = 128, .cs = 1, .m0 = 8, .n0 = 8,
+   .rs0 = 1, .cs0 = 8, .rs1 = 1024, .cs1 = 64},
+
+  {TEST, .m = 300, .n = 200, .rs = 200, .cs = 1, .m0 = 64, .n0 = 16,
+   .rs0 = 16, .cs0 = 1, .rs1 = 13312, .cs1 = 1024},
+  {TEST, .m = 300, .n = 200, .rs = 200, .cs = 1, .m0 = 64, .n0 = 16,
+   .rs0 = 16, .cs0 = 1, .rs1 = 1024, .cs1 = 5120},
+  {TEST, .m = 300, .n = 200, .rs = 200, .cs = 1, .m0 = 64, .n0 = 16,
+   .rs0 = 1, .cs0 = 64, .rs1 = 13312, .cs1 = 1024},
+  {TEST, .m = 300, .n = 200, .rs = 200, .cs = 1, .m0 = 64, .n0 = 16,
+   .rs0 = 1, .cs0 = 64, .rs1 = 1024, .cs1 = 5120},
+
+  {TEST, .m = 300, .n = 200, .rs = 1, .cs = 300, .m0 = 64, .n0 = 16,
+   .rs0 = 16, .cs0 = 1, .rs1 = 13312, .cs1 = 1024},
+  {TEST, .m = 300, .n = 200, .rs = 1, .cs = 300, .m0 = 64, .n0 = 16,
+   .rs0 = 16, .cs0 = 1, .rs1 = 1024, .cs1 = 5120},
+  {TEST, .m = 300, .n = 200, .rs = 1, .cs = 300, .m0 = 64, .n0 = 16,
+   .rs0 = 1, .cs0 = 64, .rs1 = 13312, .cs1 = 1024},
+  {TEST, .m = 300, .n = 200, .rs = 1, .cs = 300, .m0 = 64, .n0 = 16,
+   .rs0 = 1, .cs0 = 64, .rs1 = 1024, .cs1 = 5120},
+#endif
+};
+// clang-format on
+
+static skl_test_suite_t suite = {.name = "skl_pack_e32_zve32x",
+                                 .num_tests = sizeof(tests) / sizeof(tests[0]),
+                                 .test_size = sizeof(pack_e32rc_e32rcprc_t),
+                                 .tests = tests};
+
+static void execute(skl_test_t *t) {
+  const pack_e32rc_e32rcprc_t *h = (pack_e32rc_e32rcprc_t *)t->harness;
+
+  skl_pack_e32rc_e32rcprc_zve32x(h->m, h->n, h->src.data, h->rs, h->cs, h->m0,
+                                 h->n0, h->dst.data, h->rs0, h->cs0, h->rs1,
+                                 h->cs1, h->pad);
+}
+
+int main(void) { return skl_test_driver_run_suite(&suite); }

--- a/test/pack/rvv/skl_pack_e32rc_e32rcprc_zve32x.c
+++ b/test/pack/rvv/skl_pack_e32rc_e32rcprc_zve32x.c
@@ -3,7 +3,7 @@
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT
 
-#include "pack/pack_e8rc_e8rcprc.h"
+#include "pack/pack_e32rc_e32rcprc.h"
 #include "skl-test-driver.h"
 #include "skl.h"
 
@@ -17,34 +17,34 @@
 /**
  * @brief Test cases for pack with Zve32x extension.
  *
- * This test uses the pack_e8rc_e8rcprc harness.
+ * This test uses the pack_e32rc_e32rcprc harness.
  */
 
 #define TEST                                                                   \
-  PACK_E8RC_E8RCPRC_DEFAULTS, .steps = {                                       \
-                                  .init = pack_e8rc_e8rcprc_init,              \
-                                  .warmup = NULL,                              \
-                                  .execute = execute,                          \
-                                  .verify = pack_e8rc_e8rcprc_verify,          \
-                                  .report = pack_e8rc_e8rcprc_test_report,     \
-                                  .cleanup = pack_e8rc_e8rcprc_cleanup,        \
+  PACK_E32RC_E32RCPRC_DEFAULTS, .steps = {                                     \
+                                    .init = pack_e32rc_e32rcprc_init,          \
+                                    .warmup = NULL,                            \
+                                    .execute = execute,                        \
+                                    .verify = pack_e32rc_e32rcprc_verify,      \
+                                    .report = pack_e32rc_e32rcprc_test_report, \
+                                    .cleanup = pack_e32rc_e32rcprc_cleanup,    \
   }
 
 #define BENCH                                                                  \
-  PACK_E8RC_E8RCPRC_DEFAULTS,                                                  \
+  PACK_E32RC_E32RCPRC_DEFAULTS,                                                \
       .steps = {                                                               \
-          .init = pack_e8rc_e8rcprc_init,                                      \
+          .init = pack_e32rc_e32rcprc_init,                                    \
           .warmup = execute,                                                   \
           .execute = execute,                                                  \
           .verify = NULL,                                                      \
-          .report = pack_e8rc_e8rcprc_benchmark_report,                        \
-          .cleanup = pack_e8rc_e8rcprc_cleanup,                                \
+          .report = pack_e32rc_e32rcprc_benchmark_report,                      \
+          .cleanup = pack_e32rc_e32rcprc_cleanup,                              \
   }
 
 static void execute(skl_test_t *t);
 
 // clang-format off
-pack_e8rc_e8rcprc_t tests[] = {
+pack_e32rc_e32rcprc_t tests[] = {
 #ifdef SKL_ENABLE_BENCHMARKS
   // Benchmark tests
   {BENCH, .m = 128, .n = 128, .rs = 128, .cs = 1, .m0 = 8, .n0 = 8,
@@ -161,17 +161,17 @@ pack_e8rc_e8rcprc_t tests[] = {
 };
 // clang-format on
 
-static skl_test_suite_t suite = {.name = "skl_pack_e8_zve32x",
+static skl_test_suite_t suite = {.name = "skl_pack_e32rc_e32rcprc_zve32x",
                                  .num_tests = sizeof(tests) / sizeof(tests[0]),
-                                 .test_size = sizeof(pack_e8rc_e8rcprc_t),
+                                 .test_size = sizeof(pack_e32rc_e32rcprc_t),
                                  .tests = tests};
 
 static void execute(skl_test_t *t) {
-  const pack_e8rc_e8rcprc_t *h = (pack_e8rc_e8rcprc_t *)t->harness;
+  const pack_e32rc_e32rcprc_t *h = (pack_e32rc_e32rcprc_t *)t->harness;
 
-  skl_pack_e8rc_e8rcprc_zve32x(h->m, h->n, h->src.data, h->rs, h->cs, h->m0,
-                               h->n0, h->dst.data, h->rs0, h->cs0, h->rs1,
-                               h->cs1, h->pad);
+  skl_pack_e32rc_e32rcprc_zve32x(h->m, h->n, h->src.data, h->rs, h->cs, h->m0,
+                                 h->n0, h->dst.data, h->rs0, h->cs0, h->rs1,
+                                 h->cs1, h->pad);
 }
 
 int main(void) { return skl_test_driver_run_suite(&suite); }

--- a/test/pack/rvv/skl_pack_e8rc_e8rcprc_zve32x.c
+++ b/test/pack/rvv/skl_pack_e8rc_e8rcprc_zve32x.c
@@ -3,7 +3,7 @@
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT
 
-#include "pack/pack_e16rc_e16rcprc.h"
+#include "pack/pack_e8rc_e8rcprc.h"
 #include "skl-test-driver.h"
 #include "skl.h"
 
@@ -17,34 +17,34 @@
 /**
  * @brief Test cases for pack with Zve32x extension.
  *
- * This test uses the pack_e16rc_e16rcprc harness.
+ * This test uses the pack_e8rc_e8rcprc harness.
  */
 
 #define TEST                                                                   \
-  PACK_E16RC_E16RCPRC_DEFAULTS, .steps = {                                     \
-                                    .init = pack_e16rc_e16rcprc_init,          \
-                                    .warmup = NULL,                            \
-                                    .execute = execute,                        \
-                                    .verify = pack_e16rc_e16rcprc_verify,      \
-                                    .report = pack_e16rc_e16rcprc_test_report, \
-                                    .cleanup = pack_e16rc_e16rcprc_cleanup,    \
+  PACK_E8RC_E8RCPRC_DEFAULTS, .steps = {                                       \
+                                  .init = pack_e8rc_e8rcprc_init,              \
+                                  .warmup = NULL,                              \
+                                  .execute = execute,                          \
+                                  .verify = pack_e8rc_e8rcprc_verify,          \
+                                  .report = pack_e8rc_e8rcprc_test_report,     \
+                                  .cleanup = pack_e8rc_e8rcprc_cleanup,        \
   }
 
 #define BENCH                                                                  \
-  PACK_E16RC_E16RCPRC_DEFAULTS,                                                \
+  PACK_E8RC_E8RCPRC_DEFAULTS,                                                  \
       .steps = {                                                               \
-          .init = pack_e16rc_e16rcprc_init,                                    \
+          .init = pack_e8rc_e8rcprc_init,                                      \
           .warmup = execute,                                                   \
           .execute = execute,                                                  \
           .verify = NULL,                                                      \
-          .report = pack_e16rc_e16rcprc_benchmark_report,                      \
-          .cleanup = pack_e16rc_e16rcprc_cleanup,                              \
+          .report = pack_e8rc_e8rcprc_benchmark_report,                        \
+          .cleanup = pack_e8rc_e8rcprc_cleanup,                                \
   }
 
 static void execute(skl_test_t *t);
 
 // clang-format off
-pack_e16rc_e16rcprc_t tests[] = {
+pack_e8rc_e8rcprc_t tests[] = {
 #ifdef SKL_ENABLE_BENCHMARKS
   // Benchmark tests
   {BENCH, .m = 128, .n = 128, .rs = 128, .cs = 1, .m0 = 8, .n0 = 8,
@@ -161,17 +161,17 @@ pack_e16rc_e16rcprc_t tests[] = {
 };
 // clang-format on
 
-static skl_test_suite_t suite = {.name = "skl_pack_e16_zve32x",
+static skl_test_suite_t suite = {.name = "skl_pack_e8rc_e8rcprc_zve32x",
                                  .num_tests = sizeof(tests) / sizeof(tests[0]),
-                                 .test_size = sizeof(pack_e16rc_e16rcprc_t),
+                                 .test_size = sizeof(pack_e8rc_e8rcprc_t),
                                  .tests = tests};
 
 static void execute(skl_test_t *t) {
-  const pack_e16rc_e16rcprc_t *h = (pack_e16rc_e16rcprc_t *)t->harness;
+  const pack_e8rc_e8rcprc_t *h = (pack_e8rc_e8rcprc_t *)t->harness;
 
-  skl_pack_e16rc_e16rcprc_zve32x(h->m, h->n, h->src.data, h->rs, h->cs, h->m0,
-                                 h->n0, h->dst.data, h->rs0, h->cs0, h->rs1,
-                                 h->cs1, h->pad);
+  skl_pack_e8rc_e8rcprc_zve32x(h->m, h->n, h->src.data, h->rs, h->cs, h->m0,
+                               h->n0, h->dst.data, h->rs0, h->cs0, h->rs1,
+                               h->cs1, h->pad);
 }
 
 int main(void) { return skl_test_driver_run_suite(&suite); }


### PR DESCRIPTION
This is a follow-up PR to https://github.com/sifive/skl/pull/98 to add 16b and 32b pack kernels and their corresponding test harnesses.