### PR TITLE
[CI] Check license headers only for pull request event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         fetch-depth: 0
 
     - name: Check license headers
+      if: ${{ github.event_name == 'pull_request' }}
       run: |
         HEAD_SHA=${{ github.event.pull_request.head.sha }}
         BASE_SHA=${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
This PR fixes the CI workflow so that license headers are checked pre-merge only.