### PR TITLE
[GEMM] Add widening bf16 RVV kernels for x390

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ add_skl_src(src/exp/exp_f32_zve32f.c "zve32f")
 add_skl_src(src/gelu/gelu_f32_zve32f.c "zve32f")
 
 add_skl_src(src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c "zvfbfwma")
+add_skl_src(src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.c "zvfbfwma")
 add_skl_src(src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.c "zvfh")
 add_skl_src(src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c "zvfh")
 add_skl_src(src/gemm/rvv/gemm_f32_f32_f32_zve32f_x390.c "zve32f")

--- a/include/skl.h
+++ b/include/skl.h
@@ -22,6 +22,7 @@
 
 #if defined(__riscv_zvfbfwma)
 #include "../src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.h"
+#include "../src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.h"
 #endif
 
 #if defined(__riscv_zve32f)

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.c
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.c
@@ -112,7 +112,7 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm8x18_bf16_bf16_f32_zvfbfwma_x390(
           "vfmul.vf %[acc], %[acc], %[a0] \n\t"
           : [a0] "=&f"(a0),
             [b0] "=&vr"(b0),
-            [acc] "=vr"(acc)
+            [acc] "=&vr"(acc)
           : [jj_vl_in] "r"(jj_vl),
             [a_addr] "r"(a + ii * rsa),
             [b_addr] "r"(b + jj)
@@ -1172,7 +1172,7 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4x12_bf16_bf16_f32_zvfbfwma_x390(
 
             "vsetvli zero, %[jj_vl_in], e32, m4, ta, ma \n\t"
             "vfmul.vf %[acc], %[acc], %[a0] \n\t"
-            : [a0] "=&f"(a0), [b0] "=&vr"(b0), [acc] "=vr"(acc)
+            : [a0] "=&f"(a0), [b0] "=&vr"(b0), [acc] "=&vr"(acc)
             : [a_addr_83] "r"(a + (((ii0 + 0) * rsa) + ((kk_peel + 0) * 1))),
               [jj_vl_in] "r"(jj_vl),
               [b_addr_13] "r"(b + (((kk_peel + 0) * rsb) + ((jj + 0) * 1)))

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.c
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.c
@@ -70,12 +70,12 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm8x18_bf16_bf16_f32_zvfbfwma_x390(
   float a3;
   float a4;
   float a5;
-  vfloat16m4_t b0;
-  vfloat16m4_t b1;
-  vfloat16m4_t b2;
-  vfloat16m4_t b3;
-  vfloat16m4_t b4;
-  vfloat16m4_t b5;
+  vbfloat16m4_t b0;
+  vbfloat16m4_t b1;
+  vbfloat16m4_t b2;
+  vbfloat16m4_t b3;
+  vbfloat16m4_t b4;
+  vbfloat16m4_t b5;
   vfloat32m8_t acc;
   vfloat32m8_t c0;
 
@@ -453,10 +453,10 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4x12_bf16_bf16_f32_zvfbfwma_x390(
   float a33;
   float a43;
   float a53;
-  vfloat16m2_t b00;
-  vfloat16m2_t b10;
-  vfloat16m2_t b20;
-  vfloat16m2_t b30;
+  vbfloat16m2_t b00;
+  vbfloat16m2_t b10;
+  vbfloat16m2_t b20;
+  vbfloat16m2_t b30;
   vfloat32m4_t acc0;
   vfloat32m4_t acc1;
   vfloat32m4_t acc2;
@@ -464,7 +464,7 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4x12_bf16_bf16_f32_zvfbfwma_x390(
   vfloat32m4_t acc4;
   vfloat32m4_t acc5;
   float a0;
-  vfloat16m2_t b0;
+  vbfloat16m2_t b0;
   vfloat32m4_t acc;
   vfloat32m4_t c0;
   vfloat32m4_t c1;

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.c
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.c
@@ -1,0 +1,1224 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#if !defined(__riscv_zvfbfwma) || __riscv_zvfbfwma < 1000000
+#error This file requires the RISC-V Zvfbfwma extension, version 1000000.
+#endif
+
+#include <riscv_vector.h>
+#include <stddef.h>
+
+#include "skl-common.h"
+
+#if defined(__riscv_zihintntl)
+#define NTL_P1 "ntl.p1 \n\t"
+#else
+#define NTL_P1
+#endif
+
+/**
+ * @brief RVV bfloat16 matrix-matrix multiply with float32 output for row-major
+ * matrices, tuned for X390.
+ *
+ * @param m - Number of rows in matrices A and C.
+ * @param n - Number of columns in matrices B and C.
+ * @param k - Number of columns in A and rows in B (inner dimension).
+ * @param alpha - Scalar multiplier for A*B product.
+ * @param a - Pointer to matrix A.
+ * @param rsa - Row stride of matrix A in elements.
+ * @param b - Pointer to matrix B.
+ * @param rsb - Row stride of matrix B in elements.
+ * @param beta - Scalar multiplier for matrix C.
+ * @param c - Pointer to matrix C.
+ * @param rsc - Row stride of matrix C in elements.
+ *
+ * Computes `C = alpha * A * B + beta * C` for BF16 row-major matrices A and
+ * B and FP32 row-major matrix C.
+ *
+ * Functionally equivalent to calling:
+ * ```
+ * skl_gemm_bf16rc_bf16rc_f32rc_ref(
+ *     m, n, k,
+ *     alpha,
+ *     a, rsa, 1,
+ *     b, rsb, 1,
+ *     beta,
+ *     c, rsc, 1
+ * );
+ * ```
+ *
+ * Uses a 1 x LMUL=8 x 18 register tile. Vectorized across the N dimension.
+ *
+ * @note
+ * Works best when `m = 1` and `n >= __riscv_vsetvlmax_e32m8()`.
+ */
+SKL_FUNC_PRIVATE void skl_gemm_1xm8x18_bf16_bf16_f32_zvfbfwma_x390(
+    size_t m, size_t n, size_t k, float alpha, const __bf16 *a, size_t rsa,
+    const __bf16 *b, size_t rsb, float beta, float *c, size_t rsc) {
+  size_t jj_vl;
+  size_t ii;
+  size_t jj;
+  size_t kk;
+
+  // Due to a compiler bug, temporary A matrix values used in the inline
+  // assembly below are typed as float instead of __bf16.
+  float a0;
+  float a1;
+  float a2;
+  float a3;
+  float a4;
+  float a5;
+  vfloat16m4_t b0;
+  vfloat16m4_t b1;
+  vfloat16m4_t b2;
+  vfloat16m4_t b3;
+  vfloat16m4_t b4;
+  vfloat16m4_t b5;
+  vfloat32m8_t acc;
+  vfloat32m8_t c0;
+
+  if (k == 0) {
+    for (ii = 0; (ii + 1) <= m; ii = ii + 1) {
+      for (jj = 0; jj < n; jj = jj + jj_vl) {
+        jj_vl = __riscv_vsetvl_e32m8(n - jj);
+        c0 = __riscv_vle32_v_f32m8(c + ii * rsc + jj, jj_vl);
+        c0 = __riscv_vfmul_vf_f32m8(c0, beta, jj_vl);
+        __riscv_vse32_v_f32m8(c + ii * rsc + jj, c0, jj_vl);
+      }
+    }
+    return;
+  }
+
+  for (ii = 0; (ii + 1) <= m; ii = ii + 1) {
+    for (jj = 0; jj < n; jj = jj + jj_vl) {
+      jj_vl = __riscv_vsetvl_e16m4(n - jj);
+
+      const size_t kk_unroll_degree = 18;
+      const size_t preload_distance = 6;
+
+      __asm__ volatile(
+          // clang-format off
+          "\n\t"
+          "flh %[a0], 0(%[a_addr]) \n\t"
+          "fcvt.s.bf16 %[a0], %[a0] \n\t"
+
+          "vsetvli zero, %[jj_vl_in], e16, m4, ta, ma \n\t"
+          "vle16.v %[b0], (%[b_addr]) \n\t"
+          "vfwcvtbf16.f.f.v %[acc], %[b0] \n\t"
+
+          "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+          "vfmul.vf %[acc], %[acc], %[a0] \n\t"
+          : [a0] "=&f"(a0),
+            [b0] "=&vr"(b0),
+            [acc] "=vr"(acc)
+          : [jj_vl_in] "r"(jj_vl),
+            [a_addr] "r"(a + ii * rsa),
+            [b_addr] "r"(b + jj)
+          : "vtype", "vl", "memory"
+          // clang-format on
+      );
+
+      kk = 1;
+
+      if (kk_unroll_degree + preload_distance < k) {
+        // Load initial values for kk loop below.
+        const __bf16 *b_addr = b + kk * rsb + jj;
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m4, ta, ma \n\t"
+
+            "flh %[a0],  0(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "flh %[a1],  2(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "flh %[a2],  4(%[a_addr]) \n\t"
+            "vle16.v %[b2], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "flh %[a3],  6(%[a_addr]) \n\t"
+            "vle16.v %[b3], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "flh %[a4],  8(%[a_addr]) \n\t"
+            "vle16.v %[b4], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "flh %[a5], 10(%[a_addr]) \n\t"
+            "vle16.v %[b5], (%[b_addr]) \n\t"
+            : [a0] "=&f" (a0),
+              [a1] "=&f" (a1),
+              [a2] "=&f" (a2),
+              [a3] "=&f" (a3),
+              [a4] "=&f" (a4),
+              [a5] "=&f" (a5),
+              [b0] "=&vr" (b0),
+              [b1] "=&vr" (b1),
+              [b2] "=&vr" (b2),
+              [b3] "=&vr" (b3),
+              [b4] "=&vr" (b4),
+              [b5] "=vr" (b5),
+              [b_addr] "+&r" (b_addr)
+            : [jj_vl_in] "r" (jj_vl),
+              [a_addr] "r" (a + ii * rsa + kk),
+              [rsb2] "r" (rsb * sizeof(__bf16))
+            : "vtype", "vl", "memory"
+            // clang-format on
+        );
+      }
+
+      for (; (kk + kk_unroll_degree + preload_distance) <= k;
+           kk += kk_unroll_degree) {
+        const size_t offset = preload_distance;
+        const __bf16 *b_addr = b + (kk + offset) * rsb + jj;
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m4, ta, ma \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a0], %[b0] \n\t"
+            NTL_P1
+            "flh %[a0],  0(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a1], %[b1] \n\t"
+            NTL_P1
+            "flh %[a1],  2(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a2], %[b2] \n\t"
+            NTL_P1
+            "flh %[a2],  4(%[a_addr]) \n\t"
+            "vle16.v %[b2], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a3], %[b3] \n\t"
+            NTL_P1
+            "flh %[a3],  6(%[a_addr]) \n\t"
+            "vle16.v %[b3], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a4], %[b4] \n\t"
+            NTL_P1
+            "flh %[a4],  8(%[a_addr]) \n\t"
+            "vle16.v %[b4], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a5], %[b5] \n\t"
+            NTL_P1
+            "flh %[a5], 10(%[a_addr]) \n\t"
+            "vle16.v %[b5], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a0], %[b0] \n\t"
+            NTL_P1
+            "flh %[a0], 12(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a1], %[b1] \n\t"
+            NTL_P1
+            "flh %[a1], 14(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a2], %[b2] \n\t"
+            NTL_P1
+            "flh %[a2], 16(%[a_addr]) \n\t"
+            "vle16.v %[b2], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a3], %[b3] \n\t"
+            NTL_P1
+            "flh %[a3], 18(%[a_addr]) \n\t"
+            "vle16.v %[b3], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a4], %[b4] \n\t"
+            NTL_P1
+            "flh %[a4], 20(%[a_addr]) \n\t"
+            "vle16.v %[b4], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a5], %[b5] \n\t"
+            NTL_P1
+            "flh %[a5], 22(%[a_addr]) \n\t"
+            "vle16.v %[b5], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a0], %[b0] \n\t"
+            NTL_P1
+            "flh %[a0], 24(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a1], %[b1] \n\t"
+            NTL_P1
+            "flh %[a1], 26(%[a_addr]) \n\t"
+            "vle16.v %[b1], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a2], %[b2] \n\t"
+            NTL_P1
+            "flh %[a2], 28(%[a_addr]) \n\t"
+            "vle16.v %[b2], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a3], %[b3] \n\t"
+            NTL_P1
+            "flh %[a3], 30(%[a_addr]) \n\t"
+            "vle16.v %[b3], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a4], %[b4] \n\t"
+            NTL_P1
+            "flh %[a4], 32(%[a_addr]) \n\t"
+            "vle16.v %[b4], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc], %[a5], %[b5] \n\t"
+            NTL_P1
+            "flh %[a5], 34(%[a_addr]) \n\t"
+            "vle16.v %[b5], (%[b_addr]) \n\t"
+            : [a0] "+&f"(a0),
+              [a1] "+&f"(a1),
+              [a2] "+&f"(a2),
+              [a3] "+&f"(a3),
+              [a4] "+&f"(a4),
+              [a5] "+&f"(a5),
+              [b0] "+&vr"(b0),
+              [b1] "+&vr"(b1),
+              [b2] "+&vr"(b2),
+              [b3] "+&vr"(b3),
+              [b4] "+&vr"(b4),
+              [b5] "+&vr"(b5),
+              [acc] "+&vr"(acc),
+              [b_addr] "+&r"(b_addr)
+            : [jj_vl_in] "r"(jj_vl),
+              [a_addr] "r"(a + ii  * rsa + kk + offset),
+              [rsb2] "r" (rsb * sizeof(__bf16))
+            : "vtype", "vl", "memory"
+            // clang-format on
+        );
+      }
+
+      if (kk_unroll_degree + preload_distance < k) {
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m4, ta, ma \n\t"
+            "vfwmaccbf16.vf %[acc], %[a0], %[b0] \n\t"
+            "vfwmaccbf16.vf %[acc], %[a1], %[b1] \n\t"
+            "vfwmaccbf16.vf %[acc], %[a2], %[b2] \n\t"
+            "vfwmaccbf16.vf %[acc], %[a3], %[b3] \n\t"
+            "vfwmaccbf16.vf %[acc], %[a4], %[b4] \n\t"
+            "vfwmaccbf16.vf %[acc], %[a5], %[b5] \n\t"
+            : [acc] "+&vr"(acc)
+            : [jj_vl_in] "r" (jj_vl),
+              [a0] "f"(a0),
+              [a1] "f"(a1),
+              [a2] "f"(a2),
+              [a3] "f"(a3),
+              [a4] "f"(a4),
+              [a5] "f"(a5),
+              [b0] "vr"(b0),
+              [b1] "vr"(b1),
+              [b2] "vr"(b2),
+              [b3] "vr"(b3),
+              [b4] "vr"(b4),
+              [b5] "vr"(b5)
+            : "vtype", "vl"
+            // clang-format on
+        );
+        kk += preload_distance;
+      }
+
+      for (; (kk + 1) <= k; kk = kk + 1) {
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m4, ta, ma \n\t"
+
+            "flh %[a0], 0(%[a_addr]) \n\t"
+            "vle16.v %[b0], (%[b_addr]) \n\t"
+            "vfwmaccbf16.vf %[acc], %[a0], %[b0] \n\t"
+            : [a0] "=&f"(a0),
+              [b0] "=&vr"(b0),
+              [acc] "+vr"(acc)
+            : [jj_vl_in] "r"(jj_vl),
+              [a_addr] "r"(a + ii  * rsa + kk),
+              [b_addr] "r"(b + kk  * rsb + jj)
+            : "vtype", "vl", "memory"
+            // clang-format on
+        );
+      }
+      __asm__ volatile(
+          // clang-format off
+          "\n\t"
+          "vsetvli zero, %[jj_vl_in], e32, m8, ta, ma \n\t"
+
+          "vle32.v %[c0], (%[c_addr]) \n\t"
+          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
+          "vfmacc.vf %[c0], %[alpha], %[acc] \n\t"
+          "vse32.v %[c0], (%[c_addr]) \n\t"
+          : [c0] "=&vr"(c0)
+          : [jj_vl_in] "r"(jj_vl),
+            [c_addr] "r"(c + ii * rsc + jj),
+            [beta] "f"(beta),
+            [alpha] "f"(alpha),
+            [acc] "vr"(acc)
+          : "vtype", "vl", "memory"
+          // clang-format on
+      );
+    }
+  }
+}
+
+/**
+ * @brief RVV bfloat16 matrix-matrix multiplication with float32 output for
+ * row-major matrices, tuned for X390.
+ *
+ * @param m - Number of rows in matrices A and C.
+ * @param n - Number of columns in matrices B and C.
+ * @param k - Number of columns in A and rows in B (inner dimension).
+ * @param alpha - Scalar multiplier for A*B product.
+ * @param a - Pointer to matrix A.
+ * @param rsa - Row stride of matrix A in elements.
+ * @param b - Pointer to matrix B.
+ * @param rsb - Row stride of matrix B in elements.
+ * @param beta - Scalar multiplier for matrix C.
+ * @param c - Pointer to matrix C.
+ * @param rsc - Row stride of matrix C in elements.
+ *
+ * Computes `C = alpha * A * B + beta * C` for BF16 row-major matrices A and B
+ * and FP32 row-major output matrix C.
+ *
+ * Functionally equivalent to calling:
+ * ```
+ * skl_gemm_bf16rc_bf16rc_f32rc_ref(
+ *     m, n, k,
+ *     alpha,
+ *     a, rsa, 1,
+ *     b, rsb, 1,
+ *     beta,
+ *     c, rsc, 1
+ * );
+ * ```
+ * Uses a 6 x LMUL=4 x 12 register tile. Vectorized across the N dimension.
+ *
+ * @note
+ * Works best when `m >= 6` and `n >= __riscv_vsetvlmax_e32m4()`.
+ */
+SKL_FUNC_PRIVATE void skl_gemm_6xm4x12_bf16_bf16_f32_zvfbfwma_x390(
+    size_t m, size_t n, size_t k, float alpha, const __bf16 *a, size_t rsa,
+    const __bf16 *b, size_t rsb, float beta, float *c, size_t rsc) {
+  size_t jj_vl;
+  size_t ii;
+  size_t jj;
+  size_t kk;
+  size_t ii0;
+  size_t kk_peel;
+
+  // Due to a compiler bug, temporary A matrix values used in the inline
+  // assembly below are typed as float instead of __bf16.
+  float a00;
+  float a10;
+  float a20;
+  float a30;
+  float a40;
+  float a50;
+  float a01;
+  float a11;
+  float a21;
+  float a31;
+  float a41;
+  float a51;
+  float a02;
+  float a12;
+  float a22;
+  float a32;
+  float a42;
+  float a52;
+  float a03;
+  float a13;
+  float a23;
+  float a33;
+  float a43;
+  float a53;
+  vfloat16m2_t b00;
+  vfloat16m2_t b10;
+  vfloat16m2_t b20;
+  vfloat16m2_t b30;
+  vfloat32m4_t acc0;
+  vfloat32m4_t acc1;
+  vfloat32m4_t acc2;
+  vfloat32m4_t acc3;
+  vfloat32m4_t acc4;
+  vfloat32m4_t acc5;
+  float a0;
+  vfloat16m2_t b0;
+  vfloat32m4_t acc;
+  vfloat32m4_t c0;
+  vfloat32m4_t c1;
+
+  if (k == 0) {
+    for (ii = 0; (ii + 1) <= m; ii = ii + 1) {
+      for (jj = 0; jj < n; jj = jj + jj_vl) {
+        jj_vl = __riscv_vsetvl_e32m4(n - jj);
+        c0 = __riscv_vle32_v_f32m4(c + ii * rsc + jj, jj_vl);
+        c0 = __riscv_vfmul_vf_f32m4(c0, beta, jj_vl);
+        __riscv_vse32_v_f32m4(c + ii * rsc + jj, c0, jj_vl);
+      }
+    }
+    return;
+  }
+
+  for (ii = 0; (ii + 6) <= m; ii = ii + 6) {
+    for (jj = 0; jj < n; jj = jj + jj_vl) {
+      jj_vl = __riscv_vsetvl_e16m2(n - jj);
+
+      {
+        vfloat32m4_t b00_wide;
+        const __bf16 *a_addr = a + ii * rsa;
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+
+            "flh %[a00], 0(%[a_addr]) \n\t"
+            "fcvt.s.bf16 %[a00], %[a00] \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            "flh %[a10], 0(%[a_addr]) \n\t"
+            "fcvt.s.bf16 %[a10], %[a10] \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            "flh %[a20], 0(%[a_addr]) \n\t"
+            "fcvt.s.bf16 %[a20], %[a20] \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            "flh %[a30], 0(%[a_addr]) \n\t"
+            "fcvt.s.bf16 %[a30], %[a30] \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            "flh %[a40], 0(%[a_addr]) \n\t"
+            "fcvt.s.bf16 %[a40], %[a40] \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            "flh %[a50], 0(%[a_addr]) \n\t"
+            "fcvt.s.bf16 %[a50], %[a50] \n\t"
+
+            "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "vfwcvtbf16.f.f.v %[b00_wide], %[b00] \n\t"
+
+            "vsetvli zero, %[jj_vl_in], e32, m4, ta, ma \n\t"
+            "vfmul.vf %[acc0], %[b00_wide], %[a00] \n\t"
+            "vfmul.vf %[acc1], %[b00_wide], %[a10] \n\t"
+            "vfmul.vf %[acc2], %[b00_wide], %[a20] \n\t"
+            "vfmul.vf %[acc3], %[b00_wide], %[a30] \n\t"
+            "vfmul.vf %[acc4], %[b00_wide], %[a40] \n\t"
+            "vfmul.vf %[acc5], %[b00_wide], %[a50] \n\t"
+            : [a00] "=&f"(a00),
+              [a10] "=&f"(a10),
+              [a20] "=&f"(a20),
+              [a30] "=&f"(a30),
+              [a40] "=&f"(a40),
+              [a50] "=&f"(a50),
+              [a_addr] "+&r"(a_addr),
+              [b00] "=&vr"(b00),
+              [b00_wide] "=&vr" (b00_wide),
+              [acc0] "=&vr"(acc0),
+              [acc1] "=&vr"(acc1),
+              [acc2] "=&vr"(acc2),
+              [acc3] "=&vr"(acc3),
+              [acc4] "=&vr"(acc4),
+              [acc5] "=vr"(acc5)
+            : [jj_vl_in] "r"(jj_vl),
+              [rsa2] "r" (rsa * sizeof(__bf16)),
+              [b_addr] "r"(b + jj)
+            : "vtype", "vl", "memory"
+            // clang-format on
+        );
+      }
+
+      const size_t kk_unroll_degree = 12;
+      const size_t preload_distance = 4;
+
+      if (kk_unroll_degree + preload_distance < k) {
+        const size_t offset = 1;
+        const __bf16 *a_addr = a + ii * rsa + offset;
+        const __bf16 *b_addr = b + offset * rsb + jj;
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+
+            "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+
+            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            NTL_P1
+            "flh %[a00], 0(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a01], 2(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a02], 4(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a03], 6(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            NTL_P1
+            "flh %[a10], 0(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a11], 2(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a12], 4(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a13], 6(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            "vle16.v %[b10], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            NTL_P1
+            "flh %[a20], 0(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a21], 2(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a22], 4(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a23], 6(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            NTL_P1
+            "flh %[a30], 0(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a31], 2(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a32], 4(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a33], 6(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            "vle16.v %[b20], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+            NTL_P1
+            "flh %[a40], 0(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a41], 2(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a42], 4(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a43], 6(%[a_addr]) \n\t"
+            "add %[a_addr], %[a_addr], %[rsa2] \n\t"
+            NTL_P1
+            "flh %[a50], 0(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a51], 2(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a52], 4(%[a_addr]) \n\t"
+            NTL_P1
+            "flh %[a53], 6(%[a_addr]) \n\t"
+            "vle16.v %[b30], (%[b_addr]) \n\t"
+
+          : [a00] "=&f"(a00),
+            [a10] "=&f"(a10),
+            [a20] "=&f"(a20),
+            [a30] "=&f"(a30),
+            [a40] "=&f"(a40),
+            [a50] "=&f"(a50),
+            [a01] "=&f"(a01),
+            [a11] "=&f"(a11),
+            [a21] "=&f"(a21),
+            [a31] "=&f"(a31),
+            [a41] "=&f"(a41),
+            [a51] "=&f"(a51),
+            [a02] "=&f"(a02),
+            [a12] "=&f"(a12),
+            [a22] "=&f"(a22),
+            [a32] "=&f"(a32),
+            [a42] "=&f"(a42),
+            [a52] "=&f"(a52),
+            [a03] "=&f"(a03),
+            [a13] "=&f"(a13),
+            [a23] "=&f"(a23),
+            [a33] "=&f"(a33),
+            [a43] "=&f"(a43),
+            [a53] "=&f"(a53),
+            [a_addr] "+&r"(a_addr),
+            [b00] "=&vr"(b00),
+            [b10] "=&vr"(b10),
+            [b20] "=&vr"(b20),
+            [b30] "=vr"(b30),
+            [b_addr] "+&r"(b_addr)
+          : [jj_vl_in] "r"(jj_vl),
+            [rsa2] "r" (rsa * sizeof(__bf16)),
+            [rsb2] "r" (rsb * sizeof(__bf16))
+          : "vtype", "vl", "memory"
+            // clang-format on
+        );
+      }
+
+      for (kk = 1; (kk + kk_unroll_degree + preload_distance) <= k;
+           kk += kk_unroll_degree) {
+        const size_t offset = preload_distance;
+        const __bf16 *b_addr = b + (kk + offset) * rsb + jj;
+        const __bf16 *a_addr_0 = a + (ii + 0) * rsa + kk + offset;
+        const __bf16 *a_addr_1;
+        const __bf16 *a_addr_2;
+        const __bf16 *a_addr_3;
+        const __bf16 *a_addr_4;
+        const __bf16 *a_addr_5;
+        __asm__ volatile(
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Woverlength-strings"
+            // clang-format off
+            "\n\t"
+            "add %[a_addr_1], %[a_addr_0], %[rsa2] \n\t"
+            "add %[a_addr_2], %[a_addr_1], %[rsa2] \n\t"
+            "add %[a_addr_3], %[a_addr_2], %[rsa2] \n\t"
+            "add %[a_addr_4], %[a_addr_3], %[rsa2] \n\t"
+            "add %[a_addr_5], %[a_addr_4], %[rsa2] \n\t"
+
+            "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a00], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a10], %[b00] \n\t"
+            NTL_P1
+            "flh %[a00],  0(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a10],  0(%[a_addr_1]) \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a20], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a30], %[b00] \n\t"
+            NTL_P1
+            "flh %[a20],  0(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a30],  0(%[a_addr_3]) \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a40], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a50], %[b00] \n\t"
+            NTL_P1
+            "flh %[a40],  0(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a50],  0(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a01], %[b10] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a11], %[b10] \n\t"
+            NTL_P1
+            "flh %[a01],  2(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a11],  2(%[a_addr_1]) \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a21], %[b10] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a31], %[b10] \n\t"
+            NTL_P1
+            "flh %[a21],  2(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a31],  2(%[a_addr_3]) \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a41], %[b10] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a51], %[b10] \n\t"
+            NTL_P1
+            "flh %[a41],  2(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a51],  2(%[a_addr_5]) \n\t"
+            "vle16.v %[b10], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a02], %[b20] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a12], %[b20] \n\t"
+            NTL_P1
+            "flh %[a02],  4(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a12],  4(%[a_addr_1]) \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a22], %[b20] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a32], %[b20] \n\t"
+            NTL_P1
+            "flh %[a22],  4(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a32],  4(%[a_addr_3]) \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a42], %[b20] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a52], %[b20] \n\t"
+            NTL_P1
+            "flh %[a42],  4(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a52],  4(%[a_addr_5]) \n\t"
+            "vle16.v %[b20], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a03], %[b30] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a13], %[b30] \n\t"
+            NTL_P1
+            "flh %[a03],  6(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a13],  6(%[a_addr_1]) \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a23], %[b30] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a33], %[b30] \n\t"
+            NTL_P1
+            "flh %[a23],  6(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a33],  6(%[a_addr_3]) \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a43], %[b30] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a53], %[b30] \n\t"
+            NTL_P1
+            "flh %[a43],  6(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a53],  6(%[a_addr_5]) \n\t"
+            "vle16.v %[b30], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a00], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a10], %[b00] \n\t"
+            NTL_P1
+            "flh %[a00],  8(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a10],  8(%[a_addr_1]) \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a20], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a30], %[b00] \n\t"
+            NTL_P1
+            "flh %[a20],  8(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a30],  8(%[a_addr_3]) \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a40], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a50], %[b00] \n\t"
+            NTL_P1
+            "flh %[a40],  8(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a50],  8(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a01], %[b10] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a11], %[b10] \n\t"
+            NTL_P1
+            "flh %[a01], 10(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a11], 10(%[a_addr_1]) \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a21], %[b10] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a31], %[b10] \n\t"
+            NTL_P1
+            "flh %[a21], 10(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a31], 10(%[a_addr_3]) \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a41], %[b10] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a51], %[b10] \n\t"
+            NTL_P1
+            "flh %[a41], 10(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a51], 10(%[a_addr_5]) \n\t"
+            "vle16.v %[b10], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a02], %[b20] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a12], %[b20] \n\t"
+            NTL_P1
+            "flh %[a02], 12(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a12], 12(%[a_addr_1]) \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a22], %[b20] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a32], %[b20] \n\t"
+            NTL_P1
+            "flh %[a22], 12(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a32], 12(%[a_addr_3]) \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a42], %[b20] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a52], %[b20] \n\t"
+            NTL_P1
+            "flh %[a42], 12(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a52], 12(%[a_addr_5]) \n\t"
+            "vle16.v %[b20], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a03], %[b30] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a13], %[b30] \n\t"
+            NTL_P1
+            "flh %[a03], 14(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a13], 14(%[a_addr_1]) \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a23], %[b30] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a33], %[b30] \n\t"
+            NTL_P1
+            "flh %[a23], 14(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a33], 14(%[a_addr_3]) \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a43], %[b30] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a53], %[b30] \n\t"
+            NTL_P1
+            "flh %[a43], 14(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a53], 14(%[a_addr_5]) \n\t"
+            "vle16.v %[b30], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a00], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a10], %[b00] \n\t"
+            NTL_P1
+            "flh %[a00], 16(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a10], 16(%[a_addr_1]) \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a20], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a30], %[b00] \n\t"
+            NTL_P1
+            "flh %[a20], 16(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a30], 16(%[a_addr_3]) \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a40], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a50], %[b00] \n\t"
+            NTL_P1
+            "flh %[a40], 16(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a50], 16(%[a_addr_5]) \n\t"
+            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a01], %[b10] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a11], %[b10] \n\t"
+            NTL_P1
+            "flh %[a01], 18(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a11], 18(%[a_addr_1]) \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a21], %[b10] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a31], %[b10] \n\t"
+            NTL_P1
+            "flh %[a21], 18(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a31], 18(%[a_addr_3]) \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a41], %[b10] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a51], %[b10] \n\t"
+            NTL_P1
+            "flh %[a41], 18(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a51], 18(%[a_addr_5]) \n\t"
+            "vle16.v %[b10], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a02], %[b20] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a12], %[b20] \n\t"
+            NTL_P1
+            "flh %[a02], 20(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a12], 20(%[a_addr_1]) \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a22], %[b20] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a32], %[b20] \n\t"
+            NTL_P1
+            "flh %[a22], 20(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a32], 20(%[a_addr_3]) \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a42], %[b20] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a52], %[b20] \n\t"
+            NTL_P1
+            "flh %[a42], 20(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a52], 20(%[a_addr_5]) \n\t"
+            "vle16.v %[b20], (%[b_addr]) \n\t"
+            "add %[b_addr], %[b_addr], %[rsb2] \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a03], %[b30] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a13], %[b30] \n\t"
+            NTL_P1
+            "flh %[a03], 22(%[a_addr_0]) \n\t"
+            NTL_P1
+            "flh %[a13], 22(%[a_addr_1]) \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a23], %[b30] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a33], %[b30] \n\t"
+            NTL_P1
+            "flh %[a23], 22(%[a_addr_2]) \n\t"
+            NTL_P1
+            "flh %[a33], 22(%[a_addr_3]) \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a43], %[b30] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a53], %[b30] \n\t"
+            NTL_P1
+            "flh %[a43], 22(%[a_addr_4]) \n\t"
+            NTL_P1
+            "flh %[a53], 22(%[a_addr_5]) \n\t"
+            "vle16.v %[b30], (%[b_addr]) \n\t"
+#pragma clang diagnostic pop
+            : [a00] "+&f"(a00),
+              [a10] "+&f"(a10),
+              [a20] "+&f"(a20),
+              [a30] "+&f"(a30),
+              [a40] "+&f"(a40),
+              [a50] "+&f"(a50),
+              [a01] "+&f"(a01),
+              [a11] "+&f"(a11),
+              [a21] "+&f"(a21),
+              [a31] "+&f"(a31),
+              [a41] "+&f"(a41),
+              [a51] "+&f"(a51),
+              [a02] "+&f"(a02),
+              [a12] "+&f"(a12),
+              [a22] "+&f"(a22),
+              [a32] "+&f"(a32),
+              [a42] "+&f"(a42),
+              [a52] "+&f"(a52),
+              [a03] "+&f"(a03),
+              [a13] "+&f"(a13),
+              [a23] "+&f"(a23),
+              [a33] "+&f"(a33),
+              [a43] "+&f"(a43),
+              [a53] "+&f"(a53),
+              [b00] "+&vr"(b00),
+              [b10] "+&vr"(b10),
+              [b20] "+&vr"(b20),
+              [b30] "+&vr"(b30),
+              [acc0] "+&vr"(acc0),
+              [acc1] "+&vr"(acc1),
+              [acc2] "+&vr"(acc2),
+              [acc3] "+&vr"(acc3),
+              [acc4] "+&vr"(acc4),
+              [acc5] "+&vr"(acc5),
+              [b_addr] "+&r"(b_addr),
+              [a_addr_1] "=&r" (a_addr_1),
+              [a_addr_2] "=&r" (a_addr_2),
+              [a_addr_3] "=&r" (a_addr_3),
+              [a_addr_4] "=&r" (a_addr_4),
+              [a_addr_5] "=&r" (a_addr_5)
+            : [jj_vl_in] "r"(jj_vl),
+              [a_addr_0] "r" (a_addr_0),
+              [rsa2] "r" (rsa * sizeof(__bf16)),
+              [rsb2] "r" (rsb * sizeof(__bf16))
+            : "vtype", "vl", "memory"
+            // clang-format on
+        );
+      }
+
+      if (kk_unroll_degree + preload_distance < k) {
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a00], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a10], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a20], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a30], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a40], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a50], %[b00] \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a01], %[b10] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a11], %[b10] \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a21], %[b10] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a31], %[b10] \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a41], %[b10] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a51], %[b10] \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a02], %[b20] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a12], %[b20] \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a22], %[b20] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a32], %[b20] \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a42], %[b20] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a52], %[b20] \n\t"
+
+            "vfwmaccbf16.vf %[acc0], %[a03], %[b30] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a13], %[b30] \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a23], %[b30] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a33], %[b30] \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a43], %[b30] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a53], %[b30] \n\t"
+            : [acc0] "+&vr" (acc0),
+              [acc1] "+&vr" (acc1),
+              [acc2] "+&vr" (acc2),
+              [acc3] "+&vr" (acc3),
+              [acc4] "+&vr" (acc4),
+              [acc5] "+&vr" (acc5)
+            : [jj_vl_in] "r"(jj_vl),
+              [b00] "vr" (b00),
+              [b10] "vr" (b10),
+              [b20] "vr" (b20),
+              [b30] "vr" (b30),
+              [a00] "f"(a00),
+              [a10] "f"(a10),
+              [a20] "f"(a20),
+              [a30] "f"(a30),
+              [a40] "f"(a40),
+              [a50] "f"(a50),
+              [a01] "f"(a01),
+              [a11] "f"(a11),
+              [a21] "f"(a21),
+              [a31] "f"(a31),
+              [a41] "f"(a41),
+              [a51] "f"(a51),
+              [a02] "f"(a02),
+              [a12] "f"(a12),
+              [a22] "f"(a22),
+              [a32] "f"(a32),
+              [a42] "f"(a42),
+              [a52] "f"(a52),
+              [a03] "f"(a03),
+              [a13] "f"(a13),
+              [a23] "f"(a23),
+              [a33] "f"(a33),
+              [a43] "f"(a43),
+              [a53] "f"(a53)
+            : "vtype", "vl", "memory"
+            // clang-format on
+        );
+        kk += preload_distance;
+      }
+
+      for (; kk < k; kk++) {
+        __asm__ volatile(
+            // clang-format off
+            "\n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+            "vle16.v %[b00], (%[b_addr]) \n\t"
+            "flh %[a00], 0(%[a_addr_0]) \n\t"
+            "flh %[a10], 0(%[a_addr_1]) \n\t"
+            "flh %[a20], 0(%[a_addr_2]) \n\t"
+            "flh %[a30], 0(%[a_addr_3]) \n\t"
+            "flh %[a40], 0(%[a_addr_4]) \n\t"
+            "flh %[a50], 0(%[a_addr_5]) \n\t"
+            "vfwmaccbf16.vf %[acc0], %[a00], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc1], %[a10], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc2], %[a20], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc3], %[a30], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc4], %[a40], %[b00] \n\t"
+            "vfwmaccbf16.vf %[acc5], %[a50], %[b00] \n\t"
+            : [a00] "=&f"(a00),
+              [a10] "=&f"(a10),
+              [a20] "=&f"(a20),
+              [a30] "=&f"(a30),
+              [a40] "=&f"(a40),
+              [a50] "=&f"(a50),
+              [b00] "=&vr"(b00),
+              [acc0] "+&vr"(acc0),
+              [acc1] "+&vr"(acc1),
+              [acc2] "+&vr"(acc2),
+              [acc3] "+&vr"(acc3),
+              [acc4] "+&vr"(acc4),
+              [acc5] "+vr"(acc5)
+            : [jj_vl_in] "r"(jj_vl),
+              [a_addr_0] "r"(a + (ii + 0) * rsa + kk),
+              [a_addr_1] "r"(a + (ii + 1) * rsa + kk),
+              [a_addr_2] "r"(a + (ii + 2) * rsa + kk),
+              [a_addr_3] "r"(a + (ii + 3) * rsa + kk),
+              [a_addr_4] "r"(a + (ii + 4) * rsa + kk),
+              [a_addr_5] "r"(a + (ii + 5) * rsa + kk),
+              [b_addr] "r"(b + kk * rsb + jj)
+            : "vtype", "vl", "memory"
+            // clang-format on
+        );
+      }
+
+      float *c_addr = c + ii * rsc + jj;
+      __asm__ volatile(
+          // clang-format off
+          "\n\t"
+          "vsetvli zero, %[jj_vl_in], e32, m4, ta, ma \n\t"
+
+          "vle32.v %[c0], (%[c_addr]) \n\t"
+          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
+          "vfmacc.vf %[c0], %[alpha], %[acc0] \n\t"
+          "vse32.v %[c0], (%[c_addr]) \n\t"
+          "add %[c_addr], %[c_addr], %[rsc4] \n\t"
+
+          "vle32.v %[c1], (%[c_addr]) \n\t"
+          "vfmul.vf %[c1], %[c1], %[beta] \n\t"
+          "vfmacc.vf %[c1], %[alpha], %[acc1] \n\t"
+          "vse32.v %[c1], (%[c_addr]) \n\t"
+          "add %[c_addr], %[c_addr], %[rsc4] \n\t"
+
+          "vle32.v %[c0], (%[c_addr]) \n\t"
+          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
+          "vfmacc.vf %[c0], %[alpha], %[acc2] \n\t"
+          "vse32.v %[c0], (%[c_addr]) \n\t"
+          "add %[c_addr], %[c_addr], %[rsc4] \n\t"
+
+          "vle32.v %[c1], (%[c_addr]) \n\t"
+          "vfmul.vf %[c1], %[c1], %[beta] \n\t"
+          "vfmacc.vf %[c1], %[alpha], %[acc3] \n\t"
+          "vse32.v %[c1], (%[c_addr]) \n\t"
+          "add %[c_addr], %[c_addr], %[rsc4] \n\t"
+
+          "vle32.v %[c0], (%[c_addr]) \n\t"
+          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
+          "vfmacc.vf %[c0], %[alpha], %[acc4] \n\t"
+          "vse32.v %[c0], (%[c_addr]) \n\t"
+          "add %[c_addr], %[c_addr], %[rsc4] \n\t"
+
+          "vle32.v %[c1], (%[c_addr]) \n\t"
+          "vfmul.vf %[c1], %[c1], %[beta] \n\t"
+          "vfmacc.vf %[c1], %[alpha], %[acc5] \n\t"
+          "vse32.v %[c1], (%[c_addr]) \n\t"
+          : [c0] "=&vr"(c0),
+            [c1] "=&vr"(c1),
+            [c_addr] "+&r"(c_addr)
+          : [jj_vl_in] "r"(jj_vl),
+            [beta] "f"(beta),
+            [alpha] "f"(alpha),
+            [acc0] "vr"(acc0),
+            [acc1] "vr"(acc1),
+            [acc2] "vr"(acc2),
+            [acc3] "vr"(acc3),
+            [acc4] "vr"(acc4),
+            [acc5] "vr"(acc5),
+            [rsc4] "r"(rsc * sizeof(float))
+          : "vtype", "vl", "memory"
+          // clang-format on
+      );
+    }
+  }
+
+  for (ii0 = ii; (ii0 + 1) <= m; ii0 = ii0 + 1) {
+    for (jj = 0; jj < n; jj = jj + jj_vl) {
+      jj_vl = __riscv_vsetvl_e16m2(n - jj);
+      for (kk_peel = 0; ((kk_peel + 1) <= k) && (kk_peel < (0 + (1 * 1)));
+           kk_peel = kk_peel + 1) {
+        __asm__ volatile(
+            "\n\t"
+            "flh %[a0], 0(%[a_addr_83]) \n\t"
+            "fcvt.s.bf16 %[a0], %[a0] \n\t"
+
+            "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+            "vle16.v %[b0], (%[b_addr_13]) \n\t"
+            "vfwcvtbf16.f.f.v %[acc], %[b0] \n\t"
+
+            "vsetvli zero, %[jj_vl_in], e32, m4, ta, ma \n\t"
+            "vfmul.vf %[acc], %[acc], %[a0] \n\t"
+            : [a0] "=&f"(a0), [b0] "=&vr"(b0), [acc] "=vr"(acc)
+            : [a_addr_83] "r"(a + (((ii0 + 0) * rsa) + ((kk_peel + 0) * 1))),
+              [jj_vl_in] "r"(jj_vl),
+              [b_addr_13] "r"(b + (((kk_peel + 0) * rsb) + ((jj + 0) * 1)))
+            : "vtype", "vl", "memory");
+      }
+      for (kk = kk_peel; (kk + 1) <= k; kk = kk + 1) {
+        __asm__ volatile(
+            "\n\t"
+            "flh %[a0], 0(%[a_addr_84]) \n\t"
+            "vsetvli zero, %[jj_vl_in], e16, m2, ta, ma \n\t"
+            "vle16.v %[b0], (%[b_addr_14]) \n\t"
+            "vfwmaccbf16.vf %[acc], %[a0], %[b0] \n\t"
+            : [a0] "=&f"(a0), [b0] "=&vr"(b0), [acc] "+vr"(acc)
+            : [a_addr_84] "r"(a + (((ii0 + 0) * rsa) + ((kk + 0) * 1))),
+              [jj_vl_in] "r"(jj_vl),
+              [b_addr_14] "r"(b + (((kk + 0) * rsb) + ((jj + 0) * 1)))
+            : "vtype", "vl", "memory");
+      }
+      __asm__ volatile(
+          "\n\t"
+          "vsetvli zero, %[jj_vl_in], e32, m4, ta, ma \n\t"
+          "vle32.v %[c0], (%[c_addr_5]) \n\t"
+          "vfmul.vf %[c0], %[c0], %[beta] \n\t"
+          "vfmacc.vf %[c0], %[alpha], %[acc] \n\t"
+          "vse32.v %[c0], (%[c_addr_5]) \n\t"
+          : [c0] "=&vr"(c0)
+          : [jj_vl_in] "r"(jj_vl),
+            [c_addr_5] "r"(c + (((ii0 + 0) * rsc) + ((jj + 0) * 1))),
+            [beta] "f"(beta), [alpha] "f"(alpha), [acc] "vr"(acc)
+          : "vtype", "vl", "memory");
+    }
+  }
+}
+
+SKL_FUNC void skl_gemm_bf16_bf16_f32_zvfbfwma_x390(size_t m, size_t n, size_t k,
+                                                   float alpha, const __bf16 *a,
+                                                   size_t rsa, const __bf16 *b,
+                                                   size_t rsb, float beta,
+                                                   float *c, size_t rsc) {
+  if (m == 1) {
+    skl_gemm_1xm8x18_bf16_bf16_f32_zvfbfwma_x390(m, n, k, alpha, a, rsc, b, rsb,
+                                                 beta, c, rsc);
+    return;
+  }
+  skl_gemm_6xm4x12_bf16_bf16_f32_zvfbfwma_x390(m, n, k, alpha, a, rsa, b, rsb,
+                                               beta, c, rsc);
+}
+
+#undef NTL_P1

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.c
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.c
@@ -473,9 +473,9 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4x12_bf16_bf16_f32_zvfbfwma_x390(
     for (ii = 0; (ii + 1) <= m; ii = ii + 1) {
       for (jj = 0; jj < n; jj = jj + jj_vl) {
         jj_vl = __riscv_vsetvl_e32m4(n - jj);
-        c0 = __riscv_vle32_v_f32m4(c + ii * rsc + jj, jj_vl);
-        c0 = __riscv_vfmul_vf_f32m4(c0, beta, jj_vl);
-        __riscv_vse32_v_f32m4(c + ii * rsc + jj, c0, jj_vl);
+        vfloat32m8_t c0m8 = __riscv_vle32_v_f32m8(c + ii * rsc + jj, jj_vl);
+        c0m8 = __riscv_vfmul_vf_f32m8(c0m8, beta, jj_vl);
+        __riscv_vse32_v_f32m8(c + ii * rsc + jj, c0m8, jj_vl);
       }
     }
     return;

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.c
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.c
@@ -62,8 +62,11 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm8x18_bf16_bf16_f32_zvfbfwma_x390(
   size_t jj;
   size_t kk;
 
-  // Due to a compiler bug, temporary A matrix values used in the inline
-  // assembly below are typed as float instead of __bf16.
+  // FIXME: due to a compiler bug, temporary A matrix values used in the inline
+  // assembly of this kernel are typed as float instead of __bf16. Change to
+  // __bf16 once the following patch is available in our toolchain:
+  // https://github.com/llvm/llvm-project/pull/184566
+
   float a0;
   float a1;
   float a2;
@@ -427,8 +430,10 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4x12_bf16_bf16_f32_zvfbfwma_x390(
   size_t ii0;
   size_t kk_peel;
 
-  // Due to a compiler bug, temporary A matrix values used in the inline
-  // assembly below are typed as float instead of __bf16.
+  // FIXME: due to a compiler bug, temporary A matrix values used in the inline
+  // assembly of this kernel are typed as float instead of __bf16. Change to
+  // __bf16 once the following patch is available in our toolchain:
+  // https://github.com/llvm/llvm-project/pull/184566
   float a00;
   float a10;
   float a20;

--- a/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.h
+++ b/src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#if !defined(__riscv_zvfbfwma) || __riscv_zvfbfwma < 1000000
+#error This file requires the RISC-V Zvfbfwma extension, version 1000000.
+#endif
+
+#include <stddef.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * @brief RVV bfloat16 matrix-matrix multiplication with float32 output for
+ * row-major matrices, tuned for X390.
+ *
+ * @param m - Number of rows in matrices A and C.
+ * @param n - Number of columns in matrices B and C.
+ * @param k - Number of columns in A and rows in B (inner dimension).
+ * @param alpha - Scalar multiplier for A*B product.
+ * @param a - Pointer to matrix A.
+ * @param rsa - Row stride of matrix A in elements.
+ * @param b - Pointer to matrix B.
+ * @param rsb - Row stride of matrix B in elements.
+ * @param beta - Scalar multiplier for matrix C.
+ * @param c - Pointer to matrix C.
+ * @param rsc - Row stride of matrix C in elements.
+ *
+ * Computes `C = alpha * A * B + beta * C` for BF16 row-major matrices A and B
+ * and FP32 row-major output matrix C.
+ *
+ * Functionally equivalent to calling:
+ * ```
+ * skl_gemm_bf16rc_bf16rc_f32rc_ref(
+ *     m, n, k,
+ *     alpha,
+ *     a, rsa, 1,
+ *     b, rsb, 1,
+ *     beta,
+ *     c, rsc, 1
+ * );
+ * ```
+ */
+void skl_gemm_bf16_bf16_f32_zvfbfwma_x390(size_t m, size_t n, size_t k,
+                                          float alpha, const __bf16 *a,
+                                          size_t rsa, const __bf16 *b,
+                                          size_t rsb, float beta, float *c,
+                                          size_t rsc);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -242,6 +242,13 @@ skl_add_test(
   ""
 )
 skl_add_test(
+  skl_gemm_bf16_bf16_f32_zvfbfwma_x390
+  gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+  gemm/rvv/skl_gemm_bf16_bf16_f32_zvfbfwma_x390.c
+  "zvfbfwma"
+  ""
+)
+skl_add_test(
   skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f
   gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
   gemm/xsfmm/skl_gemm_a1b01_bf16c_bf16_f32_xsfmm32a16f.c

--- a/test/gemm/rvv/skl_gemm_bf16_bf16_f32_zvfbfwma_x390.c
+++ b/test/gemm/rvv/skl_gemm_bf16_bf16_f32_zvfbfwma_x390.c
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#include "gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h"
+#include "skl-test-driver.h"
+#include "skl.h"
+#include <stddef.h>
+
+#if !defined(__riscv_zvfbfwma)
+#error This file requires the Zvfbfwma extension
+#endif
+
+/**
+ * @brief Test cases for the skl_gemm_bf16_bf16_f32_zvfbfwma kernel.
+ *
+ * This test uses the gemm_bf16rcprc_bf16rcprc_f32rcprc harness with the
+ * following restrictions on the input parameters:
+ *  - The block dimensions are m0 = 1, n0 = 1, and k0 = 1
+ *  - All matrices are row-major (csa1 == 1, csb1 == 1, csc1 == 1)
+ */
+
+#define TEST                                                                   \
+  GEMM_BF16RCPRC_BF16RCPRC_F32RCPRC_DEFAULTS,                                  \
+      .steps = {                                                               \
+          .init = init,                                                        \
+          .warmup = NULL,                                                      \
+          .execute = execute,                                                  \
+          .verify = gemm_bf16rcprc_bf16rcprc_f32rcprc_verify,                  \
+          .report = gemm_bf16rcprc_bf16rcprc_f32rcprc_test_report,             \
+          .cleanup = gemm_bf16rcprc_bf16rcprc_f32rcprc_cleanup,                \
+  }
+
+#define BENCH                                                                  \
+  GEMM_BF16RCPRC_BF16RCPRC_F32RCPRC_DEFAULTS,                                  \
+      .steps = {                                                               \
+          .init = init,                                                        \
+          .warmup = execute,                                                   \
+          .execute = execute,                                                  \
+          .verify = NULL,                                                      \
+          .report = gemm_bf16rcprc_bf16rcprc_f32rcprc_benchmark_report,        \
+          .cleanup = gemm_bf16rcprc_bf16rcprc_f32rcprc_cleanup,                \
+  }
+
+static void init(skl_test_t *t);
+static void execute(skl_test_t *t);
+
+// clang-format off
+gemm_bf16rcprc_bf16rcprc_f32rcprc_t tests[] = {
+#ifdef SKL_ENABLE_BENCHMARKS
+    // Benchmark tests
+    {BENCH, .m1 =  64, .n1 = 128, .k1 = 128, .alpha = 1.f},
+#endif // SKL_ENABLE_BENCHMARKS
+
+#ifdef SKL_ENABLE_TESTS
+    // Verification tests - comprehensive coverage for RVV GEMM
+    /* Edge cases: minimal dimensions */
+    {TEST, .m1 = 1,   .n1 = 1,   .k1 = 0,  .alpha = 2.f},
+    {TEST, .m1 = 1,   .n1 = 1,   .k1 = 1,  .alpha = 2.f},
+
+    /* Small odd dimensions for remainder handling */
+    {TEST, .m1 = 7,   .n1 = 7,   .k1 = 7,  .alpha = 2.f},
+    {TEST, .m1 = 17,  .n1 = 17,  .k1 = 17, .alpha = 2.f},
+
+    /* Skinny matrices (one dimension = 1) */
+    {TEST, .m1 = 1,   .n1 = 33,  .k1 = 31, .alpha = 2.f},
+    {TEST, .m1 = 33,  .n1 = 1,   .k1 = 31, .alpha = 2.f},
+
+    /* k=0 edge case (C = beta*C, no A*B contribution) */
+    {TEST, .m1 = 33,  .n1 = 33,  .k1 = 0,  .alpha = 2.f},
+    {TEST, .m1 = 16,  .n1 = 16,  .k1 = 0,  .alpha = 2.f,  .beta = 2.f},
+
+    /* Vector length boundary tests (multiples of 4, 8, 16, 32) */
+    {TEST, .m1 = 16,  .n1 = 16,  .k1 = 16, .alpha = 2.f},
+    {TEST, .m1 = 32,  .n1 = 32,  .k1 = 32, .alpha = 2.f},
+
+    /* Near-boundary tests (±1 from vector length multiples) */
+    {TEST, .m1 = 15,  .n1 = 17,  .k1 = 31, .alpha = 2.f},
+    {TEST, .m1 = 31,  .n1 = 33,  .k1 = 15, .alpha = 2.f},
+
+    /* Wide and tall matrices */
+    {TEST, .m1 = 33,  .n1 = 129, .k1 = 32, .alpha = 2.f},
+    {TEST, .m1 = 129, .n1 = 33,  .k1 = 32, .alpha = 2.f},
+    {TEST, .m1 = 31,  .n1 = 133, .k1 = 32, .alpha = 2.f},
+
+    /* Beta scaling test (beta=1, accumulate into existing C) */
+    {TEST, .m1 = 32,  .n1 = 32,  .k1 = 32, .alpha = 2.f,  .beta = 1.f},
+#endif // SKL_ENABLE_TESTS
+};
+// clang-format on
+
+static skl_test_suite_t suite = {
+    .name = "skl_gemm_bf16_bf16_f32_zvfbfwma",
+    .num_tests = sizeof(tests) / sizeof(tests[0]),
+    .test_size = sizeof(gemm_bf16rcprc_bf16rcprc_f32rcprc_t),
+    .tests = tests};
+
+static void init(skl_test_t *t) {
+  const gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
+      (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
+
+  SKL_TEST_REQUIRE(t, init_status, h->m0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->n0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->k0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->csa1 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->csb1 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->csc1 == 1);
+
+  gemm_bf16rcprc_bf16rcprc_f32rcprc_init(t);
+}
+
+static void execute(skl_test_t *t) {
+  const gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
+      (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
+
+  skl_gemm_bf16_bf16_f32_zvfbfwma_x390(
+      h->m1, h->n1, h->k1, h->alpha, h->a_pack.data, h->rsa1, h->b_pack.data,
+      h->rsb1, h->beta, h->c_pack.data, h->rsc1);
+}
+
+int main(void) {
+  // Set default strides: all matrices are row-major
+  for (size_t i = 0; i < suite.num_tests; ++i) {
+    tests[i].m0 = 1;
+    tests[i].n0 = 1;
+    tests[i].k0 = 1;
+
+    tests[i].rsa0 = 1;
+    tests[i].csa0 = 1;
+    tests[i].rsa1 = tests[i].rsa1 ? tests[i].rsa1 : tests[i].k1;
+    tests[i].csa1 = tests[i].csa1 ? tests[i].csa1 : 1;
+
+    tests[i].rsb0 = 1;
+    tests[i].csb0 = 1;
+    tests[i].rsb1 = tests[i].rsb1 ? tests[i].rsb1 : tests[i].n1;
+    tests[i].csb1 = tests[i].csb1 ? tests[i].csb1 : 1;
+
+    tests[i].rsc0 = 1;
+    tests[i].csc0 = 1;
+    tests[i].rsc1 = tests[i].rsc1 ? tests[i].rsc1 : tests[i].n1;
+    tests[i].csc1 = tests[i].csc1 ? tests[i].csc1 : 1;
+  }
+
+  return skl_test_driver_run_suite(&suite);
+}

--- a/test/gemm/rvv/skl_gemm_bf16_bf16_f32_zvfbfwma_x390.c
+++ b/test/gemm/rvv/skl_gemm_bf16_bf16_f32_zvfbfwma_x390.c
@@ -129,17 +129,17 @@ int main(void) {
     tests[i].rsa0 = 1;
     tests[i].csa0 = 1;
     tests[i].rsa1 = tests[i].rsa1 ? tests[i].rsa1 : tests[i].k1;
-    tests[i].csa1 = tests[i].csa1 ? tests[i].csa1 : 1;
+    tests[i].csa1 = 1;
 
     tests[i].rsb0 = 1;
     tests[i].csb0 = 1;
     tests[i].rsb1 = tests[i].rsb1 ? tests[i].rsb1 : tests[i].n1;
-    tests[i].csb1 = tests[i].csb1 ? tests[i].csb1 : 1;
+    tests[i].csb1 = 1;
 
     tests[i].rsc0 = 1;
     tests[i].csc0 = 1;
     tests[i].rsc1 = tests[i].rsc1 ? tests[i].rsc1 : tests[i].n1;
-    tests[i].csc1 = tests[i].csc1 ? tests[i].csc1 : 1;
+    tests[i].csc1 = 1;
   }
 
   return skl_test_driver_run_suite(&suite);


### PR DESCRIPTION
This adds widening bf16 RVV GEMM kernels specialized for x390 using the zvfbfwma extension. These kernels are a copy-paste of the f16 versions, with the following changes/notes:
- `vfwmacc.vf` was changed to `vfwmaccbf16.vf`.
- Since there is no widening multiply in the zvfbfwma extension, the `vfwmul.vf`s were replaced with a widening conversion followed by `vfmul.vf` in f32.
- There is a compiler bug on using `__bf16` values in an inline asm operand for which a fix has been landed but not yet included in our toolchain: https://github.com/llvm/llvm-project/pull/184566. The workaround taken in this PR is to use `float` types for the temporary A matrix values.

The performance for the new kernels is in line with the f16 versions.