### PR TITLE
[Test] Refactor `SKL_TEST_BUF_CREATE`

### DIFF
--- a/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f16_f16_f16.c
@@ -24,7 +24,6 @@
 #error This file requires the Zvfh extension
 #endif
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 void depthwise_conv2d_f16_f16_f16_init(skl_test_t *t) {
   depthwise_conv2d_f16_f16_f16_t *h =
       (depthwise_conv2d_f16_f16_f16_t *)t->harness;
@@ -49,7 +48,6 @@ void depthwise_conv2d_f16_f16_f16_init(skl_test_t *t) {
         h->output.len > 0 ? malloc(h->output.len * sizeof(double)) : NULL;
   }
 }
-// NOLINTEND(readability-function-cognitive-complexity)
 
 void depthwise_conv2d_f16_f16_f16_verify(skl_test_t *t) {
   /* Compute the reference output and error bounds. */

--- a/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_f32_f32_f32.c
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 void depthwise_conv2d_f32_f32_f32_init(skl_test_t *t) {
   depthwise_conv2d_f32_f32_f32_t *h =
       (depthwise_conv2d_f32_f32_f32_t *)t->harness;
@@ -45,7 +44,6 @@ void depthwise_conv2d_f32_f32_f32_init(skl_test_t *t) {
         h->output.len > 0 ? malloc(h->output.len * sizeof(double)) : NULL;
   }
 }
-// NOLINTEND(readability-function-cognitive-complexity)
 
 void depthwise_conv2d_f32_f32_f32_verify(skl_test_t *t) {
   /* Compute the reference output and error bounds. */

--- a/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
+++ b/test/depthwise_conv2d/depthwise_conv2d_i8_i8_i32.c
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 void depthwise_conv2d_i8_i8_i32_init(skl_test_t *t) {
   depthwise_conv2d_i8_i8_i32_t *h = (depthwise_conv2d_i8_i8_i32_t *)t->harness;
 
@@ -41,7 +40,6 @@ void depthwise_conv2d_i8_i8_i32_init(skl_test_t *t) {
     memcpy(h->ctx.ref_output, h->output.data, h->output.len * sizeof(int32_t));
   }
 }
-// NOLINTEND(readability-function-cognitive-complexity)
 
 void depthwise_conv2d_i8_i8_i32_verify(skl_test_t *t) {
   depthwise_conv2d_i8_i8_i32_t *h = (depthwise_conv2d_i8_i8_i32_t *)t->harness;

--- a/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 void gemm_bf16rcprc_bf16rcprc_f32rcprc_init(skl_test_t *t) {
   gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =
       (gemm_bf16rcprc_bf16rcprc_f32rcprc_t *)t->harness;
@@ -92,7 +91,6 @@ void gemm_bf16rcprc_bf16rcprc_f32rcprc_init(skl_test_t *t) {
     }
   }
 }
-// NOLINTEND(readability-function-cognitive-complexity)
 
 void gemm_bf16rcprc_bf16rcprc_f32rcprc_verify(skl_test_t *t) {
   gemm_bf16rcprc_bf16rcprc_f32rcprc_t *h =

--- a/test/gemm/gemm_f16rcprc_f16rcprc_f16rcprc.c
+++ b/test/gemm/gemm_f16rcprc_f16rcprc_f16rcprc.c
@@ -19,7 +19,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 void gemm_f16rcprc_f16rcprc_f16rcprc_init(skl_test_t *t) {
   gemm_f16rcprc_f16rcprc_f16rcprc_t *h =
       (gemm_f16rcprc_f16rcprc_f16rcprc_t *)t->harness;
@@ -91,7 +90,6 @@ void gemm_f16rcprc_f16rcprc_f16rcprc_init(skl_test_t *t) {
     }
   }
 }
-// NOLINTEND(readability-function-cognitive-complexity)
 
 void gemm_f16rcprc_f16rcprc_f16rcprc_verify(skl_test_t *t) {
   gemm_f16rcprc_f16rcprc_f16rcprc_t *h =

--- a/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 void gemm_f16rcprc_f16rcprc_f32rcprc_init(skl_test_t *t) {
   gemm_f16rcprc_f16rcprc_f32rcprc_t *h =
       (gemm_f16rcprc_f16rcprc_f32rcprc_t *)t->harness;
@@ -94,7 +93,6 @@ void gemm_f16rcprc_f16rcprc_f32rcprc_init(skl_test_t *t) {
     }
   }
 }
-// NOLINTEND(readability-function-cognitive-complexity)
 
 void gemm_f16rcprc_f16rcprc_f32rcprc_verify(skl_test_t *t) {
   gemm_f16rcprc_f16rcprc_f32rcprc_t *h =

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 void gemm_f32rcprc_f32rcprc_f32rcprc_init(skl_test_t *t) {
   gemm_f32rcprc_f32rcprc_f32rcprc_t *h =
       (gemm_f32rcprc_f32rcprc_f32rcprc_t *)t->harness;
@@ -94,7 +93,6 @@ void gemm_f32rcprc_f32rcprc_f32rcprc_init(skl_test_t *t) {
     }
   }
 }
-// NOLINTEND(readability-function-cognitive-complexity)
 
 void gemm_f32rcprc_f32rcprc_f32rcprc_verify(skl_test_t *t) {
   /* Compute the reference matrix output. */

--- a/test/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.c
+++ b/test/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.c
@@ -19,7 +19,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 void gemm_f64rcprc_f64rcprc_f64rcprc_init(skl_test_t *t) {
   gemm_f64rcprc_f64rcprc_f64rcprc_t *h =
       (gemm_f64rcprc_f64rcprc_f64rcprc_t *)t->harness;
@@ -91,7 +90,6 @@ void gemm_f64rcprc_f64rcprc_f64rcprc_init(skl_test_t *t) {
     }
   }
 }
-// NOLINTEND(readability-function-cognitive-complexity)
 
 // Higher precision reference GEMM for computing error bounds for GEMMs with
 // float64 accumulators. This function is placed here instead of skl-ref because

--- a/test/gemm/gemm_f8rcprc_f8rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f8rcprc_f8rcprc_f32rcprc.c
@@ -21,7 +21,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 void gemm_f8rcprc_f8rcprc_f32rcprc_init(skl_test_t *t) {
   gemm_f8rcprc_f8rcprc_f32rcprc_t *h =
       (gemm_f8rcprc_f8rcprc_f32rcprc_t *)t->harness;
@@ -93,7 +92,6 @@ void gemm_f8rcprc_f8rcprc_f32rcprc_init(skl_test_t *t) {
     }
   }
 }
-// NOLINTEND(readability-function-cognitive-complexity)
 
 void gemm_f8rcprc_f8rcprc_f32rcprc_verify(skl_test_t *t) {
   gemm_f8rcprc_f8rcprc_f32rcprc_t *h =

--- a/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/test/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 void gemm_i8rcprc_i8rcprc_i32rcprc_init(skl_test_t *t) {
   gemm_i8rcprc_i8rcprc_i32rcprc_t *h =
       (gemm_i8rcprc_i8rcprc_i32rcprc_t *)t->harness;
@@ -86,7 +85,6 @@ void gemm_i8rcprc_i8rcprc_i32rcprc_init(skl_test_t *t) {
     }
   }
 }
-// NOLINTEND(readability-function-cognitive-complexity)
 
 void gemm_i8rcprc_i8rcprc_i32rcprc_verify(skl_test_t *t) {
   gemm_i8rcprc_i8rcprc_i32rcprc_t *h =

--- a/test/skl-test-driver.h
+++ b/test/skl-test-driver.h
@@ -367,10 +367,10 @@ enum {
 // Helper macros for generating random values (used internally by
 // SKL_TEST_BUF_CREATE)
 
-#define SKL_TEST_RANDOM_FLOAT_(TYPE, MIN, MAX, LEN)                            \
+#define SKL_TEST_RANDOM_FLOAT_(TYPE, MIN, MAX)                                 \
   ((TYPE)(TYPE)((MIN) + ((float)rand() / (float)RAND_MAX) * ((MAX) - (MIN))))
 
-#define SKL_TEST_RANDOM_INT_(TYPE, MIN, MAX, LEN)                              \
+#define SKL_TEST_RANDOM_INT_(TYPE, MIN, MAX)                                   \
   ((TYPE)(rand() % ((MAX) - (MIN) + 1) + (MIN)))
 
 /**
@@ -389,7 +389,7 @@ enum {
                  "  populating with random values in [%" FMT ", %" FMT "]\n",  \
                  (PRINT_TYPE)min, (PRINT_TYPE)max);                            \
     for (size_t i = 0; i < len; ++i) {                                         \
-      buf[i] = SKL_TEST_RANDOM_##RAND_TYPE##_(BUF_TYPE, min, max, len);        \
+      buf[i] = SKL_TEST_RANDOM_##RAND_TYPE##_(BUF_TYPE, min, max);             \
     }                                                                          \
   }
 

--- a/test/skl-test-driver.h
+++ b/test/skl-test-driver.h
@@ -33,6 +33,7 @@
 #pragma once
 
 #include <float.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -366,38 +367,119 @@ enum {
 // Helper macros for generating random values (used internally by
 // SKL_TEST_BUF_CREATE)
 
-#define SKL_TEST_BUF_RANDOM_FLOAT_(TYPE, MIN, MAX, LEN)                        \
+#define SKL_TEST_RANDOM_FLOAT_(TYPE, MIN, MAX, LEN)                            \
   ((TYPE)(TYPE)((MIN) + ((float)rand() / (float)RAND_MAX) * ((MAX) - (MIN))))
 
-#define SKL_TEST_BUF_RANDOM___bf16(TYPE, MIN, MAX, LEN)                        \
-  SKL_TEST_BUF_RANDOM_FLOAT_(TYPE, MIN, MAX, LEN)
-
-#define SKL_TEST_BUF_RANDOM__Float16(TYPE, MIN, MAX, LEN)                      \
-  SKL_TEST_BUF_RANDOM_FLOAT_(TYPE, MIN, MAX, LEN)
-#define SKL_TEST_BUF_RANDOM_float(TYPE, MIN, MAX, LEN)                         \
-  SKL_TEST_BUF_RANDOM_FLOAT_(TYPE, MIN, MAX, LEN)
-#define SKL_TEST_BUF_RANDOM_double(TYPE, MIN, MAX, LEN)                        \
-  SKL_TEST_BUF_RANDOM_FLOAT_(TYPE, MIN, MAX, LEN)
-
-#define SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)                          \
+#define SKL_TEST_RANDOM_INT_(TYPE, MIN, MAX, LEN)                              \
   ((TYPE)(rand() % ((MAX) - (MIN) + 1) + (MIN)))
 
-#define SKL_TEST_BUF_RANDOM_int8_t(TYPE, MIN, MAX, LEN)                        \
-  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
-#define SKL_TEST_BUF_RANDOM_uint8_t(TYPE, MIN, MAX, LEN)                       \
-  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
-#define SKL_TEST_BUF_RANDOM_int16_t(TYPE, MIN, MAX, LEN)                       \
-  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
-#define SKL_TEST_BUF_RANDOM_uint16_t(TYPE, MIN, MAX, LEN)                      \
-  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
-#define SKL_TEST_BUF_RANDOM_int32_t(TYPE, MIN, MAX, LEN)                       \
-  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
-#define SKL_TEST_BUF_RANDOM_uint32_t(TYPE, MIN, MAX, LEN)                      \
-  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
-#define SKL_TEST_BUF_RANDOM_int64_t(TYPE, MIN, MAX, LEN)                       \
-  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
-#define SKL_TEST_BUF_RANDOM_uint64_t(TYPE, MIN, MAX, LEN)                      \
-  SKL_TEST_BUF_RANDOM_INT_(TYPE, MIN, MAX, LEN)
+/**
+ * @brief Populate a buffer with random data.
+ *
+ * @param t Test context pointer.
+ * @param buf The buffer to populate.
+ * @param len Length of the buffer buf.
+ * @param min Minimum value of interval from which to sample values.
+ * @param max Maximum value of interval from which to sample values.
+ */
+#define SKL_TEST_BUF_RANDOM_IMPL(BUF_TYPE, PRINT_TYPE, RAND_TYPE, FMT)         \
+  static inline void skl_test_buf_random_##BUF_TYPE(                           \
+      skl_test_t *t, BUF_TYPE *buf, size_t len, BUF_TYPE min, BUF_TYPE max) {  \
+    SKL_TEST_LOG(t, SKL_TEST_LOG_DEBUG,                                        \
+                 "  populating with random values in [%" FMT ", %" FMT "]\n",  \
+                 (PRINT_TYPE)min, (PRINT_TYPE)max);                            \
+    for (size_t i = 0; i < len; ++i) {                                         \
+      buf[i] = SKL_TEST_RANDOM_##RAND_TYPE##_(BUF_TYPE, min, max, len);        \
+    }                                                                          \
+  }
+
+// clang-format off
+SKL_TEST_BUF_RANDOM_IMPL(int8_t,   int8_t,   INT,   PRId8)
+SKL_TEST_BUF_RANDOM_IMPL(int16_t,  int16_t,  INT,   PRId16)
+SKL_TEST_BUF_RANDOM_IMPL(int32_t,  int32_t,  INT,   PRId32)
+SKL_TEST_BUF_RANDOM_IMPL(int64_t,  int64_t,  INT,   PRId64)
+SKL_TEST_BUF_RANDOM_IMPL(uint8_t,  uint8_t,  INT,   PRIu8)
+SKL_TEST_BUF_RANDOM_IMPL(uint16_t, uint16_t, INT,   PRIu16)
+SKL_TEST_BUF_RANDOM_IMPL(uint32_t, uint32_t, INT,   PRIu32)
+SKL_TEST_BUF_RANDOM_IMPL(uint64_t, uint64_t, INT,   PRIu64)
+SKL_TEST_BUF_RANDOM_IMPL(_Float16, double,   FLOAT, "f")
+SKL_TEST_BUF_RANDOM_IMPL(__bf16,   double,   FLOAT, "f")
+SKL_TEST_BUF_RANDOM_IMPL(float,    double,   FLOAT, "f")
+SKL_TEST_BUF_RANDOM_IMPL(double,   double,   FLOAT, "f")
+// clang-format on
+
+/**
+ * @brief Populate a buffer with sequential data.
+ *
+ * @param t Test context pointer.
+ * @param buf The buffer to populate.
+ * @param len Length of the buffer buf.
+ * @param min Starting value of generated data.
+ * @param max Ending value of generated data.
+ *
+ * The generated values will be spaced uniformly between min and max, in
+ * ascending order.
+ */
+#define SKL_TEST_BUF_SEQ_IMPL(BUF_TYPE, PRINT_TYPE, FMT)                       \
+  static inline void skl_test_buf_seq_##BUF_TYPE(                              \
+      skl_test_t *t, BUF_TYPE *buf, size_t len, BUF_TYPE min, BUF_TYPE max) {  \
+    BUF_TYPE step = len ? (max - min) / len : 0;                               \
+    SKL_TEST_LOG(t, SKL_TEST_LOG_DEBUG,                                        \
+                 "  populating with sequential values in [%" FMT ", %" FMT     \
+                 "] by %" FMT "\n",                                            \
+                 (PRINT_TYPE)min, (PRINT_TYPE)max, (PRINT_TYPE)step);          \
+    for (size_t i = 0; i < len; ++i) {                                         \
+      buf[i] = min + step * i;                                                 \
+    }                                                                          \
+  }
+
+// clang-format off
+SKL_TEST_BUF_SEQ_IMPL(int8_t,   int8_t,   PRId8)
+SKL_TEST_BUF_SEQ_IMPL(int16_t,  int16_t,  PRId16)
+SKL_TEST_BUF_SEQ_IMPL(int32_t,  int32_t,  PRId32)
+SKL_TEST_BUF_SEQ_IMPL(int64_t,  int64_t,  PRId64)
+SKL_TEST_BUF_SEQ_IMPL(uint8_t,  uint8_t,  PRIu8)
+SKL_TEST_BUF_SEQ_IMPL(uint16_t, uint16_t, PRIu16)
+SKL_TEST_BUF_SEQ_IMPL(uint32_t, uint32_t, PRIu32)
+SKL_TEST_BUF_SEQ_IMPL(uint64_t, uint64_t, PRIu64)
+SKL_TEST_BUF_SEQ_IMPL(_Float16, double,   "f")
+SKL_TEST_BUF_SEQ_IMPL(__bf16,   double,   "f")
+SKL_TEST_BUF_SEQ_IMPL(float,    double,   "f")
+SKL_TEST_BUF_SEQ_IMPL(double,   double,   "f")
+// clang-format on
+
+/**
+ * @brief Populate a buffer by copying data from a circular buffer.
+ *
+ * @param t Test context pointer.
+ * @param dst The destination buffer to populate.
+ * @param dst_len The length of the destination buffer dst.
+ * @param src The source buffer to copy values from.
+ * @param src_len The length of the source buffer src.
+ * @param sizeof_data The size of each element of the buffers, in bytes.
+ *
+ * If src_len < dst_len, the source buffer src will be circularly copied.
+ */
+static inline void skl_test_buf_circular_copy(skl_test_t *t, void *dst,
+                                              size_t dst_len, const void *src,
+                                              size_t src_len,
+                                              size_t sizeof_data) {
+  if (!src || (src_len == 0)) {
+    SKL_TEST_LOG(t, SKL_TEST_LOG_DEBUG, "  no static data available!\n");
+    return;
+  }
+  SKL_TEST_LOG(t, SKL_TEST_LOG_DEBUG,
+               "  populating with static data from %p (len = %zd)\n", src,
+               src_len);
+  /* Copy static data in chunks for efficiency */
+  char *dst_offset = dst;
+  for (size_t remaining = dst_len; remaining > 0;) {
+    size_t n_copy = (remaining < src_len) ? remaining : src_len;
+    memcpy(dst_offset, src, n_copy * sizeof_data);
+    dst_offset += n_copy * sizeof_data;
+    remaining -= n_copy;
+  }
+}
 
 /**
  * @brief Test buffer descriptor.
@@ -452,41 +534,17 @@ typedef enum {
                  #BUF, (BUF)->len, (BUF)->data);                               \
     switch ((BUF)->mode) {                                                     \
     case SKL_TEST_RANDOM:                                                      \
-      SKL_TEST_LOG((T), SKL_TEST_LOG_DEBUG, "random values in [%f, %f]\n",     \
-                   (double)(BUF)->min, (double)(BUF)->max);                    \
-      for (size_t i = 0; i < (BUF)->len; ++i) {                                \
-        (BUF)->data[i] = SKL_TEST_BUF_RANDOM_##TYPE(TYPE, (BUF)->min,          \
-                                                    (BUF)->max, (BUF)->len);   \
-      }                                                                        \
+      skl_test_buf_random_##TYPE((T), (BUF)->data, (BUF)->len, (BUF)->min,     \
+                                 (BUF)->max);                                  \
       break;                                                                   \
     case SKL_TEST_STATIC:                                                      \
-      SKL_TEST_LOG((T), SKL_TEST_LOG_DEBUG,                                    \
-                   "static data from %p (len = %zd)\n", (BUF)->static_data,    \
-                   (BUF)->static_data_len);                                    \
-      if ((BUF)->static_data) {                                                \
-        /* Copy static data in chunks for efficiency */                        \
-        size_t offset = 0;                                                     \
-        for (size_t remaining = (BUF)->len; remaining > 0;) {                  \
-          size_t n_copy = (remaining < (BUF)->static_data_len)                 \
-                              ? remaining                                      \
-                              : (BUF)->static_data_len;                        \
-          memcpy((BUF)->data + offset, (BUF)->static_data,                     \
-                 n_copy * sizeof(TYPE));                                       \
-          offset += n_copy;                                                    \
-          remaining -= n_copy;                                                 \
-        }                                                                      \
-      } else {                                                                 \
-        SKL_TEST_LOG((T), SKL_TEST_LOG_DEBUG, "no static data\n");             \
-      }                                                                        \
+      skl_test_buf_circular_copy((T), (BUF)->data, (BUF)->len,                 \
+                                 (BUF)->static_data, (BUF)->static_data_len,   \
+                                 sizeof(TYPE));                                \
       break;                                                                   \
     case SKL_TEST_SEQ: {                                                       \
-      TYPE step = (BUF)->len ? ((BUF)->max - (BUF)->min) / (BUF)->len : 0;     \
-      SKL_TEST_LOG((T), SKL_TEST_LOG_DEBUG,                                    \
-                   "sequential values in [%f, %f] by %f\n",                    \
-                   (double)(BUF)->min, (double)(BUF)->max, (double)step);      \
-      for (size_t i = 0; i < (BUF)->len; ++i) {                                \
-        (BUF)->data[i] = (BUF)->min + step * i;                                \
-      }                                                                        \
+      skl_test_buf_seq_##TYPE((T), (BUF)->data, (BUF)->len, (BUF)->min,        \
+                              (BUF)->max);                                     \
       break;                                                                   \
     }                                                                          \
     }                                                                          \

