### PR TITLE
[SKL][Pack] Optimize panel block cases

### DIFF
--- a/src/pack/rvv/skl_pack_e8_zve32x.c
+++ b/src/pack/rvv/skl_pack_e8_zve32x.c
@@ -571,7 +571,11 @@ skl_transpose_nvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
       read_ptr += rsa;
       vrow3 = __riscv_vle8_v_u8m2(read_ptr, vl);
       vuint8m2x4_t vrows = __riscv_vcreate_v_u8m2x4(vrow0, vrow1, vrow2, vrow3);
-      __riscv_vssseg4e8_v_u8m2x4(out_tile, output_seg_bstride, vrows, vl);
+      if (rsat == 4) {
+        __riscv_vsseg4e8_v_u8m2x4(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg4e8_v_u8m2x4(out_tile, output_seg_bstride, vrows, vl);
+      }
       in_tile += vl;
       out_tile += vl * rsat;
     }
@@ -1012,72 +1016,117 @@ skl_pack_e8_e8rcprc_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT src,
   size_t m1 = (m + m0 - 1) / m0; // Num. block-rows in output matrix
   size_t n1 = (n + n0 - 1) / n0; // Num. block-columns in output matrix
 
+  /* Column panels */
+  if (rs0 == 1 && n0 == 1) {
+    if (m0 == rs1) {
+      /* column-major block ordering */
+      skl_transpose_padded_m_e8_zve32x(m0 * m1, m, n, src, rs, dst, cs1, pad);
+    } else {
+      /* row-major block ordering */
+      const uint8_t *src_block = src;
+      uint8_t *dst_block = dst;
+      for (size_t ii1 = 0; ii1 < m1 - 1; ++ii1) {
+        skl_transpose_e8_zve32x(m0, n, src_block, rs, dst_block, cs1);
+        src_block += m0 * rs;
+        dst_block += rs1;
+      }
+      size_t m_tail = m - m0 * (m1 - 1);
+      skl_transpose_padded_m_e8_zve32x(m0, m_tail, n, src_block, rs, dst_block,
+                                       cs1, pad);
+    }
+    return;
+  }
+
   /* intra-block: column-major, inter-block: row-major */
   if ((cs0 * n0 == cs1) && rs0 == 1) {
-    for (size_t ii1 = 0; ii1 < m1; ++ii1) {
-      const uint8_t *src_block = src + ii1 * m0 * rs;
-      uint8_t *dst_block = dst + ii1 * rs1;
-      size_t m_length = m0 < m - ii1 * m0 ? m0 : m - ii1 * m0;
-      skl_transpose_padded_m_e8_zve32x(m0, m_length, n, src_block, rs,
-                                       dst_block, cs0, pad);
+    const uint8_t *src_block = src;
+    uint8_t *dst_block = dst;
+    for (size_t ii1 = 0; ii1 < m1 - 1; ++ii1) {
+      skl_transpose_e8_zve32x(m0, n, src_block, rs, dst_block, cs0);
       if (n % n0) {
         // pad right
         skl_set_2d_e8_zve32x(dst_block + cs1 * (n1 - 1) + cs0 * (n % n0), cs0,
                              pad, n0 - n % n0, m0);
       }
+      src_block += m0 * rs;
+      dst_block += rs1;
+    }
+    size_t m_tail = m - m0 * (m1 - 1);
+    skl_transpose_padded_m_e8_zve32x(m0, m_tail, n, src_block, rs, dst_block,
+                                     cs0, pad);
+    if (n % n0) {
+      // pad right
+      skl_set_2d_e8_zve32x(dst_block + cs1 * (n1 - 1) + cs0 * (n % n0), cs0,
+                           pad, n0 - n % n0, m0);
+    }
+    return;
+  }
+
+  /* Row panels */
+  if (cs0 == 1 && m0 == 1) {
+    if (n0 == cs1) {
+      /* row-major block ordering */
+      skl_copy_2d_e8_zve32x(m, n, src, rs, dst, rs1);
+      // pad right
+      if (n % n0) {
+        skl_set_2d_e8_zve32x(dst + n, rs1, pad, m, n0 - n % n0);
+      }
+
+    } else {
+      /* column-major block ordering */
+      const uint8_t *src_block = src;
+      uint8_t *dst_block = dst;
+
+      for (size_t jj1 = 0; jj1 < n1 - 1; ++jj1) {
+        skl_copy_2d_e8_zve32x(m, n0, src_block, rs, dst_block, rs1);
+        src_block += n0;
+        dst_block += cs1;
+      }
+      size_t n_tail = n - n0 * (n1 - 1);
+      skl_copy_2d_e8_zve32x(m, n_tail, src_block, rs, dst_block, rs1);
+      // pad right: pad (n0 - n_tail) elements in each of m rows
+      skl_set_2d_e8_zve32x(dst_block + n_tail, rs1, pad, m, n0 - n_tail);
     }
     return;
   }
 
   /* intra-block: row-major, inter-block: column-major */
   if ((rs0 * m0 == rs1) && cs0 == 1) {
-    for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      const uint8_t *src_block = src + jj1 * n0;
-      uint8_t *dst_block = dst + jj1 * cs1;
-      size_t n_length = n0 < n - jj1 * n0 ? n0 : n - jj1 * n0;
-      skl_copy_2d_e8_zve32x(m, n_length, src_block, rs, dst_block, rs0);
+    const uint8_t *src_block = src;
+    uint8_t *dst_block = dst;
+    for (size_t jj1 = 0; jj1 < n1 - 1; ++jj1) {
+      skl_copy_2d_e8_zve32x(m, n0, src_block, rs, dst_block, rs0);
       if (m % m0) {
         // pad bottom
         skl_set_2d_e8_zve32x(dst_block + m * rs0, rs0, pad, m0 - m % m0, n0);
       }
-      // pad right: pad (n0 - n_length) elements in each of m rows
-      skl_set_2d_e8_zve32x(dst_block + n_length, rs0, pad, m, n0 - n_length);
+      src_block += n0;
+      dst_block += cs1;
     }
-    return;
-  }
-
-  /* Column panels, column-major block ordering*/
-  if (rs0 == 1 && n0 == 1 && m0 == rs1) {
-    skl_transpose_padded_m_e8_zve32x(m0 * m1, m, n, src, rs, dst, cs1, pad);
-    return;
-  }
-
-  /* Row panels, row-major block ordering*/
-  if (cs0 == 1 && m0 == 1 && n0 == cs1) {
-    skl_copy_2d_e8_zve32x(m, n, src, rs, dst, rs1);
-    // pad right
-    if (n % n0) {
-      skl_set_2d_e8_zve32x(dst + n, rs1, pad, m, n0 - n % n0);
+    size_t n_tail = n - n0 * (n1 - 1);
+    skl_copy_2d_e8_zve32x(m, n_tail, src_block, rs, dst_block, rs0);
+    if (m % m0) {
+      // pad bottom
+      skl_set_2d_e8_zve32x(dst_block + m * rs0, rs0, pad, m0 - m % m0, n0);
     }
+    // pad right: pad (n0 - n_tail) elements in each of m rows
+    skl_set_2d_e8_zve32x(dst_block + n_tail, rs0, pad, m, n0 - n_tail);
     return;
   }
 
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
+    size_t m_length = m0 < m - ii1 * m0 ? m0 : m - ii1 * m0;
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
       const uint8_t *src_block = src + ii1 * m0 * rs + jj1 * n0;
       uint8_t *dst_block = dst + ii1 * rs1 + jj1 * cs1;
-
+      size_t n_length = n0 < n - jj1 * n0 ? n0 : n - jj1 * n0;
       if (rs0 == 1) {
-        size_t m_length = m0 < m - ii1 * m0 ? m0 : m - ii1 * m0;
-        size_t n_length = n0 < n - jj1 * n0 ? n0 : n - jj1 * n0;
         skl_transpose_padded_m_e8_zve32x(m0, m_length, n_length, src_block, rs,
                                          dst_block, cs0, pad);
         // pad right
         skl_set_2d_e8_zve32x(dst_block + cs0 * n_length, cs0, pad,
                              n0 - n_length, m0);
       } else if (cs0 == 1) {
-        size_t m_length = m0 < m - ii1 * m0 ? m0 : m - ii1 * m0;
-        size_t n_length = n0 < n - jj1 * n0 ? n0 : n - jj1 * n0;
         skl_copy_2d_e8_zve32x(m_length, n_length, src_block, rs, dst_block,
                               rs0);
         // pad right: pad (n0 - n_length) elements in each of m_length rows

--- a/src/pack/rvv/skl_pack_e8_zve32x.c
+++ b/src/pack/rvv/skl_pack_e8_zve32x.c
@@ -225,7 +225,11 @@ skl_transpose_mvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
       for (size_t jj = 0; jj < m; jj += vl) {
         vl = __riscv_vsetvl_e8m1(m - jj);
 
-        vcols = __riscv_vlsseg8e8_v_u8m1x8(in_tile, input_seg_bstride, vl);
+        if (rsa == 8) {
+          vcols = __riscv_vlseg8e8_v_u8m1x8(in_tile, vl);
+        } else {
+          vcols = __riscv_vlsseg8e8_v_u8m1x8(in_tile, input_seg_bstride, vl);
+        }
 
         uint8_t *write_ptr = out_tile;
         // store each segment continuously along m
@@ -287,7 +291,11 @@ skl_transpose_mvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
     for (size_t jj = 0; jj < m; jj += vl) {
       vl = __riscv_vsetvl_e8m4(m - jj);
 
-      vcols = __riscv_vlsseg2e8_v_u8m4x2(in_tile, input_seg_bstride, vl);
+      if (rsa == 2) {
+        vcols = __riscv_vlseg2e8_v_u8m4x2(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg2e8_v_u8m4x2(in_tile, input_seg_bstride, vl);
+      }
 
       uint8_t *write_ptr = out_tile;
       // store each segment extently along m
@@ -307,7 +315,11 @@ skl_transpose_mvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
     for (size_t jj = 0; jj < m; jj += vl) {
       vl = __riscv_vsetvl_e8m2(m - jj);
 
-      vcols = __riscv_vlsseg3e8_v_u8m2x3(in_tile, input_seg_bstride, vl);
+      if (rsa == 3) {
+        vcols = __riscv_vlseg3e8_v_u8m2x3(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg3e8_v_u8m2x3(in_tile, input_seg_bstride, vl);
+      }
 
       uint8_t *write_ptr = out_tile;
       // store each segment extently along m
@@ -330,7 +342,11 @@ skl_transpose_mvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
     for (size_t jj = 0; jj < m; jj += vl) {
       vl = __riscv_vsetvl_e8m2(m - jj);
 
-      vcols = __riscv_vlsseg4e8_v_u8m2x4(in_tile, input_seg_bstride, vl);
+      if (rsa == 4) {
+        vcols = __riscv_vlseg4e8_v_u8m2x4(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg4e8_v_u8m2x4(in_tile, input_seg_bstride, vl);
+      }
 
       uint8_t *write_ptr = out_tile;
       // store each segment extently along m
@@ -355,7 +371,11 @@ skl_transpose_mvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
     for (size_t jj = 0; jj < m; jj += vl) {
       vl = __riscv_vsetvl_e8m1(m - jj);
 
-      vcols = __riscv_vlsseg5e8_v_u8m1x5(in_tile, input_seg_bstride, vl);
+      if (rsa == 5) {
+        vcols = __riscv_vlseg5e8_v_u8m1x5(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg5e8_v_u8m1x5(in_tile, input_seg_bstride, vl);
+      }
 
       uint8_t *write_ptr = out_tile;
       // store each segment extently along m
@@ -382,7 +402,11 @@ skl_transpose_mvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
     for (size_t jj = 0; jj < m; jj += vl) {
       vl = __riscv_vsetvl_e8m1(m - jj);
 
-      vcols = __riscv_vlsseg6e8_v_u8m1x6(in_tile, input_seg_bstride, vl);
+      if (rsa == 6) {
+        vcols = __riscv_vlseg6e8_v_u8m1x6(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg6e8_v_u8m1x6(in_tile, input_seg_bstride, vl);
+      }
 
       uint8_t *write_ptr = out_tile;
       // store each segment extently along m
@@ -411,7 +435,11 @@ skl_transpose_mvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
     for (size_t jj = 0; jj < m; jj += vl) {
       vl = __riscv_vsetvl_e8m1(m - jj);
 
-      vcols = __riscv_vlsseg7e8_v_u8m1x7(in_tile, input_seg_bstride, vl);
+      if (rsa == 7) {
+        vcols = __riscv_vlseg7e8_v_u8m1x7(in_tile, vl);
+      } else {
+        vcols = __riscv_vlsseg7e8_v_u8m1x7(in_tile, input_seg_bstride, vl);
+      }
 
       uint8_t *write_ptr = out_tile;
       // store each segment extently along m
@@ -486,9 +514,12 @@ skl_transpose_nvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
 
         vuint8m1x8_t vrows = __riscv_vcreate_v_u8m1x8(
             vrow0, vrow1, vrow2, vrow3, vrow4, vrow5, vrow6, vrow7);
-
-        __riscv_vssseg8e8_v_u8m1x8(at + (jj * rsat) + ii, output_seg_bstride,
-                                   vrows, vl);
+        if (rsat == 8) {
+          __riscv_vsseg8e8_v_u8m1x8(at + (jj * rsat) + ii, vrows, vl);
+        } else {
+          __riscv_vssseg8e8_v_u8m1x8(at + (jj * rsat) + ii, output_seg_bstride,
+                                     vrows, vl);
+        }
       }
     }
   }
@@ -524,7 +555,11 @@ skl_transpose_nvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
       read_ptr += rsa;
       vrow1 = __riscv_vle8_v_u8m4(read_ptr, vl);
       vuint8m4x2_t vrows = __riscv_vcreate_v_u8m4x2(vrow0, vrow1);
-      __riscv_vssseg2e8_v_u8m4x2(out_tile, output_seg_bstride, vrows, vl);
+      if (rsat == 2) {
+        __riscv_vsseg2e8_v_u8m4x2(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg2e8_v_u8m4x2(out_tile, output_seg_bstride, vrows, vl);
+      }
       in_tile += vl;
       out_tile += vl * rsat;
     }
@@ -546,7 +581,11 @@ skl_transpose_nvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
       read_ptr += rsa;
       vrow2 = __riscv_vle8_v_u8m2(read_ptr, vl);
       vuint8m2x3_t vrows = __riscv_vcreate_v_u8m2x3(vrow0, vrow1, vrow2);
-      __riscv_vssseg3e8_v_u8m2x3(out_tile, output_seg_bstride, vrows, vl);
+      if (rsat == 3) {
+        __riscv_vsseg3e8_v_u8m2x3(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg3e8_v_u8m2x3(out_tile, output_seg_bstride, vrows, vl);
+      }
       in_tile += vl;
       out_tile += vl * rsat;
     }
@@ -604,7 +643,11 @@ skl_transpose_nvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
       vrow4 = __riscv_vle8_v_u8m1(read_ptr, vl);
       vuint8m1x5_t vrows =
           __riscv_vcreate_v_u8m1x5(vrow0, vrow1, vrow2, vrow3, vrow4);
-      __riscv_vssseg5e8_v_u8m1x5(out_tile, output_seg_bstride, vrows, vl);
+      if (rsat == 5) {
+        __riscv_vsseg5e8_v_u8m1x5(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg5e8_v_u8m1x5(out_tile, output_seg_bstride, vrows, vl);
+      }
       in_tile += vl;
       out_tile += vl * rsat;
     }
@@ -636,7 +679,11 @@ skl_transpose_nvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
       vrow5 = __riscv_vle8_v_u8m1(read_ptr, vl);
       vuint8m1x6_t vrows =
           __riscv_vcreate_v_u8m1x6(vrow0, vrow1, vrow2, vrow3, vrow4, vrow5);
-      __riscv_vssseg6e8_v_u8m1x6(out_tile, output_seg_bstride, vrows, vl);
+      if (rsat == 6) {
+        __riscv_vsseg6e8_v_u8m1x6(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg6e8_v_u8m1x6(out_tile, output_seg_bstride, vrows, vl);
+      }
       in_tile += vl;
       out_tile += vl * rsat;
     }
@@ -671,7 +718,11 @@ skl_transpose_nvec_e8_zve32x(size_t m, size_t n, const uint8_t *SKL_RESTRICT a,
       vrow6 = __riscv_vle8_v_u8m1(read_ptr, vl);
       vuint8m1x7_t vrows = __riscv_vcreate_v_u8m1x7(vrow0, vrow1, vrow2, vrow3,
                                                     vrow4, vrow5, vrow6);
-      __riscv_vssseg7e8_v_u8m1x7(out_tile, output_seg_bstride, vrows, vl);
+      if (rsat == 7) {
+        __riscv_vsseg7e8_v_u8m1x7(out_tile, vrows, vl);
+      } else {
+        __riscv_vssseg7e8_v_u8m1x7(out_tile, output_seg_bstride, vrows, vl);
+      }
       in_tile += vl;
       out_tile += vl * rsat;
     }
@@ -753,8 +804,13 @@ SKL_FUNC_PRIVATE void skl_transpose_padded_m_e8_zve32x(
         vuint8m4x2_t pad_vec_group2 =
             __riscv_vcreate_v_u8m4x2(__riscv_vle8_v_u8m4(in_tile, vl),
                                      __riscv_vget_v_u8m8_u8m4(pad_vec, 1));
-        __riscv_vssseg2e8_v_u8m4x2(
-            out_tile, (ptrdiff_t)(rsat * sizeof(uint8_t)), pad_vec_group2, vl);
+        if (rsat == 2) {
+          __riscv_vsseg2e8_v_u8m4x2(out_tile, pad_vec_group2, vl);
+        } else {
+          __riscv_vssseg2e8_v_u8m4x2(out_tile,
+                                     (ptrdiff_t)(rsat * sizeof(uint8_t)),
+                                     pad_vec_group2, vl);
+        }
         in_tile += vl;
         out_tile += vl * rsat;
       }
@@ -779,8 +835,13 @@ SKL_FUNC_PRIVATE void skl_transpose_padded_m_e8_zve32x(
         default:
           break;
         }
-        __riscv_vssseg3e8_v_u8m2x3(
-            out_tile, (ptrdiff_t)(rsat * sizeof(uint8_t)), pad_vec_group3, vl);
+        if (rsat == 3) {
+          __riscv_vsseg3e8_v_u8m2x3(out_tile, pad_vec_group3, vl);
+        } else {
+          __riscv_vssseg3e8_v_u8m2x3(out_tile,
+                                     (ptrdiff_t)(rsat * sizeof(uint8_t)),
+                                     pad_vec_group3, vl);
+        }
         in_tile += vl;
         out_tile += vl * rsat;
       }
@@ -810,8 +871,13 @@ SKL_FUNC_PRIVATE void skl_transpose_padded_m_e8_zve32x(
         default:
           break;
         }
-        __riscv_vssseg4e8_v_u8m2x4(
-            out_tile, (ptrdiff_t)(rsat * sizeof(uint8_t)), pad_vec_group4, vl);
+        if (rsat == 4) {
+          __riscv_vsseg4e8_v_u8m2x4(out_tile, pad_vec_group4, vl);
+        } else {
+          __riscv_vssseg4e8_v_u8m2x4(out_tile,
+                                     (ptrdiff_t)(rsat * sizeof(uint8_t)),
+                                     pad_vec_group4, vl);
+        }
         in_tile += vl;
         out_tile += vl * rsat;
       }
@@ -846,8 +912,13 @@ SKL_FUNC_PRIVATE void skl_transpose_padded_m_e8_zve32x(
         default:
           break;
         }
-        __riscv_vssseg5e8_v_u8m1x5(
-            out_tile, (ptrdiff_t)(rsat * sizeof(uint8_t)), pad_vec_group5, vl);
+        if (rsat == 5) {
+          __riscv_vsseg5e8_v_u8m1x5(out_tile, pad_vec_group5, vl);
+        } else {
+          __riscv_vssseg5e8_v_u8m1x5(out_tile,
+                                     (ptrdiff_t)(rsat * sizeof(uint8_t)),
+                                     pad_vec_group5, vl);
+        }
         in_tile += vl;
         out_tile += vl * rsat;
       }
@@ -887,8 +958,13 @@ SKL_FUNC_PRIVATE void skl_transpose_padded_m_e8_zve32x(
         default:
           break;
         }
-        __riscv_vssseg6e8_v_u8m1x6(
-            out_tile, (ptrdiff_t)(rsat * sizeof(uint8_t)), pad_vec_group6, vl);
+        if (rsat == 6) {
+          __riscv_vsseg6e8_v_u8m1x6(out_tile, pad_vec_group6, vl);
+        } else {
+          __riscv_vssseg6e8_v_u8m1x6(out_tile,
+                                     (ptrdiff_t)(rsat * sizeof(uint8_t)),
+                                     pad_vec_group6, vl);
+        }
         in_tile += vl;
         out_tile += vl * rsat;
       }
@@ -933,8 +1009,13 @@ SKL_FUNC_PRIVATE void skl_transpose_padded_m_e8_zve32x(
         default:
           break;
         }
-        __riscv_vssseg7e8_v_u8m1x7(
-            out_tile, (ptrdiff_t)(rsat * sizeof(uint8_t)), pad_vec_group7, vl);
+        if (rsat == 7) {
+          __riscv_vsseg7e8_v_u8m1x7(out_tile, pad_vec_group7, vl);
+        } else {
+          __riscv_vssseg7e8_v_u8m1x7(out_tile,
+                                     (ptrdiff_t)(rsat * sizeof(uint8_t)),
+                                     pad_vec_group7, vl);
+        }
         in_tile += vl;
         out_tile += vl * rsat;
       }
@@ -984,8 +1065,13 @@ SKL_FUNC_PRIVATE void skl_transpose_padded_m_e8_zve32x(
         default:
           break;
         }
-        __riscv_vssseg8e8_v_u8m1x8(
-            out_tile, (ptrdiff_t)(rsat * sizeof(uint8_t)), pad_vec_group8, vl);
+        if (rsat == 8) {
+          __riscv_vsseg8e8_v_u8m1x8(out_tile, pad_vec_group8, vl);
+        } else {
+          __riscv_vssseg8e8_v_u8m1x8(out_tile,
+                                     (ptrdiff_t)(rsat * sizeof(uint8_t)),
+                                     pad_vec_group8, vl);
+        }
         in_tile += vl;
         out_tile += vl * rsat;
       }


### PR DESCRIPTION
This PR aims to close the performance gap between the general Pack kernel and the legacy `skl_pack_b_i8_xsfvqdotq` kernel, which was removed in https://github.com/sifive/skl/pull/119.
The potential gap mainly stems from the strided segmented load/store instructions in the current Pack kernel, as the hardware may achieve better performance by using unit-strided segmented load/store instructions instead.
Another minor improvement is the reduction of redundant scalar code for non-fringe blocks.
It also enables the optimization path for panel cases where `rs0` or `cs0` are ignored in row and column panels, respectively.
