### PR TITLE
[GEMM] Rename Xsfvqdotq GEMM kernels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ add_skl_src(src/gemm/xsfmm/gemm_a1b01_f32c_f32_f32_xsfmm32a32f.c "xsfmm32a32f")
 add_skl_src(src/gemm/xsfmm/gemm_a1b01_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c "xsfmm32a8f")
 add_skl_src(src/gemm/xsfmm/gemm_a1b01_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c "xsfmm32a8f")
 add_skl_src(src/gemm/xsfmm/gemm_a1b01_i8c_i8_i32_xsfmm32a8i.c "xsfmm32a8i")
-add_skl_src(src/gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.c "xsfvqdotq")
+add_skl_src(src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.c "xsfvqdotq")
 
 add_skl_src(src/logistic/logistic_bf16_xsfvfbfa.c "xsfvfbfa")
 add_skl_src(src/logistic/logistic_bf16_xsfvfbfexp16e_xsfvfbfa.c "xsfvfbfexp16e;xsfvfbfa")

--- a/include/skl.h
+++ b/include/skl.h
@@ -52,7 +52,7 @@
 #endif
 
 #if defined(__riscv_xsfvqdotq)
-#include "gemm/xsfvqdotq/gemm_i8rcp_i8pc_i32_xsfvqdotq.h"
+#include "gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.h"
 #endif
 
 /*

--- a/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.c
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.c
@@ -25,10 +25,10 @@
 #define NTL_P1
 #endif
 
-// a_pack is 4-byte aligned and rsa1 and csa1 are multiples of 4
+// a is 4-byte aligned and rsa1 and csa1 are multiples of 4
 SKL_FUNC_PRIVATE void skl_gemm_6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
-    size_t n, size_t k1, int32_t alpha, const int8_t *a_pack, size_t rsa1,
-    size_t csa1, const int8_t *b_pack, size_t rsb1, int32_t beta, int32_t *c,
+    size_t n, size_t k1, int32_t alpha, const int8_t *a, size_t rsa1,
+    size_t csa1, const int8_t *b, size_t rsb1, int32_t beta, int32_t *c,
     size_t rsc) {
   if (n == 0) {
     return;
@@ -41,8 +41,8 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
   vint32m4_t vec4 = __riscv_vmv_v_x_i32m4(0, n);
   vint32m4_t vec5 = __riscv_vmv_v_x_i32m4(0, n);
 
-  const int8_t *a0 = a_pack + 0 * rsa1;
-  const int8_t *a1 = a_pack + 1 * rsa1;
+  const int8_t *a0 = a + 0 * rsa1;
+  const int8_t *a1 = a + 1 * rsa1;
 
   if (k1) {
     uint32_t a0_0;
@@ -88,13 +88,12 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
 
         // load first B tile (4xn)
         "vsetvli x0, %[n4], e8, m4, ta, ma\n"
-        "vle8.v %[bvec0], (%[b_pack])\n"
-        "add %[b_pack], %[b_pack], %[rsb1]\n"
+        "vle8.v %[bvec0], (%[b])\n"
+        "add %[b], %[b], %[rsb1]\n"
         // clang-format on
         : [bvec0] "=&vr"(bvec0), [a0_0] "=&r"(a0_0), [a0_1] "=&r"(a0_1),
           [a0_2] "=&r"(a0_2), [a0_3] "=&r"(a0_3), [a0_4] "=&r"(a0_4),
-          [a0_5] "=&r"(a0_5), [a0] "+&r"(a0), [a1] "+&r"(a1),
-          [b_pack] "+&r"(b_pack)
+          [a0_5] "=&r"(a0_5), [a0] "+&r"(a0), [a1] "+&r"(a1), [b] "+&r"(b)
         : [rsa1_0] "rI"(2 * rsa1 * sizeof(int8_t)),
           [rsa1_1] "rI"(csa1 - 4 * rsa1 * sizeof(int8_t)),
           [rsb1] "rI"(rsb1 * sizeof(int8_t)), [n4] "r"(4 * n)
@@ -129,8 +128,8 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
 
           // load second B tile (4xn)
           "vsetvli x0, %[n4], e8, m4, ta, ma\n"
-          "vle8.v %[bvec1], (%[b_pack])\n"
-          "add %[b_pack], %[b_pack], %[rsb1]\n"
+          "vle8.v %[bvec1], (%[b])\n"
+          "add %[b], %[b], %[rsb1]\n"
 
           // compute first tile
           "vsetvli x0, %[n], e32, m4, ta, ma\n"
@@ -167,8 +166,8 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
 
           // pre-load first B tile (4xn) of next iteration
           "vsetvli x0, %[n4], e8, m4, ta, ma\n"
-          "vle8.v %[bvec0], (%[b_pack])\n"
-          "add %[b_pack], %[b_pack], %[rsb1]\n"
+          "vle8.v %[bvec0], (%[b])\n"
+          "add %[b], %[b], %[rsb1]\n"
 
           // compute second tile
           "vsetvli x0, %[n], e32, m4, ta, ma\n"
@@ -186,7 +185,7 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
             [a0_4] "+&r"(a0_4), [a0_5] "+&r"(a0_5), [a1_0] "=&r"(a1_0),
             [a1_1] "=&r"(a1_1), [a1_2] "=&r"(a1_2), [a1_3] "=&r"(a1_3),
             [a1_4] "=&r"(a1_4), [a1_5] "=&r"(a1_5), [a0] "+&r"(a0),
-            [a1] "+&r"(a1), [b_pack] "+&r"(b_pack)
+            [a1] "+&r"(a1), [b] "+&r"(b)
           : [rsa1_0] "rI"(2 * rsa1 * sizeof(int8_t)),
             [rsa1_1] "rI"(csa1 - 4 * rsa1 * sizeof(int8_t)),
             [rsb1] "rI"(rsb1 * sizeof(int8_t)), [n] "r"(n), [n4] "r"(4 * n)
@@ -224,8 +223,8 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
 
           // load second B tile (4xn)
           "vsetvli x0, %[n4], e8, m4, ta, ma\n"
-          "vle8.v %[bvec1], (%[b_pack])\n"
-          "add %[b_pack], %[b_pack], %[rsb1]\n"
+          "vle8.v %[bvec1], (%[b])\n"
+          "add %[b], %[b], %[rsb1]\n"
 
           // compute first tile
           "vsetvli x0, %[n], e32, m4, ta, ma\n"
@@ -248,8 +247,7 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
             [vec3] "+&vr"(vec3), [vec4] "+&vr"(vec4), [vec5] "+&vr"(vec5),
             [bvec1] "=&vr"(bvec1), [a1_0] "=&r"(a1_0), [a1_1] "=&r"(a1_1),
             [a1_2] "=&r"(a1_2), [a1_3] "=&r"(a1_3), [a1_4] "=&r"(a1_4),
-            [a1_5] "=&r"(a1_5), [a0] "+&r"(a0), [a1] "+&r"(a1),
-            [b_pack] "+&r"(b_pack)
+            [a1_5] "=&r"(a1_5), [a0] "+&r"(a0), [a1] "+&r"(a1), [b] "+&r"(b)
           : [bvec0] "vr"(bvec0), [a0_0] "r"(a0_0), [a0_1] "r"(a0_1),
             [a0_2] "r"(a0_2), [a0_3] "r"(a0_3), [a0_4] "r"(a0_4),
             [a0_5] "r"(a0_5), [rsa1_0] "rI"(2 * rsa1 * sizeof(int8_t)),
@@ -332,11 +330,11 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
   __riscv_vse32_v_i32m4(c, vec5, n);
 }
 
-// a_pack is 4-byte aligned and rsa1 and csa1 are multiples of 4
+// a is 4-byte aligned and rsa1 and csa1 are multiples of 4
 SKL_FUNC_PRIVATE void skl_gemm_lt6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
-    size_t m, size_t n, size_t k1, int32_t alpha, const int8_t *a_pack,
-    size_t rsa1, size_t csa1, const int8_t *b_pack, size_t rsb1, int32_t beta,
-    int32_t *c, size_t rsc) {
+    size_t m, size_t n, size_t k1, int32_t alpha, const int8_t *a, size_t rsa1,
+    size_t csa1, const int8_t *b, size_t rsb1, int32_t beta, int32_t *c,
+    size_t rsc) {
   if (m == 0 || n == 0) {
     return;
   }
@@ -347,17 +345,17 @@ SKL_FUNC_PRIVATE void skl_gemm_lt6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
   vint32m4_t vec3 = __riscv_vmv_v_x_i32m4(0, n);
   vint32m4_t vec4 = __riscv_vmv_v_x_i32m4(0, n);
 
-  const int8_t *a0 = a_pack + 0 * rsa1;
-  const int8_t *a1 = a_pack + 1 * rsa1;
-  const int8_t *a2 = a_pack + 2 * rsa1;
-  const int8_t *a3 = a_pack + 3 * rsa1;
-  const int8_t *a4 = a_pack + 4 * rsa1;
+  const int8_t *a0 = a + 0 * rsa1;
+  const int8_t *a1 = a + 1 * rsa1;
+  const int8_t *a2 = a + 2 * rsa1;
+  const int8_t *a3 = a + 3 * rsa1;
+  const int8_t *a4 = a + 4 * rsa1;
 
   // compute 1 micro-tile at once
   while (k1) {
     // load one B tile (4xn)
-    vint8m4_t bvec = __riscv_vle8_v_i8m4(b_pack, 4 * n);
-    b_pack += rsb1;
+    vint8m4_t bvec = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
 
     // compute micro-tile
     switch (m) {
@@ -498,10 +496,10 @@ SKL_FUNC_PRIVATE void skl_gemm_lt6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
   }
 }
 
-// a_pack need not be 4-byte-aligned nor csa1 a multiple of 4
+// a need not be 4-byte-aligned nor csa1 a multiple of 4
 SKL_FUNC_PRIVATE void skl_gemm_1xm4_unaligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
-    size_t n, size_t k1, int32_t alpha, const int8_t *a_pack, size_t csa1,
-    const int8_t *b_pack, size_t rsb1, int32_t beta, int32_t *c) {
+    size_t n, size_t k1, int32_t alpha, const int8_t *a, size_t csa1,
+    const int8_t *b, size_t rsb1, int32_t beta, int32_t *c) {
   if (n == 0) {
     return;
   }
@@ -513,12 +511,12 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm4_unaligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
 
   while (k1) {
     // load 1 word from A
-    skl_memcpy(&a0, a_pack, 4);
-    a_pack += csa1;
+    skl_memcpy(&a0, a, 4);
+    a += csa1;
 
     // load 1 B tile (4xn)
-    vint8m4_t bvec0 = __riscv_vle8_v_i8m4(b_pack, 4 * n);
-    b_pack += rsb1;
+    vint8m4_t bvec0 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
 
     vec0 = __riscv_sf_vqdot_vx_i32m4(vec0, bvec0, a0, n);
 
@@ -541,10 +539,10 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm4_unaligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
   __riscv_vse32_v_i32m4(c, vec0, n);
 }
 
-// a_pack is 4-byte aligned and csa1 is a multiple of 4
+// a is 4-byte aligned and csa1 is a multiple of 4
 SKL_FUNC_PRIVATE void skl_gemm_1xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
-    size_t n, size_t k1, int32_t alpha, const int8_t *a_pack, size_t csa1,
-    const int8_t *b_pack, size_t rsb1, int32_t beta, int32_t *c) {
+    size_t n, size_t k1, int32_t alpha, const int8_t *a, size_t csa1,
+    const int8_t *b, size_t rsb1, int32_t beta, int32_t *c) {
   if (n == 0) {
     return;
   }
@@ -555,24 +553,24 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
 
   while (k1 >= 4) {
     // load 4 words from A
-    uint32_t a0 = *(uint32_t *)a_pack;
-    a_pack += csa1;
-    uint32_t a1 = *(uint32_t *)a_pack;
-    a_pack += csa1;
-    uint32_t a2 = *(uint32_t *)a_pack;
-    a_pack += csa1;
-    uint32_t a3 = *(uint32_t *)a_pack;
-    a_pack += csa1;
+    uint32_t a0 = *(uint32_t *)a;
+    a += csa1;
+    uint32_t a1 = *(uint32_t *)a;
+    a += csa1;
+    uint32_t a2 = *(uint32_t *)a;
+    a += csa1;
+    uint32_t a3 = *(uint32_t *)a;
+    a += csa1;
 
     // load 4 B tiles (4xn)
-    vint8m4_t bvec0 = __riscv_vle8_v_i8m4(b_pack, 4 * n);
-    b_pack += rsb1;
-    vint8m4_t bvec1 = __riscv_vle8_v_i8m4(b_pack, 4 * n);
-    b_pack += rsb1;
-    vint8m4_t bvec2 = __riscv_vle8_v_i8m4(b_pack, 4 * n);
-    b_pack += rsb1;
-    vint8m4_t bvec3 = __riscv_vle8_v_i8m4(b_pack, 4 * n);
-    b_pack += rsb1;
+    vint8m4_t bvec0 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
+    vint8m4_t bvec1 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
+    vint8m4_t bvec2 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
+    vint8m4_t bvec3 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
 
     vec0 = __riscv_sf_vqdot_vx_i32m4(vec0, bvec0, a0, n);
     vec1 = __riscv_sf_vqdot_vx_i32m4(vec1, bvec1, a1, n);
@@ -584,16 +582,16 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
 
   while (k1 >= 2) {
     // load 2 words from A
-    uint32_t a0 = *(uint32_t *)a_pack;
-    a_pack += csa1;
-    uint32_t a1 = *(uint32_t *)a_pack;
-    a_pack += csa1;
+    uint32_t a0 = *(uint32_t *)a;
+    a += csa1;
+    uint32_t a1 = *(uint32_t *)a;
+    a += csa1;
 
     // load 2 B tiles (4xn)
-    vint8m4_t bvec0 = __riscv_vle8_v_i8m4(b_pack, 4 * n);
-    b_pack += rsb1;
-    vint8m4_t bvec1 = __riscv_vle8_v_i8m4(b_pack, 4 * n);
-    b_pack += rsb1;
+    vint8m4_t bvec0 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
+    vint8m4_t bvec1 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
 
     vec0 = __riscv_sf_vqdot_vx_i32m4(vec0, bvec0, a0, n);
     vec1 = __riscv_sf_vqdot_vx_i32m4(vec1, bvec1, a1, n);
@@ -603,12 +601,12 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
 
   while (k1) {
     // load 1 word from A
-    uint32_t a0 = *(uint32_t *)a_pack;
-    a_pack += csa1;
+    uint32_t a0 = *(uint32_t *)a;
+    a += csa1;
 
     // load 1 B tile (4xn)
-    vint8m4_t bvec0 = __riscv_vle8_v_i8m4(b_pack, 4 * n);
-    b_pack += rsb1;
+    vint8m4_t bvec0 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
 
     vec0 = __riscv_sf_vqdot_vx_i32m4(vec0, bvec0, a0, n);
 
@@ -634,9 +632,9 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
 }
 
 SKL_FUNC_PRIVATE void skl_gemm_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
-    size_t m, size_t n, size_t k1, int32_t alpha, const int8_t *a_pack,
-    size_t rsa1, size_t csa1, const int8_t *b_pack, size_t rsb1, int32_t beta,
-    int32_t *c, size_t rsc) {
+    size_t m, size_t n, size_t k1, int32_t alpha, const int8_t *a, size_t rsa1,
+    size_t csa1, const int8_t *b, size_t rsb1, int32_t beta, int32_t *c,
+    size_t rsc) {
   if (m == 0 || n == 0) {
     return;
   }
@@ -647,8 +645,8 @@ SKL_FUNC_PRIVATE void skl_gemm_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
   if (m == 1) {
     // dispatch to GEMV kernel for better performance
     int32_t *c_write = c;
-    const int8_t *a_tile_ptr = a_pack;
-    const int8_t *b_tile_ptr = b_pack;
+    const int8_t *a_tile_ptr = a;
+    const int8_t *b_tile_ptr = b;
     size_t n_avl = n;
     while (n_avl) {
       size_t vl = __riscv_vsetvl_e32m4(n_avl);
@@ -662,8 +660,8 @@ SKL_FUNC_PRIVATE void skl_gemm_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
     size_t m_idx = 0;
     for (; m_idx + m0 - 1 < m; m_idx += m0) {
       int32_t *c_write = c + m_idx * rsc;
-      const int8_t *a_tile_ptr = a_pack + m_idx * rsa1;
-      const int8_t *b_tile_ptr = b_pack;
+      const int8_t *a_tile_ptr = a + m_idx * rsa1;
+      const int8_t *b_tile_ptr = b;
       size_t n_avl = n;
       while (n_avl) {
         size_t vl = __riscv_vsetvl_e32m4(n_avl);
@@ -679,8 +677,8 @@ SKL_FUNC_PRIVATE void skl_gemm_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
     size_t m_left = m - m_idx;
     if (m_left) {
       int32_t *c_write = c + m_idx * rsc;
-      const int8_t *a_tile_ptr = a_pack + m_idx * rsa1;
-      const int8_t *b_tile_ptr = b_pack;
+      const int8_t *a_tile_ptr = a + m_idx * rsa1;
+      const int8_t *b_tile_ptr = b;
       size_t n_avl = n;
       while (n_avl) {
         size_t vl = __riscv_vsetvl_e32m4(n_avl);
@@ -696,25 +694,25 @@ SKL_FUNC_PRIVATE void skl_gemm_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
 }
 
 SKL_FUNC void skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
-    size_t m, size_t n, size_t k1, int32_t alpha, const int8_t *a_pack,
-    size_t rsa1, size_t csa1, const int8_t *b_pack, size_t rsb1, int32_t beta,
-    int32_t *c, size_t rsc) {
+    size_t m, size_t n, size_t k1, int32_t alpha, const int8_t *a, size_t rsa1,
+    size_t csa1, const int8_t *b, size_t rsb1, int32_t beta, int32_t *c,
+    size_t rsc) {
   if (m == 0 || n == 0) {
     return;
   }
 
   const size_t k0 = 4;
 
-  if ((uintptr_t)a_pack % (k0 * sizeof(int8_t)) == 0 && rsa1 % k0 == 0 &&
+  if ((uintptr_t)a % (k0 * sizeof(int8_t)) == 0 && rsa1 % k0 == 0 &&
       csa1 % k0 == 0) {
     skl_gemm_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
-        m, n, k1, alpha, a_pack, rsa1, csa1, b_pack, rsb1, beta, c, rsc);
+        m, n, k1, alpha, a, rsa1, csa1, b, rsb1, beta, c, rsc);
   } else {
     size_t m_idx = 0;
     for (; m_idx < m; ++m_idx) {
       int32_t *c_write = c + m_idx * rsc;
-      const int8_t *a_tile_ptr = a_pack + m_idx * rsa1;
-      const int8_t *b_tile_ptr = b_pack;
+      const int8_t *a_tile_ptr = a + m_idx * rsa1;
+      const int8_t *b_tile_ptr = b;
       size_t n_avl = n;
       while (n_avl) {
         size_t vl = __riscv_vsetvl_e32m4(n_avl);

--- a/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.c
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.c
@@ -26,7 +26,7 @@
 #endif
 
 // a_pack is 4-byte aligned and rsa1 and csa1 are multiples of 4
-SKL_FUNC_PRIVATE void skl_gemm_6xm4_aligned_i8rcp_i8pc_i32_xsfvqdotq(
+SKL_FUNC_PRIVATE void skl_gemm_6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
     size_t n, size_t k1, int32_t alpha, const int8_t *a_pack, size_t rsa1,
     size_t csa1, const int8_t *b_pack, size_t rsb1, int32_t beta, int32_t *c,
     size_t rsc) {
@@ -333,7 +333,7 @@ SKL_FUNC_PRIVATE void skl_gemm_6xm4_aligned_i8rcp_i8pc_i32_xsfvqdotq(
 }
 
 // a_pack is 4-byte aligned and rsa1 and csa1 are multiples of 4
-SKL_FUNC_PRIVATE void skl_gemm_lt6xm4_aligned_i8rcp_i8pc_i32_xsfvqdotq(
+SKL_FUNC_PRIVATE void skl_gemm_lt6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
     size_t m, size_t n, size_t k1, int32_t alpha, const int8_t *a_pack,
     size_t rsa1, size_t csa1, const int8_t *b_pack, size_t rsb1, int32_t beta,
     int32_t *c, size_t rsc) {
@@ -499,7 +499,7 @@ SKL_FUNC_PRIVATE void skl_gemm_lt6xm4_aligned_i8rcp_i8pc_i32_xsfvqdotq(
 }
 
 // a_pack need not be 4-byte-aligned nor csa1 a multiple of 4
-SKL_FUNC_PRIVATE void skl_gemm_1xm4_unaligned_i8rcp_i8pc_i32_xsfvqdotq(
+SKL_FUNC_PRIVATE void skl_gemm_1xm4_unaligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
     size_t n, size_t k1, int32_t alpha, const int8_t *a_pack, size_t csa1,
     const int8_t *b_pack, size_t rsb1, int32_t beta, int32_t *c) {
   if (n == 0) {
@@ -542,7 +542,7 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm4_unaligned_i8rcp_i8pc_i32_xsfvqdotq(
 }
 
 // a_pack is 4-byte aligned and csa1 is a multiple of 4
-SKL_FUNC_PRIVATE void skl_gemm_1xm4_aligned_i8rcp_i8pc_i32_xsfvqdotq(
+SKL_FUNC_PRIVATE void skl_gemm_1xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
     size_t n, size_t k1, int32_t alpha, const int8_t *a_pack, size_t csa1,
     const int8_t *b_pack, size_t rsb1, int32_t beta, int32_t *c) {
   if (n == 0) {
@@ -633,7 +633,7 @@ SKL_FUNC_PRIVATE void skl_gemm_1xm4_aligned_i8rcp_i8pc_i32_xsfvqdotq(
   __riscv_vse32_v_i32m4(c, vec0, n);
 }
 
-SKL_FUNC_PRIVATE void skl_gemm_aligned_i8rcp_i8pc_i32_xsfvqdotq(
+SKL_FUNC_PRIVATE void skl_gemm_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
     size_t m, size_t n, size_t k1, int32_t alpha, const int8_t *a_pack,
     size_t rsa1, size_t csa1, const int8_t *b_pack, size_t rsb1, int32_t beta,
     int32_t *c, size_t rsc) {
@@ -652,7 +652,7 @@ SKL_FUNC_PRIVATE void skl_gemm_aligned_i8rcp_i8pc_i32_xsfvqdotq(
     size_t n_avl = n;
     while (n_avl) {
       size_t vl = __riscv_vsetvl_e32m4(n_avl);
-      skl_gemm_1xm4_aligned_i8rcp_i8pc_i32_xsfvqdotq(
+      skl_gemm_1xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
           vl, k1, alpha, a_tile_ptr, csa1, b_tile_ptr, rsb1, beta, c_write);
       b_tile_ptr += k0 * vl;
       c_write += vl;
@@ -667,7 +667,7 @@ SKL_FUNC_PRIVATE void skl_gemm_aligned_i8rcp_i8pc_i32_xsfvqdotq(
       size_t n_avl = n;
       while (n_avl) {
         size_t vl = __riscv_vsetvl_e32m4(n_avl);
-        skl_gemm_6xm4_aligned_i8rcp_i8pc_i32_xsfvqdotq(
+        skl_gemm_6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
             vl, k1, alpha, a_tile_ptr, rsa1, csa1, b_tile_ptr, rsb1, beta,
             c_write, rsc);
         b_tile_ptr += k0 * vl;
@@ -684,7 +684,7 @@ SKL_FUNC_PRIVATE void skl_gemm_aligned_i8rcp_i8pc_i32_xsfvqdotq(
       size_t n_avl = n;
       while (n_avl) {
         size_t vl = __riscv_vsetvl_e32m4(n_avl);
-        skl_gemm_lt6xm4_aligned_i8rcp_i8pc_i32_xsfvqdotq(
+        skl_gemm_lt6xm4_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
             m_left, vl, k1, alpha, a_tile_ptr, rsa1, csa1, b_tile_ptr, rsb1,
             beta, c_write, rsc);
         b_tile_ptr += k0 * vl;
@@ -695,7 +695,7 @@ SKL_FUNC_PRIVATE void skl_gemm_aligned_i8rcp_i8pc_i32_xsfvqdotq(
   }
 }
 
-SKL_FUNC void skl_gemm_i8rcp_i8pc_i32_xsfvqdotq(
+SKL_FUNC void skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
     size_t m, size_t n, size_t k1, int32_t alpha, const int8_t *a_pack,
     size_t rsa1, size_t csa1, const int8_t *b_pack, size_t rsb1, int32_t beta,
     int32_t *c, size_t rsc) {
@@ -707,8 +707,8 @@ SKL_FUNC void skl_gemm_i8rcp_i8pc_i32_xsfvqdotq(
 
   if ((uintptr_t)a_pack % (k0 * sizeof(int8_t)) == 0 && rsa1 % k0 == 0 &&
       csa1 % k0 == 0) {
-    skl_gemm_aligned_i8rcp_i8pc_i32_xsfvqdotq(m, n, k1, alpha, a_pack, rsa1,
-                                              csa1, b_pack, rsb1, beta, c, rsc);
+    skl_gemm_aligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
+        m, n, k1, alpha, a_pack, rsa1, csa1, b_pack, rsb1, beta, c, rsc);
   } else {
     size_t m_idx = 0;
     for (; m_idx < m; ++m_idx) {
@@ -718,7 +718,7 @@ SKL_FUNC void skl_gemm_i8rcp_i8pc_i32_xsfvqdotq(
       size_t n_avl = n;
       while (n_avl) {
         size_t vl = __riscv_vsetvl_e32m4(n_avl);
-        skl_gemm_1xm4_unaligned_i8rcp_i8pc_i32_xsfvqdotq(
+        skl_gemm_1xm4_unaligned_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
             vl, k1, alpha, a_tile_ptr, csa1, b_tile_ptr, rsb1, beta, c_write);
         b_tile_ptr += k0 * vl;
         c_write += vl;

--- a/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.h
@@ -54,17 +54,12 @@ extern "C" {
  *
  * This kernel uses the SiFive Xsfvqdotq extension for vector quad widening 4D
  * dot product operations to achieve high performance on 8-bit integer data.
- * When A satisfies certain alignment requirements (it is 4-byte aligned
- * and rsa1 and csa1 are multiples of 4), the kernel automatically dispatches to
- * optimized internal implementations:
- * - For m=1: uses an internal GEMV kernel
- * - For m>1: uses tiled GEMM kernels
+ * Works best when A is 4-byte aligned and rsa1 and csa1 are multiples of 4.
  *
  * @note
  * If A does not meet the alignment requirements stated above, the kernel
- * falls back to an unaligned 1xm4 implementation. This implementation is
- * unlikely to get good performance since it must handle misaligned loads from
- * A.
+ * falls back to an unaligned implementation that is unlikely to get good
+ * performance since it must handle misaligned loads from A.
  *
  * @note
  * The simplest way to pack a row-major A matrix into an A that meets the

--- a/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.h
@@ -72,11 +72,12 @@ extern "C" {
  * padding between the rows so that the row stride is a multiple of 4. Then the
  * kernel can be called by setting rsa1 to the row stride and csa1 = 4.
  */
