### PR TITLE
Fix builds for Xsfmmbase

### DIFF
--- a/src/transpose/xsfmm/transpose_e16_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e16_xsfmmbase.h
@@ -12,6 +12,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "skl-common.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif

--- a/src/transpose/xsfmm/transpose_e32_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e32_xsfmmbase.h
@@ -12,6 +12,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "skl-common.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif

--- a/src/transpose/xsfmm/transpose_e8_xsfmmbase.h
+++ b/src/transpose/xsfmm/transpose_e8_xsfmmbase.h
@@ -12,6 +12,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "skl-common.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif


### PR DESCRIPTION
bafc8c1 used SKL_RESTRICT in headers that didn't include skl-common.h, leading to build failures when Xsfmm extensions were enabled.

EDIT: I think bafc8c1 actually exposed the fact that some headers didn't include skl-common.h by removing includes from skl.h.

This commit adds #include's where it was found they were necessary.