### PR TITLE
Add SiLU and logistic documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Performance benchmarks can be enabled by supplying `-DSKL_ENABLE_BENCHMARKS=TRUE
 
 SKL provides two kinds of documentation to assist developers in using SKL.
 
-Many directories contain a `README.md` file that gives a summary of the files and kernels residing in that directory, and possible also in subdirectories.
+Many directories contain a `README.md` file that gives a summary of the files and kernels residing in that directory, and possibly also in subdirectories.
 More comprehensive documents can be found in the `doc` directory.
 
 Each SKL function that is exposed in the SKL API (i.e., those declared with the `SKL_FUNC` attribute) also has a [Doxygen](https://www.doxygen.nl/index.html) documentation string in its associated header which describes the function's operation and its arguments.

--- a/src/logistic/README.md
+++ b/src/logistic/README.md
@@ -3,9 +3,8 @@
 The Logistic function is a widely-used sigmoid activation function in neural networks that maps inputs to values between 0 and 1.
 It is primarily used in multi-label classification and logistic regression models.
 
-## Overview
+Sometimes known simply as "sigmoid", the Logistic function computes the following elementwise function:
 
-The Logistic function, also known as the sigmoid function, computes the following function, elementwise:
 
 ```
 logistic(x) = 1 / (1 + e^(-x))

--- a/src/logistic/README.md
+++ b/src/logistic/README.md
@@ -1,4 +1,4 @@
-# Logistic (Sigmoid) Kernels
+# Logistic Kernels
 
 The Logistic function is a widely-used sigmoid activation function in neural networks that maps inputs to values between 0 and 1.
 It is primarily used in multi-label classification and logistic regression models.

--- a/src/logistic/README.md
+++ b/src/logistic/README.md
@@ -1,0 +1,53 @@
+# Logistic (Sigmoid) Kernels
+
+The Logistic function is a widely-used sigmoid activation function in neural networks that maps inputs to values between 0 and 1.
+It is primarily used in multi-label classification and logistic regression models.
+
+## Overview
+
+The Logistic function, also known as the sigmoid function, computes the following function, elementwise:
+
+```
+logistic(x) = 1 / (1 + e^(-x))
+```
+
+## Kernel Naming Convention
+
+The kernel names follow the pattern: `skl_logistic_<accuracy>_<type>_<isa>`
+
+where:
+
+- `<accuracy>`: denotes the maximum absolute error in ULP (e.g., `3u` for 3 ULP).
+- `<type>`: denotes the type of the input and output arrays.
+- `<isa>`: denotes the instruction set architecture extension(s) the kernel requires.
+
+## Constraints
+
+- Input and output arrays may overlap only for in-place computation.
+- For maximum performance, input and output arrays should be naturally aligned.
+
+## Kernel List
+
+- FP32 APIs
+
+```c
+void skl_logistic_3u_f32_zve32f(float *out, const float *in, size_t n);
+void skl_logistic_4u_f32_xsfvfexpa(float *out, const float *in, size_t n);
+void skl_logistic_5u_f32_xsfvfexp32e(float *out, const float *in, size_t n);
+```
+
+- FP16 APIs
+
+```c
+void skl_logistic_3u_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n);
+void skl_logistic_5u_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in, size_t n);
+```
+
+- BF16 APIs
+
+```c
+void skl_logistic_2u_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n);
+void skl_logistic_3u_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n);
+void skl_logistic_2u_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in, size_t n);
+void skl_logistic_5u_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n);
+```

--- a/src/silu/README.md
+++ b/src/silu/README.md
@@ -1,0 +1,49 @@
+# Sigmoid Linear Unit (SiLU) Kernels
+
+The Sigmoid Linear Unit (SiLU) function is a widely-used activation function in large language models (LLMs), computer vision, and stable diffusion neural networks, as a smooth alternative to the Rectified Linear Unit (ReLU).
+SiLU multiplies its input with a sigmoid function.
+SKL's SiLU uses the logistic as its sigmoid function, which is typically the case in AI frameworks.
+
+## Overview
+
+SiLU, also known as Swish, computes the following function, elementwise:
+
+```
+silu(x) = x / (1 + e^(-x))
+```
+
+## Kernel Naming Convention
+
+The kernel names follow the pattern: `skl_silu_<accuracy>_<type>_<isa>`
+
+where:
+
+- `<accuracy>`: denotes the maximum absolute error in ULP (e.g., `52u` for 52 ULP, `9u` for 9 ULP).
+- `<type>`: denotes the type of the input and output arrays.
+- `<isa>`: denotes the instruction set architecture extension(s) the kernel requires.
+
+## Constraints
+
+- Input and output arrays may overlap only for in-place computation.
+- For maximum performance, input and output arrays should be naturally aligned.
+
+## Kernel List
+
+- FP32 APIs
+```c
+void skl_silu_52u_f32_zve32f(float *out, const float *in, size_t n);
+void skl_silu_52u_f32_xsfvfexpa(float *out, const float *in, size_t n);
+void skl_silu_52u_f32_xsfvfexp32e(float *out, const float *in, size_t n);
+```
+
+- FP16 APIs
+
+```c
+void skl_silu_9u_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n);
+void skl_silu_9u_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in, size_t n);
+void skl_silu_31u_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in, size_t n);
+```
+
+## Implementation Details
+
+For x = -∞, implementations return NaN.

--- a/src/silu/README.md
+++ b/src/silu/README.md
@@ -2,11 +2,7 @@
 
 The Sigmoid Linear Unit (SiLU) function is a widely-used activation function in large language models (LLMs), computer vision, and stable diffusion neural networks, as a smooth alternative to the Rectified Linear Unit (ReLU).
 SiLU multiplies its input with a sigmoid function.
-SKL's SiLU uses the logistic as its sigmoid function, which is typically the case in AI frameworks.
-
-## Overview
-
-SiLU, also known as Swish, computes the following function, elementwise:
+SKL's SiLU uses the logistic as its sigmoid, computing the following elementwise function:
 
 ```
 silu(x) = x / (1 + e^(-x))
@@ -44,6 +40,6 @@ void skl_silu_9u_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in, size_t n)
 void skl_silu_31u_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in, size_t n);
 ```
 
-## Implementation Details
+## Notes
 
 For x = -∞, implementations return NaN.


### PR DESCRIPTION
This adds documentation for SiLU and logistic kernels, as well as fixes a typo related to documentation in `README.md`.