-void skl_gemm_i8rcp_i8pc_i32_xsfvqdotq(size_t m, size_t n, size_t k1,
-                                       int32_t alpha, const int8_t *a_pack,
-                                       size_t rsa1, size_t csa1,
-                                       const int8_t *b_pack, size_t rsb1,
-                                       int32_t beta, int32_t *c, size_t rsc);
+void skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(size_t m, size_t n, size_t k1,
+                                             int32_t alpha,
+                                             const int8_t *a_pack, size_t rsa1,
+                                             size_t csa1, const int8_t *b_pack,
+                                             size_t rsb1, int32_t beta,
+                                             int32_t *c, size_t rsc);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.h
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.h
@@ -23,61 +23,61 @@ extern "C" {
 /**
  * @brief Xsfvqdotq int8 GEMM with int32 accumulator.
  *
- * @param m - Number of rows in A_pack and C.
- * @param n - Number of columns in B_pack and C.
- * @param k1 - Number of block-columns in A_pack, block-rows in B_pack.
- * @param alpha - Scalar multiplier for A_pack * B_pack.
- * @param a_pack - Pointer to packed matrix A_pack (m0 = 1, k0 = 4, csa0 = 1).
- * @param rsa1 - Row stride between blocks of A_pack in elements.
- * @param csa1 - Column stride between blocks of A_pack in elements.
- * @param b_pack - Pointer to packed matrix B_pack (k0 = 4, n0 = 1, rsb0 = 1,
- *                 csb1 = 4).
- * @param rsb1 - Row stride between blocks of B_pack in elements.
+ * @param m - Number of rows in A and C.
+ * @param n - Number of columns in B and C.
+ * @param k1 - Number of block-columns in A, block-rows in B.
+ * @param alpha - Scalar multiplier for A * B.
+ * @param a - Pointer to packed matrix A (m0 = 1, k0 = 4, csa0 = 1).
+ * @param rsa1 - Row stride between blocks of A in elements.
+ * @param csa1 - Column stride between blocks of A in elements.
+ * @param b - Pointer to packed matrix B (k0 = 4, n0 = 1, rsb0 = 1,
+ *            csb1 = 4).
+ * @param rsb1 - Row stride between blocks of B in elements.
  * @param beta - Scalar multiplier for matrix C.
  * @param c - Pointer to matrix C in row-major format.
  * @param rsc - Stride between rows of matrix C in elements.
  *
- * Computes `C = alpha * A_pack * B_pack + beta * C` for packed int8 matrices
- * A_pack and B_pack and int32 output matrix C.
+ * Computes `C = alpha * A * B + beta * C` for packed int8 matrices
+ * A and B and int32 output matrix C.
  *
  * Equivalent to:
  * ```
  * skl_gemm_i8rcprc_i8rcprc_i32rcprc_ref(
- *     1, 1, 4, m, n, k1,        // m0, n0, k0, m1, n1, k1
- *     alpha,                    // alpha
- *     a_pack, 0, 1, rsa1, csa1, // a_pack, rsa0, csa0, rsa1, csa1
- *     b_pack, 1, 0, rsb1, 4,    // b_pack, rsb0, csb0, rsb1, csb1
- *     beta,                     // beta
- *     c, 0, 0, rsc, 1           // c_pack, rsc0, csc0, rsc1, csc1
+ *     1, 1, 4, m, n, k1,   // m0, n0, k0, m1, n1, k1
+ *     alpha,               // alpha
+ *     a, 0, 1, rsa1, csa1, // a, rsa0, csa0, rsa1, csa1
+ *     b, 1, 0, rsb1, 4,    // b, rsb0, csb0, rsb1, csb1
+ *     beta,                // beta
+ *     c, 0, 0, rsc, 1      // c, rsc0, csc0, rsc1, csc1
  * );
  * ```
  *
  * This kernel uses the SiFive Xsfvqdotq extension for vector quad widening 4D
  * dot product operations to achieve high performance on 8-bit integer data.
- * When A_pack satisfies certain alignment requirements (it is 4-byte aligned
+ * When A satisfies certain alignment requirements (it is 4-byte aligned
  * and rsa1 and csa1 are multiples of 4), the kernel automatically dispatches to
  * optimized internal implementations:
  * - For m=1: uses an internal GEMV kernel
  * - For m>1: uses tiled GEMM kernels
  *
  * @note
- * If A_pack does not meet the alignment requirements stated above, the kernel
+ * If A does not meet the alignment requirements stated above, the kernel
  * falls back to an unaligned 1xm4 implementation. This implementation is
  * unlikely to get good performance since it must handle misaligned loads from
- * A_pack.
+ * A.
  *
  * @note
- * The simplest way to pack a row-major A matrix into an A_pack that meets the
+ * The simplest way to pack a row-major A matrix into an A that meets the
  * alignment requirements is to copy it into a 4-byte-aligned buffer, but insert
  * padding between the rows so that the row stride is a multiple of 4. Then the
  * kernel can be called by setting rsa1 to the row stride and csa1 = 4.
  */
 void skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(size_t m, size_t n, size_t k1,
-                                             int32_t alpha,
-                                             const int8_t *a_pack, size_t rsa1,
-                                             size_t csa1, const int8_t *b_pack,
-                                             size_t rsb1, int32_t beta,
-                                             int32_t *c, size_t rsc);
+                                             int32_t alpha, const int8_t *a,
+                                             size_t rsa1, size_t csa1,
+                                             const int8_t *b, size_t rsb1,
+                                             int32_t beta, int32_t *c,
+                                             size_t rsc);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -193,9 +193,9 @@ skl_add_test(
   ""
 )
 skl_add_test(
-  skl_gemm_i8rcp_i8pc_i32_xsfvqdotq
+  skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq
   gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
-  gemm/xsfvqdotq/skl_gemm_i8rcp_i8pc_i32_xsfvqdotq.c
+  gemm/xsfvqdotq/skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.c
   "xsfvqdotq"
   ""
 )

