### PR TITLE
[Pack] Add RVV-based e8 unpack kernel & test harness

### DIFF
--- a/include/skl-ref.h
+++ b/include/skl-ref.h
@@ -97,5 +97,6 @@
 #include "ref/pack/pack_e16rc_e16rcprc.h"
 #include "ref/pack/pack_e32rc_e32rcprc.h"
 #include "ref/pack/pack_e8rc_e8rcprc.h"
+#include "ref/pack/unpack_e8rcprc_e8rc.h"
 
 // IWYU pragma: end_exports

--- a/ref/CMakeLists.txt
+++ b/ref/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(skl-ref
     pack/pack_e16rc_e16rcprc.c
     pack/pack_e32rc_e32rcprc.c
     pack/pack_e8rc_e8rcprc.c
+    pack/unpack_e8rcprc_e8rc.c
     silu/silu_f16.c
     silu/silu_f32.c
     softmax/softmax_bf16.c

--- a/ref/pack/unpack_e8rcprc_e8rc.c
+++ b/ref/pack/unpack_e8rcprc_e8rc.c
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#include "skl-common.h"
+#include <stddef.h>
+#include <stdint.h>
+
+SKL_FUNC void skl_unpack_e8rcprc_e8rc_ref(size_t m0, size_t n0,
+                                          const uint8_t *SKL_RESTRICT src,
+                                          size_t rs0, size_t cs0, size_t rs1,
+                                          size_t cs1, size_t m, size_t n,
+                                          uint8_t *SKL_RESTRICT dst, size_t rs,
+                                          size_t cs) {
+  if (m0 == 0 || n0 == 0) {
+    return;
+  }
+
+  size_t m1 = (m + m0 - 1) / m0;
+  size_t n1 = (n + n0 - 1) / n0;
+
+  for (size_t ii1 = 0; ii1 < m1; ++ii1) {
+    for (size_t jj1 = 0; jj1 < n1; ++jj1) {
+      for (size_t ii0 = 0; ii0 < m0; ++ii0) {
+        for (size_t jj0 = 0; jj0 < n0; ++jj0) {
+          size_t i = ii1 * m0 + ii0;
+          size_t j = jj1 * n0 + jj0;
+          if (i < m && j < n) {
+            dst[i * rs + j * cs] =
+                src[ii1 * rs1 + jj1 * cs1 + ii0 * rs0 + jj0 * cs0];
+          }
+        }
+      }
+    }
+  }
+}

--- a/ref/pack/unpack_e8rcprc_e8rc.h
+++ b/ref/pack/unpack_e8rcprc_e8rc.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "skl-common.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * @brief Reference implementation for unpacking an 8-bit 4D blocked matrix into
+ * a 2D matrix.
+ *
+ * @param m0 - Num. rows in a block of input matrix
+ * @param n0 - Num. columns in a block of input matrix
+ * @param src - Packed input matrix [ceil(m/m0) x ceil(n/n0) x (m0 x n0)]
+ * @param rs0 - Row stride within a block of input matrix
+ * @param cs0 - Column stride within a block of input matrix
+ * @param rs1 - Row stride between blocks of input matrix
+ * @param cs1 - Column stride between blocks of input matrix
+ * @param m - Num. rows in output matrix
+ * @param n - Num. columns in output matrix
+ * @param dst - Output matrix
+ * @param rs - Stride between rows of output matrix
+ * @param cs - Stride between columns of output matrix
+ *
+ * Transforms a blocked 4D layout back into a 2D matrix.
+ *
+ * Input: Blocked layout with m1 × n1 blocks, where each block is m0 × n0
+ * elements
+ *   - m1 = ⌈m / m0⌉ = (m + m0 - 1) / m0  (number of block-rows)
+ *   - n1 = ⌈n / n0⌉ = (n + n0 - 1) / n0  (number of block-columns)
+ *
+ * Output: 2D matrix of dimensions m × n
+ *
+ * Extracts only the valid m × n elements from the blocked layout. When m or n
+ * is not a multiple of the block dimensions, elements beyond the valid range
+ * in incomplete blocks are ignored.
+ *
+ * @note Input and output matrices must not overlap.
+ */
+void skl_unpack_e8rcprc_e8rc_ref(size_t m0, size_t n0,
+                                 const uint8_t *SKL_RESTRICT src, size_t rs0,
+                                 size_t cs0, size_t rs1, size_t cs1, size_t m,
+                                 size_t n, uint8_t *SKL_RESTRICT dst, size_t rs,
+                                 size_t cs);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif

--- a/src/pack/rvv/skl_pack_e8_zve32x.c
+++ b/src/pack/rvv/skl_pack_e8_zve32x.c
@@ -1301,3 +1301,148 @@ SKL_FUNC void skl_pack_e8rc_e8rcprc_zve32x(size_t m, size_t n,
     }
   }
 }