--- a/test/skl-test-driver.h
+++ b/test/skl-test-driver.h
@@ -542,11 +542,13 @@ typedef enum {
                                  (BUF)->static_data, (BUF)->static_data_len,   \
                                  sizeof(TYPE));                                \
       break;                                                                   \
-    case SKL_TEST_SEQ: {                                                       \
+    case SKL_TEST_SEQ:                                                         \
       skl_test_buf_seq_##TYPE((T), (BUF)->data, (BUF)->len, (BUF)->min,        \
                               (BUF)->max);                                     \
       break;                                                                   \
-    }                                                                          \
+    default:                                                                   \
+      SKL_TEST_LOG((T), SKL_TEST_LOG_ERROR,                                    \
+                   "  unknown initialization mode for %s!\n", #BUF);           \
     }                                                                          \
   } while (0)
 


### PR DESCRIPTION
This refactors the `SKL_TEST_BUF_CREATE` macro to reduce cognitive complexity and resolve many suppressed clang-tidy errors that have come up recently originating from it.

The approach I've currently taken is to extract each initialization case into (families of) dedicated functions, parametrized by type. `SKL_TEST_BUF_CREATE` is now effectively just dispatch into these functions.

We could reduce clang-tidy's measurement of complexity further by similarly replacing the whole `SKL_TEST_BUF_CREATE` macro with a family of `skl_test_buf_create_{type}` functions, but I'm not sure this _actually_ reduces cognitive complexity and would additionally require updating all call sites.

The circular copy optimized in #135 was modified slightly due to the type erasure introduced in this PR.