### PR TITLE
[GEMM] Add `f16_f16_f16` RVV reference kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ add_skl_src(src/gelu/gelu_f32_zve32f.c "zve32f")
 
 add_skl_src(src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma.c "zvfbfwma")
 add_skl_src(src/gemm/rvv/gemm_bf16_bf16_f32_zvfbfwma_x390.c "zvfbfwma")
+add_skl_src(src/gemm/rvv/gemm_f16_f16_f16_zvfh.c "zvfh")
 add_skl_src(src/gemm/rvv/gemm_f16_f16_f16_zvfh_x390.c "zvfh")
 add_skl_src(src/gemm/rvv/gemm_f16_f16_f32_zvfh.c "zvfh")
 add_skl_src(src/gemm/rvv/gemm_f16_f16_f32_zvfh_x390.c "zvfh")

--- a/include/skl.h
+++ b/include/skl.h
@@ -17,6 +17,7 @@
 #endif
 
 #if defined(__riscv_zvfh)
+#include "gemm/rvv/gemm_f16_f16_f16_zvfh.h"
 #include "gemm/rvv/gemm_f16_f16_f16_zvfh_x390.h"
 #include "gemm/rvv/gemm_f16_f16_f32_zvfh.h"
 #include "gemm/rvv/gemm_f16_f16_f32_zvfh_x390.h"

