### PR TITLE
[Test] Fix clang-tidy error about assertion

### DIFF
--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -497,7 +497,7 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
 #define SKL_TEST_INIT_FUNC(TYPE, SUFFIX, IMPL_TYPE, FRAC_TYPE)                 \
   static inline void skl_test_init_##SUFFIX(TYPE *buf, size_t len, TYPE min,   \
                                             TYPE max) {                        \
-    assert(TEST_INIT_MODE == RANDOM || TEST_INIT_MODE == SEQ);                 \
+    static_assert(TEST_INIT_MODE == RANDOM || TEST_INIT_MODE == SEQ, "TEST_INIT_MODE can only be RANDOM or SEQ");          \
     const TYPE step = (max - min) / len;                                       \
     for (size_t i = 0; i < len; i++) {                                         \
       if (TEST_INIT_MODE == RANDOM) {                                          \

--- a/test/skl-test.h
+++ b/test/skl-test.h
@@ -497,7 +497,8 @@ static inline int skl_check_error_ulp_bf16(const char *name, const __bf16 *res,
 #define SKL_TEST_INIT_FUNC(TYPE, SUFFIX, IMPL_TYPE, FRAC_TYPE)                 \
   static inline void skl_test_init_##SUFFIX(TYPE *buf, size_t len, TYPE min,   \
                                             TYPE max) {                        \
-    static_assert(TEST_INIT_MODE == RANDOM || TEST_INIT_MODE == SEQ, "TEST_INIT_MODE can only be RANDOM or SEQ");          \
+    static_assert(TEST_INIT_MODE == RANDOM || TEST_INIT_MODE == SEQ,           \
+                  "TEST_INIT_MODE can only be RANDOM or SEQ");                 \
     const TYPE step = (max - min) / len;                                       \
     for (size_t i = 0; i < len; i++) {                                         \
       if (TEST_INIT_MODE == RANDOM) {                                          \


### PR DESCRIPTION
The error will be reported by newer toolchain. Here is the error message.
```
test/skl-test.h:626:1: error: found assert() that could be replaced by static_assert() [misc-static-assert,-warnings-as-errors]
```