--- a/test/gemm/xsfvqdotq/skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.c
+++ b/test/gemm/xsfvqdotq/skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.c
@@ -106,11 +106,11 @@ gemm_i8rcprc_i8rcprc_i32rcprc_t tests[] = {
 };
 // clang-format on
 
-static skl_test_suite_t suite = {.name = "skl_gemm_i8rcp_i8pc_i32_xsfvqdotq",
-                                 .num_tests = sizeof(tests) / sizeof(tests[0]),
-                                 .test_size =
-                                     sizeof(gemm_i8rcprc_i8rcprc_i32rcprc_t),
-                                 .tests = tests};
+static skl_test_suite_t suite = {
+    .name = "skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq",
+    .num_tests = sizeof(tests) / sizeof(tests[0]),
+    .test_size = sizeof(gemm_i8rcprc_i8rcprc_i32rcprc_t),
+    .tests = tests};
 
 static void init(skl_test_t *t) {
   const gemm_i8rcprc_i8rcprc_i32rcprc_t *h =
@@ -131,7 +131,7 @@ static void execute(skl_test_t *t) {
   const gemm_i8rcprc_i8rcprc_i32rcprc_t *h =
       (gemm_i8rcprc_i8rcprc_i32rcprc_t *)t->harness;
 
-  skl_gemm_i8rcp_i8pc_i32_xsfvqdotq(
+  skl_gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq(
       h->m1, h->n1, h->k1, h->alpha, h->a_pack.data, h->rsa1, h->csa1,
       h->b_pack.data, h->rsb1, h->beta, h->c_pack.data, h->rsc1);
 }


### PR DESCRIPTION
This PR renames the Xsfvqdotq GEMM kernels to include the tile shape in accordance with [packed-gemm.md](https://github.com/sifive/skl/blob/main/src/gemm/packed-gemm.md).