--- a/src/gemm/rvv/gemm_f16_f16_f16_zvfh.c
+++ b/src/gemm/rvv/gemm_f16_f16_f16_zvfh.c
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#if !defined(__riscv_zvfh)
+#error This file requires the Zvfh extension
+#endif
+
+#include <riscv_vector.h>
+#include <stddef.h>
+
+#include "skl-common.h"
+
+/**
+ * @brief RVV float16 matrix-matrix multiplication (HGEMM) for row-major
+ * matrices.
+ *
+ * @param m - Number of rows in matrices A and C.
+ * @param n - Number of columns in matrices B and C.
+ * @param k - Number of columns in A and rows in B (inner dimension).
+ * @param alpha - Scalar multiplier for A*B product.
+ * @param a - Pointer to matrix A.
+ * @param rsa - Row stride of matrix A in elements.
+ * @param b - Pointer to matrix B.
+ * @param rsb - Row stride of matrix B in elements.
+ * @param beta - Scalar multiplier for matrix C.
+ * @param c - Pointer to matrix C.
+ * @param rsc - Row stride of matrix C in elements.
+ *
+ * Computes `C = alpha * A * B + beta * C` for FP32 row-major matrices.
+ *
+ * Functionally equivalent to calling:
+ * ```
+ * skl_gemm_f16rc_f16rc_f16rc_ref(
+ *     m, n, k,
+ *     alpha,
+ *     a, rsa, 1,
+ *     b, rsb, 1,
+ *     beta,
+ *     c, rsc, 1
+ * );
+ * ```
+ * Uses a 4 x LMUL=4 x 1 register tile. Vectorized across the N dimension.
+ *
+ * @note
+ * Works best when `m >= 4` and `n >= __riscv_vsetvlmax_e16m4()`.
+ */
+SKL_FUNC_PRIVATE void skl_gemm_4xm4x1_f16_f16_f16_zvfh(
+    size_t m, size_t n, size_t k, _Float16 alpha, const _Float16 *a, size_t rsa,
+    const _Float16 *b, size_t rsb, _Float16 beta, _Float16 *c, size_t rsc) {
+  size_t jj_vl;
+  size_t ii;
+  size_t jj;
+  size_t kk;
+
+  _Float16 a00;
+  _Float16 a10;
+  _Float16 a20;
+  _Float16 a30;
+  vfloat16m4_t b00;
+  vfloat16m4_t acc00;
+  vfloat16m4_t acc10;
+  vfloat16m4_t acc20;
+  vfloat16m4_t acc30;
+  vfloat16m4_t c00;
+  vfloat16m4_t c10;
+  vfloat16m4_t c20;
+  vfloat16m4_t c30;
+
+  _Float16 a0;
+  vfloat16m8_t b0;
+  vfloat16m8_t acc0;
+  vfloat16m8_t c0;
+
+  if (k == 0) {
+    for (ii = 0; ii < m; ii++) {
+      for (jj = 0; jj < n; jj += jj_vl) {
+        jj_vl = __riscv_vsetvl_e16m8(n - jj);
+        c0 = __riscv_vle16_v_f16m8(c + (ii + 0) * rsc + jj, jj_vl);
+        c0 = __riscv_vfmul_vf_f16m8(c0, beta, jj_vl);
+        __riscv_vse16_v_f16m8(c + (ii + 0) * rsc + jj, c0, jj_vl);
+      }
+    }
+    return;
+  }
+
+  for (ii = 0; (ii + 4) <= m; ii += 4) {
+    for (jj = 0; jj < n; jj += jj_vl) {
+      jj_vl = __riscv_vsetvl_e16m4(n - jj);
+
+      a00 = a[(ii + 0) * rsa + 0];
+      a10 = a[(ii + 1) * rsa + 0];
+      a20 = a[(ii + 2) * rsa + 0];
+      a30 = a[(ii + 3) * rsa + 0];
+      b00 = __riscv_vle16_v_f16m4(b + 0 * rsb + jj, jj_vl);
+      acc00 = __riscv_vfmul_vf_f16m4(b00, a00, jj_vl);
+      acc10 = __riscv_vfmul_vf_f16m4(b00, a10, jj_vl);
+      acc20 = __riscv_vfmul_vf_f16m4(b00, a20, jj_vl);
+      acc30 = __riscv_vfmul_vf_f16m4(b00, a30, jj_vl);
+
+      for (kk = 1; kk < k; kk++) {
+        a00 = a[(ii + 0) * rsa + kk];
+        a10 = a[(ii + 1) * rsa + kk];
+        a20 = a[(ii + 2) * rsa + kk];
+        a30 = a[(ii + 3) * rsa + kk];
+        b00 = __riscv_vle16_v_f16m4(b + kk * rsb + jj, jj_vl);
+        acc00 = __riscv_vfmacc_vf_f16m4(acc00, a00, b00, jj_vl);
+        acc10 = __riscv_vfmacc_vf_f16m4(acc10, a10, b00, jj_vl);
+        acc20 = __riscv_vfmacc_vf_f16m4(acc20, a20, b00, jj_vl);
+        acc30 = __riscv_vfmacc_vf_f16m4(acc30, a30, b00, jj_vl);
+      }
+
+      c00 = __riscv_vle16_v_f16m4(c + (ii + 0) * rsc + jj, jj_vl);
+      c00 = __riscv_vfmul_vf_f16m4(c00, beta, jj_vl);
+      c00 = __riscv_vfmacc_vf_f16m4(c00, alpha, acc00, jj_vl);
+      __riscv_vse16_v_f16m4(c + (ii + 0) * rsc + jj, c00, jj_vl);
+
+      c10 = __riscv_vle16_v_f16m4(c + (ii + 1) * rsc + jj, jj_vl);
+      c10 = __riscv_vfmul_vf_f16m4(c10, beta, jj_vl);
+      c10 = __riscv_vfmacc_vf_f16m4(c10, alpha, acc10, jj_vl);
+      __riscv_vse16_v_f16m4(c + (ii + 1) * rsc + jj, c10, jj_vl);
+
+      c20 = __riscv_vle16_v_f16m4(c + (ii + 2) * rsc + jj, jj_vl);
+      c20 = __riscv_vfmul_vf_f16m4(c20, beta, jj_vl);
+      c20 = __riscv_vfmacc_vf_f16m4(c20, alpha, acc20, jj_vl);
+      __riscv_vse16_v_f16m4(c + (ii + 2) * rsc + jj, c20, jj_vl);
+
+      c30 = __riscv_vle16_v_f16m4(c + (ii + 3) * rsc + jj, jj_vl);
+      c30 = __riscv_vfmul_vf_f16m4(c30, beta, jj_vl);
+      c30 = __riscv_vfmacc_vf_f16m4(c30, alpha, acc30, jj_vl);
+      __riscv_vse16_v_f16m4(c + (ii + 3) * rsc + jj, c30, jj_vl);
+    }
+  }
+
+  for (; ii < m; ii++) {
+    for (jj = 0; jj < n; jj += jj_vl) {
+      jj_vl = __riscv_vsetvl_e16m8(n - jj);
+
+      a0 = a[(ii + 0) * rsa + 0];
+      b0 = __riscv_vle16_v_f16m8(b + 0 * rsb + jj, jj_vl);
+      acc0 = __riscv_vfmul_vf_f16m8(b0, a0, jj_vl);
+
+      for (kk = 1; kk < k; kk++) {
+        a0 = a[(ii + 0) * rsa + kk];
+        b0 = __riscv_vle16_v_f16m8(b + kk * rsb + jj, jj_vl);
+        acc0 = __riscv_vfmacc_vf_f16m8(acc0, a0, b0, jj_vl);
+      }
+
+      c0 = __riscv_vle16_v_f16m8(c + (ii + 0) * rsc + jj, jj_vl);
+      c0 = __riscv_vfmul_vf_f16m8(c0, beta, jj_vl);
+      c0 = __riscv_vfmacc_vf_f16m8(c0, alpha, acc0, jj_vl);
+      __riscv_vse16_v_f16m8(c + (ii + 0) * rsc + jj, c0, jj_vl);
+    }
+  }
+}
+
+SKL_FUNC void skl_gemm_f16_f16_f16_zvfh(size_t m, size_t n, size_t k,
+                                        _Float16 alpha, const _Float16 *a,
+                                        size_t rsa, const _Float16 *b,
+                                        size_t rsb, _Float16 beta, _Float16 *c,
+                                        size_t rsc) {
+  skl_gemm_4xm4x1_f16_f16_f16_zvfh(m, n, k, alpha, a, rsa, b, rsb, beta, c,
+                                   rsc);
+}