+
+SKL_FUNC_PRIVATE void
+skl_unpack_e8rcprc_e8_zve32x(size_t m0, size_t n0,
+                             const uint8_t *SKL_RESTRICT src, size_t rs0,
+                             size_t cs0, size_t rs1, size_t cs1, size_t m,
+                             size_t n, uint8_t *SKL_RESTRICT dst, size_t rs) {
+
+  // Handle division by zero
+  if (m0 == 0 || n0 == 0) {
+    return;
+  }
+
+  size_t m1 = (m + m0 - 1) / m0; // Num. row blocks in the matrix
+  size_t n1 = (n + n0 - 1) / n0; // Num. column blocks in the matrix
+
+  /* Column panels */
+  if (rs0 == 1 && n0 == 1) {
+    if (m0 == rs1) {
+      /* column-major block ordering */
+      // Transpose from column-major to row-major
+      skl_transpose_e8_zve32x(n, m, src, cs1, dst, rs);
+    } else {
+      /* row-major block ordering */
+      const uint8_t *src_block = src;
+      uint8_t *dst_block = dst;
+      for (size_t ii1 = 0; ii1 < m1 - 1; ++ii1) {
+        // Transpose from column-major to row-major
+        skl_transpose_e8_zve32x(n, m0, src_block, cs1, dst_block, rs);
+        src_block += rs1;
+        dst_block += m0 * rs;
+      }
+      size_t m_tail = m - m0 * (m1 - 1);
+      skl_transpose_e8_zve32x(n, m_tail, src_block, cs1, dst_block, rs);
+    }
+    return;
+  }
+
+  /* intra-block: column-major, inter-block: row-major */
+  if ((cs0 * n0 == cs1) && rs0 == 1) {
+    const uint8_t *src_block = src;
+    uint8_t *dst_block = dst;
+    for (size_t ii1 = 0; ii1 < m1 - 1; ++ii1) {
+      // Transpose from column-major to row-major
+      skl_transpose_e8_zve32x(n, m0, src_block, cs0, dst_block, rs);
+      src_block += rs1;
+      dst_block += m0 * rs;
+    }
+    size_t m_tail = m - m0 * (m1 - 1);
+    skl_transpose_e8_zve32x(n, m_tail, src_block, cs0, dst_block, rs);
+    return;
+  }
+
+  /* Row panels */
+  if (cs0 == 1 && m0 == 1) {
+    if (n0 == cs1) {
+      /* row-major block ordering */
+      skl_copy_2d_e8_zve32x(m, n, src, rs1, dst, rs);
+    } else {
+      /* column-major block ordering */
+      const uint8_t *src_block = src;
+      uint8_t *dst_block = dst;
+      for (size_t jj1 = 0; jj1 < n1 - 1; ++jj1) {
+        skl_copy_2d_e8_zve32x(m, n0, src_block, rs1, dst_block, rs);
+        src_block += cs1;
+        dst_block += n0;
+      }
+      size_t n_tail = n - n0 * (n1 - 1);
+      skl_copy_2d_e8_zve32x(m, n_tail, src_block, rs1, dst_block, rs);
+    }
+    return;
+  }
+
+  /* intra-block: row-major, inter-block: column-major */
+  if ((rs0 * m0 == rs1) && cs0 == 1) {
+    const uint8_t *src_block = src;
+    uint8_t *dst_block = dst;
+    for (size_t jj1 = 0; jj1 < n1 - 1; ++jj1) {
+      skl_copy_2d_e8_zve32x(m, n0, src_block, rs0, dst_block, rs);
+      src_block += cs1;
+      dst_block += n0;
+    }
+    size_t n_tail = n - n0 * (n1 - 1);
+    skl_copy_2d_e8_zve32x(m, n_tail, src_block, rs0, dst_block, rs);
+    return;
+  }
+
+  for (size_t ii1 = 0; ii1 < m1; ++ii1) {
+    size_t m_length = m0 < m - ii1 * m0 ? m0 : m - ii1 * m0;
+    for (size_t jj1 = 0; jj1 < n1; ++jj1) {
+      const uint8_t *src_block = src + ii1 * rs1 + jj1 * cs1;
+      uint8_t *dst_block = dst + ii1 * m0 * rs + jj1 * n0;
+      size_t n_length = n0 < n - jj1 * n0 ? n0 : n - jj1 * n0;
+
+      if (rs0 == 1) {
+        // Transpose from column-major to row-major
+        skl_transpose_e8_zve32x(n_length, m_length, src_block, cs0, dst_block,
+                                rs);
+      } else if (cs0 == 1) {
+        skl_copy_2d_e8_zve32x(m_length, n_length, src_block, rs0, dst_block,
+                              rs);
+      } else {
+        for (size_t ii0 = 0; ii0 < m0; ++ii0) {
+          for (size_t jj0 = 0; jj0 < n0; ++jj0) {
+            if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
+              dst_block[ii0 * rs + jj0] = src_block[ii0 * rs0 + jj0 * cs0];
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+SKL_FUNC void skl_unpack_e8rcprc_e8rc_zve32x(size_t m0, size_t n0,
+                                             const uint8_t *SKL_RESTRICT src,
+                                             size_t rs0, size_t cs0, size_t rs1,
+                                             size_t cs1, size_t m, size_t n,
+                                             uint8_t *SKL_RESTRICT dst,
+                                             size_t rs, size_t cs) {
+  if (cs == 1) {
+    skl_unpack_e8rcprc_e8_zve32x(m0, n0, src, rs0, cs0, rs1, cs1, m, n, dst,
+                                 rs);
+  } else if (rs == 1) {
+    // When output is column-major (rs==1), transpose both dimensions and
+    // strides
+    skl_unpack_e8rcprc_e8_zve32x(n0, m0, src, cs0, rs0, cs1, rs1, n, m, dst,
+                                 cs);
+  } else {
+    size_t m1 = (m + m0 - 1) / m0;
+    size_t n1 = (n + n0 - 1) / n0;
+    for (size_t ii1 = 0; ii1 < m1; ++ii1) {
+      for (size_t jj1 = 0; jj1 < n1; ++jj1) {
+        const uint8_t *src_block = src + ii1 * rs1 + jj1 * cs1;
+        uint8_t *dst_block = dst + ii1 * m0 * rs + jj1 * n0 * cs;
+        for (size_t ii0 = 0; ii0 < m0; ++ii0) {
+          for (size_t jj0 = 0; jj0 < n0; ++jj0) {
+            if (ii1 * m0 + ii0 < m && jj1 * n0 + jj0 < n) {
+              dst_block[ii0 * rs + jj0 * cs] = src_block[ii0 * rs0 + jj0 * cs0];
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/pack/rvv/skl_pack_e8_zve32x.h
+++ b/src/pack/rvv/skl_pack_e8_zve32x.h
@@ -54,6 +54,45 @@ void skl_pack_e8rc_e8rcprc_zve32x(size_t m, size_t n,
                                   uint8_t pad);
 
 /**
+ * @brief RVV-based 8-bit general matrix unpack kernel (blocked 4D to 2D
+ * layout).
+ *
+ * @param m0 - Num. rows in a block of input matrix
+ * @param n0 - Num. columns in a block of input matrix
+ * @param src - Packed input matrix [ceil(m/m0) x ceil(n/n0) x (m0 x n0)]
+ * @param rs0 - Row stride within a block of input matrix
+ * @param cs0 - Column stride within a block of input matrix
+ * @param rs1 - Row stride between blocks of input matrix
+ * @param cs1 - Column stride between blocks of input matrix
+ * @param m - Num. rows in output matrix
+ * @param n - Num. columns in output matrix
+ * @param dst - Output matrix
+ * @param rs - Stride between rows of output matrix
+ * @param cs - Stride between columns of output matrix
+ *
+ * Transforms a blocked 4D layout back into a 2D matrix.
+ *
+ * Input: Blocked layout with m1 × n1 blocks, where each block is m0 × n0
+ * elements
+ *   - m1 = ⌈m / m0⌉ = (m + m0 - 1) / m0  (number of block-rows)
+ *   - n1 = ⌈n / n0⌉ = (n + n0 - 1) / n0  (number of block-columns)
+ *
+ * Output: 2D matrix of dimensions m × n
+ *
+ * Extracts only the valid m × n elements from the blocked layout. When m or n
+ * is not a multiple of the block dimensions, elements beyond the valid range
+ * in incomplete blocks are ignored.
+ *
+ * @note Input and output matrices must not overlap.
+ */
+void skl_unpack_e8rcprc_e8rc_zve32x(size_t m0, size_t n0,
+                                    const uint8_t *SKL_RESTRICT src, size_t rs0,
+                                    size_t cs0, size_t rs1, size_t cs1,
+                                    size_t m, size_t n,
+                                    uint8_t *SKL_RESTRICT dst, size_t rs,
+                                    size_t cs);
+
+/**
  * @brief RVV matrix transposition for 8-bit matrices.
  *
  * @param m - Number of rows in A and columns in A^T.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -647,3 +647,10 @@ skl_add_test(
   "zve32x"
   ""
 )
+skl_add_test(
+  skl_unpack_e8rcprc_e8rc_zve32x
+  pack/unpack_e8rcprc_e8rc.c
+  pack/rvv/skl_unpack_e8rcprc_e8rc_zve32x.c
+  "zve32x"
+  ""
+)

--- a/test/pack/pack_e8rc_e8rcprc.c
+++ b/test/pack/pack_e8rc_e8rcprc.c
@@ -7,7 +7,7 @@
  * @brief Implementation of the pack_e8rc_e8rcprc test harness.
  *
  * This file defines all harness functions _except_ `execute`, which is
- * defined in the test file (e.g. rvv/skl_pack_e8rc_e8rcprc_zve32x.c.c).
+ * defined in the test file (e.g. rvv/skl_pack_e8rc_e8rcprc_zve32x.c).
  */
 
 #include "pack_e8rc_e8rcprc.h"

--- a/test/pack/rvv/skl_unpack_e8rcprc_e8rc_zve32x.c
+++ b/test/pack/rvv/skl_unpack_e8rcprc_e8rc_zve32x.c
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#include "pack/unpack_e8rcprc_e8rc.h"
+#include "skl-test-driver.h"
+#include "skl.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef __riscv_zve32x
+#error "This file requires the Zve32x extension."
+#endif
+
+/**
+ * @brief Test cases for unpack with Zve32x extension.
+ *
+ * This test uses the unpack_e8rcprc_e8rc harness.
+ */
+
+#define TEST                                                                   \
+  UNPACK_E8RCPRC_E8RC_DEFAULTS, .steps = {                                     \
+                                    .init = unpack_e8rcprc_e8rc_init,          \
+                                    .warmup = NULL,                            \
+                                    .execute = execute,                        \
+                                    .verify = unpack_e8rcprc_e8rc_verify,      \
+                                    .report = unpack_e8rcprc_e8rc_test_report, \
+                                    .cleanup = unpack_e8rcprc_e8rc_cleanup,    \
+  }
+
+#define BENCH                                                                  \
+  UNPACK_E8RCPRC_E8RC_DEFAULTS,                                                \
+      .steps = {                                                               \
+          .init = unpack_e8rcprc_e8rc_init,                                    \
+          .warmup = execute,                                                   \
+          .execute = execute,                                                  \
+          .verify = NULL,                                                      \
+          .report = unpack_e8rcprc_e8rc_benchmark_report,                      \
+          .cleanup = unpack_e8rcprc_e8rc_cleanup,                              \
+  }
+
+static void execute(skl_test_t *t);
+
+// clang-format off
+unpack_e8rcprc_e8rc_t tests[] = {
+#ifdef SKL_ENABLE_BENCHMARKS
+    // Benchmark tests
+    {BENCH, .m0 = 8, .n0 = 8, .rs0 = 1, .cs0 = 8, .rs1 = 1024, .cs1 = 64,
+     .m = 128, .n = 128, .rs = 128, .cs = 1},
+#endif
+
+#ifdef SKL_ENABLE_TESTS
+    // Verification tests
+
+    /* Small matrices (one-block case)*/
+    {TEST, .m0 = 4, .n0 = 4, .rs0 = 1, .cs0 = 4, .rs1 = 16, .cs1 = 16,
+     .m = 2, .n = 3, .rs = 3, .cs = 1},
+    {TEST, .m0 = 4, .n0 = 4, .rs0 = 1, .cs0 = 4, .rs1 = 16, .cs1 = 16,
+     .m = 2, .n = 3, .rs = 1, .cs = 2},
+    {TEST, .m0 = 4, .n0 = 4, .rs0 = 4, .cs0 = 1, .rs1 = 16, .cs1 = 16,
+     .m = 2, .n = 3, .rs = 3, .cs = 1},
+    {TEST, .m0 = 4, .n0 = 4, .rs0 = 4, .cs0 = 1, .rs1 = 16, .cs1 = 16,
+     .m = 2, .n = 3, .rs = 1, .cs = 2},
+
+    /* Non-multiple of block size */
+    {TEST, .m0 = 4, .n0 = 8, .rs0 = 1, .cs0 = 4, .rs1 = 64, .cs1 = 32,
+     .m = 5, .n = 5, .rs = 5, .cs = 1},
+    {TEST, .m0 = 8, .n0 = 8, .rs0 = 1, .cs0 = 8, .rs1 = 128, .cs1 = 64,
+     .m = 10, .n = 10, .rs = 10, .cs = 1},
+    {TEST, .m0 = 4, .n0 = 4, .rs0 = 1, .cs0 = 4, .rs1 = 48, .cs1 = 16,
+     .m = 7, .n = 9, .rs = 9, .cs = 1},
+    {TEST, .m0 = 4, .n0 = 4, .rs0 = 1, .cs0 = 4, .rs1 = 32, .cs1 = 16,
+     .m = 9, .n = 8, .rs = 8, .cs = 1},
+    {TEST, .m0 = 8, .n0 = 8, .rs0 = 1, .cs0 = 8, .rs1 = 128, .cs1 = 64,
+     .m = 20, .n = 16, .rs = 16, .cs = 1},
+
+    {TEST, .m0 = 4, .n0 = 8, .rs0 = 1, .cs0 = 4, .rs1 = 64, .cs1 = 32,
+     .m = 5, .n = 5, .rs = 1, .cs = 5},
+    {TEST, .m0 = 8, .n0 = 8, .rs0 = 8, .cs0 = 1, .rs1 = 128, .cs1 = 64,
+     .m = 10, .n = 10, .rs = 1, .cs = 10},
+    {TEST, .m0 = 4, .n0 = 4, .rs0 = 4, .cs0 = 1, .rs1 = 48, .cs1 = 16,
+     .m = 7, .n = 9, .rs = 1, .cs = 7},
+    {TEST, .m0 = 4, .n0 = 4, .rs0 = 1, .cs0 = 4, .rs1 = 32, .cs1 = 16,
+     .m = 9, .n = 8, .rs = 1, .cs = 9},
+    {TEST, .m0 = 8, .n0 = 8, .rs0 = 1, .cs0 = 8, .rs1 = 128, .cs1 = 64,
+     .m = 20, .n = 16, .rs = 1, .cs = 20},
+
+    /* Multiple of block size  */
+    {TEST, .m0 = 4, .n0 = 4, .rs0 = 1, .cs0 = 8, .rs1 = 64, .cs1 = 32,
+     .m = 8, .n = 8, .rs = 16, .cs = 1},
+    {TEST, .m0 = 4, .n0 = 4, .rs0 = 1, .cs0 = 4, .rs1 = 48, .cs1 = 16,
+     .m = 12, .n = 12, .rs = 12, .cs = 1},
+    {TEST, .m0 = 4, .n0 = 4, .rs0 = 1, .cs0 = 4, .rs1 = 64, .cs1 = 16,
+     .m = 16, .n = 16, .rs = 16, .cs = 1},
+    {TEST, .m0 = 4, .n0 = 8, .rs0 = 1, .cs0 = 4, .rs1 = 64, .cs1 = 32,
+     .m = 16, .n = 16, .rs = 16, .cs = 1},
+    {TEST, .m0 = 8, .n0 = 8, .rs0 = 1, .cs0 = 8, .rs1 = 128, .cs1 = 64,
+     .m = 16, .n = 16, .rs = 16, .cs = 1},
+    {TEST, .m0 = 16, .n0 = 16, .rs0 = 1, .cs0 = 16, .rs1 = 256, .cs1 = 256,
+     .m = 16, .n = 16, .rs = 16, .cs = 1},
+    {TEST, .m0 = 8, .n0 = 8, .rs0 = 1, .cs0 = 8, .rs1 = 64, .cs1 = 64,
+     .m = 32, .n = 8, .rs = 8, .cs = 1},
+    {TEST, .m0 = 8, .n0 = 8, .rs0 = 1, .cs0 = 8, .rs1 = 256, .cs1 = 64,
+     .m = 8, .n = 32, .rs = 32, .cs = 1},
+
+    /* Specialization 1: (cs0 * n0 == cs1) && rs0 == 1 */
+    {TEST, .m0 = 4, .n0 = 3, .rs0 = 1, .cs0 = 4, .rs1 = 48, .cs1 = 12,
+     .m = 16, .n = 12, .rs = 12, .cs = 1},
+    {TEST, .m0 = 4, .n0 = 3, .rs0 = 1, .cs0 = 4, .rs1 = 36, .cs1 = 12,
+     .m = 10, .n = 8, .rs = 8, .cs = 1},
+    {TEST, .m0 = 4, .n0 = 1, .rs0 = 1, .cs0 = 4, .rs1 = 72, .cs1 = 4,
+     .m = 10, .n = 18, .rs = 18, .cs = 1},
+
+    /* Specialization 2: (rs0 * m0 == rs1) && cs0 == 1 */
+    {TEST, .m0 = 4, .n0 = 8, .rs0 = 8, .cs0 = 1, .rs1 = 32, .cs1 = 96,
+     .m = 12, .n = 16, .rs = 16, .cs = 1},
+    {TEST, .m0 = 2, .n0 = 5, .rs0 = 5, .cs0 = 1, .rs1 = 10, .cs1 = 80,
+     .m = 16, .n = 12, .rs = 12, .cs = 1},
+    {TEST, .m0 = 4, .n0 = 8, .rs0 = 8, .cs0 = 1, .rs1 = 32, .cs1 = 32,
+     .m = 10, .n = 8, .rs = 8, .cs = 1},
+
+    /* Specialization 3: rs0 == 1 && n0 == 1 && m0 == rs1 - Column panel
+       transpose */
+    {TEST, .m0 = 4, .n0 = 1, .rs0 = 1, .cs0 = 4, .rs1 = 4, .cs1 = 12,
+     .m = 12, .n = 8, .rs = 8, .cs = 1},
+    {TEST, .m0 = 8, .n0 = 1, .rs0 = 1, .cs0 = 8, .rs1 = 8, .cs1 = 24,
+     .m = 20, .n = 16, .rs = 16, .cs = 1},
+
+    /* Specialization 4: cs0 == 1 && m0 == 1 && n0 == cs1 - Row panel copy */
+    {TEST, .m0 = 1, .n0 = 4, .rs0 = 4, .cs0 = 1, .rs1 = 12, .cs1 = 4,
+     .m = 8, .n = 12, .rs = 12, .cs = 1},
+    {TEST, .m0 = 1, .n0 = 4, .rs0 = 4, .cs0 = 1, .rs1 = 12, .cs1 = 4,
+     .m = 12, .n = 10, .rs = 10, .cs = 1},
+
+    /* Larger matrices */
+    {TEST, .m0 = 8, .n0 = 8, .rs0 = 1, .cs0 = 8, .rs1 = 512, .cs1 = 64,
+     .m = 64, .n = 64, .rs = 64, .cs = 1},
+    {TEST, .m0 = 8, .n0 = 8, .rs0 = 1, .cs0 = 8, .rs1 = 1024, .cs1 = 64,
+     .m = 128, .n = 128, .rs = 128, .cs = 1},
+
+    {TEST, .m0 = 64, .n0 = 16, .rs0 = 16, .cs0 = 1, .rs1 = 13312, .cs1 = 1024,
+     .m = 300, .n = 200, .rs = 200, .cs = 1},
+    {TEST, .m0 = 64, .n0 = 16, .rs0 = 16, .cs0 = 1, .rs1 = 1024, .cs1 = 5120,
+     .m = 300, .n = 200, .rs = 200, .cs = 1},
+    {TEST, .m0 = 64, .n0 = 16, .rs0 = 1, .cs0 = 64, .rs1 = 13312, .cs1 = 1024,
+     .m = 300, .n = 200, .rs = 200, .cs = 1},
+    {TEST, .m0 = 64, .n0 = 16, .rs0 = 1, .cs0 = 64, .rs1 = 1024, .cs1 = 5120,
+     .m = 300, .n = 200, .rs = 200, .cs = 1},
+
+    {TEST, .m0 = 64, .n0 = 16, .rs0 = 16, .cs0 = 1, .rs1 = 13312, .cs1 = 1024,
+     .m = 300, .n = 200, .rs = 1, .cs = 300},
+    {TEST, .m0 = 64, .n0 = 16, .rs0 = 16, .cs0 = 1, .rs1 = 1024, .cs1 = 5120,
+     .m = 300, .n = 200, .rs = 1, .cs = 300},
+    {TEST, .m0 = 64, .n0 = 16, .rs0 = 1, .cs0 = 64, .rs1 = 13312, .cs1 = 1024,
+     .m = 300, .n = 200, .rs = 1, .cs = 300},
+    {TEST, .m0 = 64, .n0 = 16, .rs0 = 1, .cs0 = 64, .rs1 = 1024, .cs1 = 5120,
+     .m = 300, .n = 200, .rs = 1, .cs = 300},
+#endif
+};
+// clang-format on
+
+static skl_test_suite_t suite = {.name = "skl_unpack_e8rcprc_e8rc_zve32x",
+                                 .num_tests = sizeof(tests) / sizeof(tests[0]),
+                                 .test_size = sizeof(unpack_e8rcprc_e8rc_t),
+                                 .tests = tests};
+
+static void execute(skl_test_t *t) {
+  const unpack_e8rcprc_e8rc_t *h = (unpack_e8rcprc_e8rc_t *)t->harness;
+
+  skl_unpack_e8rcprc_e8rc_zve32x(h->m0, h->n0, h->src.data, h->rs0, h->cs0,
+                                 h->rs1, h->cs1, h->m, h->n, h->dst.data, h->rs,
+                                 h->cs);
+}
+
+int main(void) { return skl_test_driver_run_suite(&suite); }

--- a/test/pack/unpack_e8rcprc_e8rc.c
+++ b/test/pack/unpack_e8rcprc_e8rc.c
@@ -4,13 +4,13 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * @brief Implementation of the pack_e8rc_e8rcprc test harness.
+ * @brief Implementation of the unpack_e8rcprc_e8rc test harness.
  *
  * This file defines all harness functions _except_ `execute`, which is
- * defined in the test file (e.g. rvv/skl_pack_e8rc_e8rcprc_zve32x.c.c).
+ * defined in the test file (e.g. rvv/skl_unpack_e8rcprc_e8rc_zve32x.c).
  */
 
-#include "pack_e8rc_e8rcprc.h"
+#include "unpack_e8rcprc_e8rc.h"
 #include "skl-ref.h"
 #include "skl-test-driver.h"
 #include "skl_test_pack.h"
@@ -20,8 +20,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-void pack_e8rc_e8rcprc_init(skl_test_t *t) {
-  pack_e8rc_e8rcprc_t *h = (pack_e8rc_e8rcprc_t *)t->harness;
+void unpack_e8rcprc_e8rc_init(skl_test_t *t) {
+  unpack_e8rcprc_e8rc_t *h = (unpack_e8rcprc_e8rc_t *)t->harness;
 
   size_t m = h->m;
   size_t n = h->n;
@@ -36,8 +36,8 @@ void pack_e8rc_e8rcprc_init(skl_test_t *t) {
   size_t rs1 = h->rs1;
   size_t cs1 = h->cs1;
 
-  skl_test_check_matrix_params_rcprc(t, 1, 1, m, n, 1, 1, rs, cs);
   skl_test_check_matrix_params_rcprc(t, m0, n0, m1, n1, rs0, cs0, rs1, cs1);
+  skl_test_check_matrix_params_rcprc(t, 1, 1, m, n, 1, 1, rs, cs);
 
   if (t->status.init_status != SKL_TEST_PASS) {
     return;
@@ -46,14 +46,14 @@ void pack_e8rc_e8rcprc_init(skl_test_t *t) {
   if (m == 0 || n == 0) {
     h->src.len = 0;
   } else {
-    h->src.len = (m - 1) * rs + (n - 1) * cs + 1;
+    h->src.len =
+        (m1 - 1) * rs1 + (n1 - 1) * cs1 + (m0 - 1) * rs0 + (n0 - 1) * cs0 + 1;
   }
 
   if (m1 == 0 || n1 == 0) {
     h->dst.len = 0;
   } else {
-    h->dst.len =
-        (m1 - 1) * rs1 + (n1 - 1) * cs1 + (m0 - 1) * rs0 + (n0 - 1) * cs0 + 1;
+    h->dst.len = (m - 1) * rs + (n - 1) * cs + 1;
   }
 
   SKL_TEST_BUF_CREATE(t, uint8_t, &h->src);
@@ -65,16 +65,15 @@ void pack_e8rc_e8rcprc_init(skl_test_t *t) {
     memcpy(h->ctx.ref_dst, h->dst.data, h->dst.len * sizeof(uint8_t));
   }
 }
-
-void pack_e8rc_e8rcprc_verify(skl_test_t *t) {
-  pack_e8rc_e8rcprc_t *h = (pack_e8rc_e8rcprc_t *)t->harness;
+void unpack_e8rcprc_e8rc_verify(skl_test_t *t) {
+  unpack_e8rcprc_e8rc_t *h = (unpack_e8rcprc_e8rc_t *)t->harness;
 
   const uint8_t *dst = h->dst.data;
   uint8_t *ref_dst = h->ctx.ref_dst;
 
   // Compute reference value
-  skl_pack_e8rc_e8rcprc_ref(h->m, h->n, h->src.data, h->rs, h->cs, h->m0, h->n0,
-                            ref_dst, h->rs0, h->cs0, h->rs1, h->cs1, h->pad);
+  skl_unpack_e8rcprc_e8rc_ref(h->m0, h->n0, h->src.data, h->rs0, h->cs0, h->rs1,
+                              h->cs1, h->m, h->n, ref_dst, h->rs, h->cs);
 
   // Verify result
   for (size_t i = 0; i < h->dst.len; ++i) {
@@ -87,23 +86,23 @@ void pack_e8rc_e8rcprc_verify(skl_test_t *t) {
   }
 }
 
-void pack_e8rc_e8rcprc_test_report(skl_test_t *t) {
-  pack_e8rc_e8rcprc_t *h = (pack_e8rc_e8rcprc_t *)t->harness;
+void unpack_e8rcprc_e8rc_test_report(skl_test_t *t) {
+  unpack_e8rcprc_e8rc_t *h = (unpack_e8rcprc_e8rc_t *)t->harness;
   pack_rc_rcprc_report_param(t, h->m, h->n, h->rs, h->cs, h->m0, h->n0, h->rs0,
                              h->cs0, h->rs1, h->cs1);
 }
 
-void pack_e8rc_e8rcprc_benchmark_report(skl_test_t *t) {
-  pack_e8rc_e8rcprc_t *h = (pack_e8rc_e8rcprc_t *)t->harness;
-  pack_e8rc_e8rcprc_test_report(t);
-  size_t m1 = (h->m + h->m0 - 1) / h->m0;
-  size_t n1 = (h->n + h->n0 - 1) / h->n0;
-  size_t output_elements = m1 * n1 * h->m0 * h->n0;
+void unpack_e8rcprc_e8rc_benchmark_report(skl_test_t *t) {
+
+  unpack_e8rcprc_e8rc_t *h = (unpack_e8rcprc_e8rc_t *)t->harness;
+  unpack_e8rcprc_e8rc_test_report(t);
+  size_t output_elements = h->m * h->n;
+
   pack_rc_rcprc_report_perf(t, h->steps.warmup, output_elements);
 }
 
-void pack_e8rc_e8rcprc_cleanup(skl_test_t *t) {
-  pack_e8rc_e8rcprc_t *h = (pack_e8rc_e8rcprc_t *)t->harness;
+void unpack_e8rcprc_e8rc_cleanup(skl_test_t *t) {
+  unpack_e8rcprc_e8rc_t *h = (unpack_e8rcprc_e8rc_t *)t->harness;
 
   SKL_TEST_BUF_FREE(t, &h->src);
   SKL_TEST_BUF_FREE(t, &h->dst);

--- a/test/pack/unpack_e8rcprc_e8rc.h
+++ b/test/pack/unpack_e8rcprc_e8rc.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @brief Test and benchmark for Unpack
+ *
+ * This test uses a table-driven approach where test configurations are defined
+ * in the `tests` array. Each test specifies:
+ *  - Input block dimensions m0, n0
+ *  - Input block strides rs0, cs0 (within block), rs1, cs1 (between blocks)
+ *  - Output matrix dimensions m, n
+ *  - Output matrix strides rs, cs
+ */
+
+#pragma once
+
+#include "skl-test-driver.h"
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+  // Test function pointers for various steps
+  // *** This field must be placed first within this struct ***
+  skl_test_steps_t steps;
+
+  // Input block dimensions
+  size_t m0, n0;
+  // Input block strides
+  size_t rs0, cs0; // within block
+  size_t rs1, cs1; // between blocks
+  // Output matrix dimensions
+  size_t m, n;
+  // Output matrix strides
+  size_t rs, cs;
+
+  // Buffer generation settings
+  SKL_TEST_BUFFER(uint8_t) src, dst;
+
+  // Derived parameters & buffers (private to the test harness)
+  struct {
+    uint8_t *ref_dst;
+  } ctx;
+} unpack_e8rcprc_e8rc_t;
+
+#define UNPACK_E8RCPRC_E8RC_DEFAULTS                                           \
+  .src = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM},                      \
+  .dst = {.min = 0, .max = 255, .mode = SKL_TEST_RANDOM}
+
+void unpack_e8rcprc_e8rc_init(skl_test_t *t);
+void unpack_e8rcprc_e8rc_verify(skl_test_t *t);
+void unpack_e8rcprc_e8rc_test_report(skl_test_t *t);
+void unpack_e8rcprc_e8rc_benchmark_report(skl_test_t *t);
+void unpack_e8rcprc_e8rc_cleanup(skl_test_t *t);


### PR DESCRIPTION
This PR adds RVV-based 8-bit general unpack kernel support.
The unpack kernel is part of "Pack" kernel but has its own test harness .