--- a/src/gemm/rvv/gemm_f16_f16_f16_zvfh.c
+++ b/src/gemm/rvv/gemm_f16_f16_f16_zvfh.c
@@ -28,7 +28,7 @@
  * @param c - Pointer to matrix C.
  * @param rsc - Row stride of matrix C in elements.
  *
- * Computes `C = alpha * A * B + beta * C` for FP32 row-major matrices.
+ * Computes `C = alpha * A * B + beta * C` for FP16 row-major matrices.
  *
  * Functionally equivalent to calling:
  * ```

--- a/src/gemm/rvv/gemm_f16_f16_f16_zvfh.h
+++ b/src/gemm/rvv/gemm_f16_f16_f16_zvfh.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#if !defined(__riscv_zvfh)
+#error This file requires the Zvfh extension
+#endif
+
+#include <stddef.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * @brief RVV float16 matrix-matrix multiplication (HGEMM) for row-major
+ * matrices.
+ *
+ * @param m - Number of rows in matrices A and C.
+ * @param n - Number of columns in matrices B and C.
+ * @param k - Number of columns in A and rows in B (inner dimension).
+ * @param alpha - Scalar multiplier for A*B product.
+ * @param a - Pointer to matrix A.
+ * @param rsa - Row stride of matrix A in elements.
+ * @param b - Pointer to matrix B.
+ * @param rsb - Row stride of matrix B in elements.
+ * @param beta - Scalar multiplier for matrix C.
+ * @param c - Pointer to matrix C.
+ * @param rsc - Row stride of matrix C in elements.
+ *
+ * Computes `C = alpha * A * B + beta * C` for FP32 row-major matrices.
+ *
+ * Functionally equivalent to calling:
+ * ```
+ * skl_gemm_f16rc_f16rc_f16rc_ref(
+ *     m, n, k,
+ *     alpha,
+ *     a, rsa, 1,
+ *     b, rsb, 1,
+ *     beta,
+ *     c, rsc, 1
+ * );
+ * ```
+ */
+void skl_gemm_f16_f16_f16_zvfh(size_t m, size_t n, size_t k, _Float16 alpha,
+                               const _Float16 *a, size_t rsa, const _Float16 *b,
+                               size_t rsb, _Float16 beta, _Float16 *c,
+                               size_t rsc);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif

--- a/src/gemm/rvv/gemm_f16_f16_f16_zvfh.h
+++ b/src/gemm/rvv/gemm_f16_f16_f16_zvfh.h
@@ -31,7 +31,7 @@ extern "C" {
  * @param c - Pointer to matrix C.
  * @param rsc - Row stride of matrix C in elements.
  *
- * Computes `C = alpha * A * B + beta * C` for FP32 row-major matrices.
+ * Computes `C = alpha * A * B + beta * C` for FP16 row-major matrices.
  *
  * Functionally equivalent to calling:
  * ```

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -277,6 +277,13 @@ skl_add_test(
   ""
 )
 skl_add_test(
+  skl_gemm_f16_f16_f16_zvfh
+  gemm/gemm_f16rcprc_f16rcprc_f16rcprc.c
+  gemm/rvv/skl_gemm_f16_f16_f16_zvfh.c
+  "zvfh"
+  ""
+)
+skl_add_test(
   skl_gemm_f16_f16_f16_zvfh_x390
   gemm/gemm_f16rcprc_f16rcprc_f16rcprc.c
   gemm/rvv/skl_gemm_f16_f16_f16_zvfh_x390.c

--- a/test/gemm/rvv/skl_gemm_f16_f16_f16_zvfh.c
+++ b/test/gemm/rvv/skl_gemm_f16_f16_f16_zvfh.c
@@ -13,7 +13,7 @@
 #endif
 
 /**
- * @brief Test cases for the skl_gemm_f16_f16_f16_zvfh_x390 kernel.
+ * @brief Test cases for the skl_gemm_f16_f16_f16_zvfh kernel.
  *
  * This test uses the gemm_f16rcprc_f16rcprc_f16rcprc harness with the following
  * restrictions on the input parameters:
@@ -90,7 +90,7 @@ gemm_f16rcprc_f16rcprc_f16rcprc_t tests[] = {
 };
 // clang-format on
 
-static skl_test_suite_t suite = {.name = "skl_gemm_f16_f16_f16_zvfh_x390",
+static skl_test_suite_t suite = {.name = "skl_gemm_f16_f16_f16_zvfh",
                                  .num_tests = sizeof(tests) / sizeof(tests[0]),
                                  .test_size =
                                      sizeof(gemm_f16rcprc_f16rcprc_f16rcprc_t),

--- a/test/gemm/rvv/skl_gemm_f16_f16_f16_zvfh.c
+++ b/test/gemm/rvv/skl_gemm_f16_f16_f16_zvfh.c
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#include "gemm/gemm_f16rcprc_f16rcprc_f16rcprc.h"
+#include "skl-test-driver.h"
+#include "skl.h"
+#include <stddef.h>
+
+#if !defined(__riscv_zvfh)
+#error This file requires the Zvfh extension
+#endif
+
+/**
+ * @brief Test cases for the skl_gemm_f16_f16_f16_zvfh_x390 kernel.
+ *
+ * This test uses the gemm_f16rcprc_f16rcprc_f16rcprc harness with the following
+ * restrictions on the input parameters:
+ *  - The block dimensions are m0 = 1, n0 = 1, and k0 = 1
+ *  - All matrices are row-major (csa1 == 1, csb1 == 1, csc1 == 1)
+ */
+
+#define TEST                                                                   \
+  GEMM_F16RCPRC_F16RCPRC_F16RCPRC_DEFAULTS,                                    \
+      .steps = {                                                               \
+          .init = init,                                                        \
+          .warmup = NULL,                                                      \
+          .execute = execute,                                                  \
+          .verify = gemm_f16rcprc_f16rcprc_f16rcprc_verify,                    \
+          .report = gemm_f16rcprc_f16rcprc_f16rcprc_test_report,               \
+          .cleanup = gemm_f16rcprc_f16rcprc_f16rcprc_cleanup,                  \
+  }
+
+#define BENCH                                                                  \
+  GEMM_F16RCPRC_F16RCPRC_F16RCPRC_DEFAULTS,                                    \
+      .steps = {                                                               \
+          .init = init,                                                        \
+          .warmup = execute,                                                   \
+          .execute = execute,                                                  \
+          .verify = NULL,                                                      \
+          .report = gemm_f16rcprc_f16rcprc_f16rcprc_benchmark_report,          \
+          .cleanup = gemm_f16rcprc_f16rcprc_f16rcprc_cleanup,                  \
+  }
+
+static void init(skl_test_t *t);
+static void execute(skl_test_t *t);
+
+// clang-format off
+gemm_f16rcprc_f16rcprc_f16rcprc_t tests[] = {
+#ifdef SKL_ENABLE_BENCHMARKS
+    // Benchmark tests
+    {BENCH, .m1 =  64, .n1 = 128, .k1 = 128, .alpha = (_Float16) 1.f},
+#endif // SKL_ENABLE_BENCHMARKS
+
+#ifdef SKL_ENABLE_TESTS
+    // Verification tests - comprehensive coverage for RVV GEMM
+    /* Edge cases: minimal dimensions */
+    {TEST, .m1 = 1,   .n1 = 1,   .k1 = 0,  .alpha = (_Float16) 2.f},
+    {TEST, .m1 = 1,   .n1 = 1,   .k1 = 1,  .alpha = (_Float16) 2.f},
+
+    /* Small odd dimensions for remainder handling */
+    {TEST, .m1 = 7,   .n1 = 7,   .k1 = 7,  .alpha = (_Float16) 2.f},
+    {TEST, .m1 = 17,  .n1 = 17,  .k1 = 17, .alpha = (_Float16) 2.f},
+
+    /* Skinny matrices (one dimension = 1) */
+    {TEST, .m1 = 1,   .n1 = 33,  .k1 = 31, .alpha = (_Float16) 2.f},
+    {TEST, .m1 = 33,  .n1 = 1,   .k1 = 31, .alpha = (_Float16) 2.f},
+
+    /* k=0 edge case (C = beta*C, no A*B contribution) */
+    {TEST, .m1 = 33,  .n1 = 33,  .k1 = 0,  .alpha = (_Float16) 2.f},
+    {TEST, .m1 = 16,  .n1 = 16,  .k1 = 0,  .alpha = (_Float16) 2.f,  .beta = (_Float16) 3.f},
+
+    /* Vector length boundary tests (multiples of 4, 8, 16, 32) */
+    {TEST, .m1 = 16,  .n1 = 256, .k1 = 16, .alpha = (_Float16) 2.f},
+    {TEST, .m1 = 32,  .n1 = 512, .k1 = 32, .alpha = (_Float16) 2.f},
+
+    /* Near-boundary tests (±1 from vector length multiples) */
+    {TEST, .m1 = 15,  .n1 = 255, .k1 = 31, .alpha = (_Float16) 2.f},
+    {TEST, .m1 = 31,  .n1 = 257, .k1 = 15, .alpha = (_Float16) 2.f},
+
+    /* Wide and tall matrices */
+    {TEST, .m1 = 33,  .n1 = 129, .k1 = 32, .alpha = (_Float16) 2.f},
+    {TEST, .m1 = 129, .n1 = 33,  .k1 = 32, .alpha = (_Float16) 2.f},
+    {TEST, .m1 = 31,  .n1 = 133, .k1 = 32, .alpha = (_Float16) 2.f},
+
+    /* Beta scaling test */
+    {TEST, .m1 = 32,  .n1 = 32,  .k1 = 32, .alpha = (_Float16) 2.f,  .beta = (_Float16) 3.f},
+#endif // SKL_ENABLE_TESTS
+};
+// clang-format on
+
+static skl_test_suite_t suite = {.name = "skl_gemm_f16_f16_f16_zvfh_x390",
+                                 .num_tests = sizeof(tests) / sizeof(tests[0]),
+                                 .test_size =
+                                     sizeof(gemm_f16rcprc_f16rcprc_f16rcprc_t),
+                                 .tests = tests};
+
+static void init(skl_test_t *t) {
+  const gemm_f16rcprc_f16rcprc_f16rcprc_t *h =
+      (gemm_f16rcprc_f16rcprc_f16rcprc_t *)t->harness;
+
+  SKL_TEST_REQUIRE(t, init_status, h->m0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->n0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->k0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->csa1 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->csb1 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->csc1 == 1);
+
+  gemm_f16rcprc_f16rcprc_f16rcprc_init(t);
+}
+
+static void execute(skl_test_t *t) {
+  const gemm_f16rcprc_f16rcprc_f16rcprc_t *h =
+      (gemm_f16rcprc_f16rcprc_f16rcprc_t *)t->harness;
+
+  skl_gemm_f16_f16_f16_zvfh(h->m1, h->n1, h->k1, h->alpha, h->a_pack.data,
+                            h->rsa1, h->b_pack.data, h->rsb1, h->beta,
+                            h->c_pack.data, h->rsc1);
+}
+
+int main(void) {
+  // Set default strides: all matrices are row-major
+  for (size_t i = 0; i < suite.num_tests; ++i) {
+    tests[i].m0 = 1;
+    tests[i].n0 = 1;
+    tests[i].k0 = 1;
+
+    tests[i].rsa0 = 1;
+    tests[i].csa0 = 1;
+    tests[i].rsa1 = tests[i].rsa1 ? tests[i].rsa1 : tests[i].k1;
+    tests[i].csa1 = tests[i].csa1 ? tests[i].csa1 : 1;
+
+    tests[i].rsb0 = 1;
+    tests[i].csb0 = 1;
+    tests[i].rsb1 = tests[i].rsb1 ? tests[i].rsb1 : tests[i].n1;
+    tests[i].csb1 = tests[i].csb1 ? tests[i].csb1 : 1;
+
+    tests[i].rsc0 = 1;
+    tests[i].csc0 = 1;
+    tests[i].rsc1 = tests[i].rsc1 ? tests[i].rsc1 : tests[i].n1;
+    tests[i].csc1 = tests[i].csc1 ? tests[i].csc1 : 1;
+  }
+
+  return skl_test_driver_run_suite(&suite);
+}

--- a/test/gemm/rvv/skl_gemm_f16_f16_f16_zvfh.c
+++ b/test/gemm/rvv/skl_gemm_f16_f16_f16_zvfh.c
@@ -129,17 +129,17 @@ int main(void) {
     tests[i].rsa0 = 1;
     tests[i].csa0 = 1;
     tests[i].rsa1 = tests[i].rsa1 ? tests[i].rsa1 : tests[i].k1;
-    tests[i].csa1 = tests[i].csa1 ? tests[i].csa1 : 1;
+    tests[i].csa1 = 1;
 
     tests[i].rsb0 = 1;
     tests[i].csb0 = 1;
     tests[i].rsb1 = tests[i].rsb1 ? tests[i].rsb1 : tests[i].n1;
-    tests[i].csb1 = tests[i].csb1 ? tests[i].csb1 : 1;
+    tests[i].csb1 = 1;
 
     tests[i].rsc0 = 1;
     tests[i].csc0 = 1;
     tests[i].rsc1 = tests[i].rsc1 ? tests[i].rsc1 : tests[i].n1;
-    tests[i].csc1 = tests[i].csc1 ? tests[i].csc1 : 1;
+    tests[i].csc1 = 1;
   }
 
   return skl_test_driver_run_suite(&suite);


### PR DESCRIPTION
This adds an RVV reference version of non-widening F16 GEMM in intrinsics.

When benchmarking with X390, performance of the added reference kernel is on par with the X390 specialization in the warmed cache + memory port allocated matrices + large problem sizes, but falls behind significantly in other scenarios. This is expected for a reference kernel.