### PR TITLE
[GEMM] Improve performance for Xsfmm f32 2x2 inner loop

### DIFF
--- a/src/gemm/xsfmm/gemm_f32c_f32_f32_xsfmm32a32f.c
+++ b/src/gemm/xsfmm/gemm_f32c_f32_f32_xsfmm32a32f.c
@@ -980,110 +980,113 @@ skl_gemm_inner_loop_2x2_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f(
   const float *a1 = a0 + rsa1;
   const float *b0 = b;
   const float *b1 = b0 + csb1;
-  __asm__ volatile("beqz %[k], 2f\n"
+  __asm__ volatile(
+      "beqz %[k], 2f\n"
 
-                   "sf.vsettnt x0, %[tn0], e32, w1\n"
-                   "sf.vsettm x0, %[tm0]\n"
-                   "sf.vsettk x0, %[k]\n"
+      "sf.vsettnt x0, %[tn0], e32, w1\n"
+      "sf.vsettm x0, %[tm0]\n"
+      "sf.vsettk x0, %[k]\n"
 
-                   "vle32.v v16, (%[b0])\n"
-                   "add %[b0], %[b0], %[rsb1]\n"
+      "vle32.v v16, (%[b0])\n"
+      "add %[b0], %[b0], %[rsb1]\n"
 
-                   "sf.vsettn x0, %[tm0]\n"
-                   "vle32.v v0, (%[a0])\n"
-                   "add %[a0], %[a0], %[csa1]\n"
+      "sf.vsettn x0, %[tm0]\n"
+      "vle32.v v0, (%[a0])\n"
+      "add %[a0], %[a0], %[csa1]\n"
 
-                   "sf.vsettn x0, %[tn1]\n"
-                   "bltu %[k], %[i2], 2f\n"
+      "sf.vsettn x0, %[tn1]\n"
+      "bltu %[k], %[i2], 2f\n"
 
-                   "bne %[tm0], %[tm1], 1f\n"
-                   "bne %[tn0], %[tn1], 1f\n"
-                   "bne %[tm0], %[tn0], 1f\n"
+      // dispatch to general inner loop if tm0, tm1, tn0, tn1 are not all equal
+      "bne %[tm0], %[tm1], 1f\n"
+      "bne %[tn0], %[tn1], 1f\n"
+      "bne %[tm0], %[tn0], 1f\n"
 
-                   "0:\n"
-                   "addi %[k], %[k], -1\n"
-                   "vle32.v v24, (%[b1])\n"
-                   "add %[b1], %[b1], %[rsb1]\n"
+      // specialized inner loop (tm0 == tm1 == tn0 == tn1)
+      "0:\n"
+      "addi %[k], %[k], -1\n"
+      "vle32.v v24, (%[b1])\n"
+      "add %[b1], %[b1], %[rsb1]\n"
 
-                   "sf.mm.f.f mt0, v0, v16\n"
+      "sf.mm.f.f mt0, v0, v16\n"
 
-                   "vle32.v v8, (%[a1])\n"
-                   "add %[a1], %[a1], %[csa1]\n"
+      "vle32.v v8, (%[a1])\n"
+      "add %[a1], %[a1], %[csa1]\n"
 
-                   "sf.mm.f.f mt4, v0, v24\n"
+      "sf.mm.f.f mt4, v0, v24\n"
 
-                   "vle32.v v0, (%[a0])\n"
-                   "add %[a0], %[a0], %[csa1]\n"
+      "vle32.v v0, (%[a0])\n"
+      "add %[a0], %[a0], %[csa1]\n"
 
-                   "sf.mm.f.f mt8, v8, v16\n"
+      "sf.mm.f.f mt8, v8, v16\n"
 
-                   "vle32.v v16, (%[b0])\n"
-                   "add %[b0], %[b0], %[rsb1]\n"
+      "vle32.v v16, (%[b0])\n"
+      "add %[b0], %[b0], %[rsb1]\n"
 
-                   "sf.mm.f.f mt12, v8, v24\n"
-                   "bgeu %[k], %[i2], 0b\n"
-                   "j 2f\n"
+      "sf.mm.f.f mt12, v8, v24\n"
+      "bgeu %[k], %[i2], 0b\n"
+      "j 2f\n"
 
-                   "1:\n"
-                   "addi %[k], %[k], -1\n"
-                   "vle32.v v24, (%[b1])\n"
-                   "add %[b1], %[b1], %[rsb1]\n"
+      // general inner loop
+      "1:\n"
+      "addi %[k], %[k], -1\n"
+      "vle32.v v24, (%[b1])\n"
+      "add %[b1], %[b1], %[rsb1]\n"
 
-                   "sf.vsettm x0, %[tm0]\n"
-                   "sf.vsettn x0, %[tn0]\n"
-                   "sf.mm.f.f mt0, v0, v16\n"
+      "sf.vsettm x0, %[tm0]\n"
+      "sf.vsettn x0, %[tn0]\n"
+      "sf.mm.f.f mt0, v0, v16\n"
 
-                   "sf.vsettn x0, %[tm1]\n"
-                   "vle32.v v8, (%[a1])\n"
-                   "add %[a1], %[a1], %[csa1]\n"
+      "sf.vsettn x0, %[tm1]\n"
+      "vle32.v v8, (%[a1])\n"
+      "add %[a1], %[a1], %[csa1]\n"
 
-                   "sf.vsettn x0, %[tn1]\n"
-                   "sf.mm.f.f mt4, v0, v24\n"
+      "sf.vsettn x0, %[tn1]\n"
+      "sf.mm.f.f mt4, v0, v24\n"
 
-                   "sf.vsettn x0, %[tm0]\n"
-                   "vle32.v v0, (%[a0])\n"
-                   "add %[a0], %[a0], %[csa1]\n"
+      "sf.vsettn x0, %[tm0]\n"
+      "vle32.v v0, (%[a0])\n"
+      "add %[a0], %[a0], %[csa1]\n"
 
-                   "sf.vsettm x0, %[tm1]\n"
-                   "sf.vsettn x0, %[tn0]\n"
-                   "sf.mm.f.f mt8, v8, v16\n"
+      "sf.vsettm x0, %[tm1]\n"
+      "sf.vsettn x0, %[tn0]\n"
+      "sf.mm.f.f mt8, v8, v16\n"
 
-                   "vle32.v v16, (%[b0])\n"
-                   "add %[b0], %[b0], %[rsb1]\n"
+      "vle32.v v16, (%[b0])\n"
+      "add %[b0], %[b0], %[rsb1]\n"
 
-                   "sf.vsettn x0, %[tn1]\n"
-                   "sf.mm.f.f mt12, v8, v24\n"
-                   "bgeu %[k], %[i2], 1b\n"
+      "sf.vsettn x0, %[tn1]\n"
+      "sf.mm.f.f mt12, v8, v24\n"
+      "bgeu %[k], %[i2], 1b\n"
 
-                   "2:\n"
-                   "vle32.v v24, (%[b1])\n"
+      "2:\n"
+      "vle32.v v24, (%[b1])\n"
 
-                   "sf.vsettm x0, %[tm0]\n"
-                   "sf.vsettn x0, %[tn0]\n"
-                   "sf.mm.f.f mt0, v0, v16\n"
+      "sf.vsettm x0, %[tm0]\n"
+      "sf.vsettn x0, %[tn0]\n"
+      "sf.mm.f.f mt0, v0, v16\n"
 
-                   "sf.vsettn x0, %[tm1]\n"
-                   "vle32.v v8, (%[a1])\n"
+      "sf.vsettn x0, %[tm1]\n"
+      "vle32.v v8, (%[a1])\n"
 
-                   "sf.vsettn x0, %[tn1]\n"
-                   "sf.mm.f.f mt4, v0, v24\n"
-                   "sf.vsettm x0, %[tm1]\n"
-                   "sf.vsettn x0, %[tn0]\n"
-                   "sf.mm.f.f mt8, v8, v16\n"
-                   "sf.vsettn x0, %[tn1]\n"
-                   "sf.mm.f.f mt12, v8, v24\n"
+      "sf.vsettn x0, %[tn1]\n"
+      "sf.mm.f.f mt4, v0, v24\n"
+      "sf.vsettm x0, %[tm1]\n"
+      "sf.vsettn x0, %[tn0]\n"
+      "sf.mm.f.f mt8, v8, v16\n"
+      "sf.vsettn x0, %[tn1]\n"
+      "sf.mm.f.f mt12, v8, v24\n"
 
-                   "3:\n"
-                   : [a0] "+&r"(a0), [a1] "+&r"(a1), [b0] "+&r"(b0),
-                     [b1] "+&r"(b1), [k] "+&r"(k)
-                   : [csa1] "r"(csa1 * sizeof(float)),
-                     [rsb1] "r"(rsb1 * sizeof(float)), [tm0] "r"(tm0),
-                     [tm1] "r"(tm1), [tn0] "r"(tn0), [tn1] "r"(tn1), [i2] "r"(2)
-                   : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
-                     "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17",
-                     "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25",
-                     "v26", "v27", "v28", "v29", "v30", "v31", "vtype", "vl",
-                     "memory");
+      "3:\n"
+      : [a0] "+&r"(a0), [a1] "+&r"(a1), [b0] "+&r"(b0), [b1] "+&r"(b1),
+        [k] "+&r"(k)
+      : [csa1] "r"(csa1 * sizeof(float)), [rsb1] "r"(rsb1 * sizeof(float)),
+        [tm0] "r"(tm0), [tm1] "r"(tm1), [tn0] "r"(tn0), [tn1] "r"(tn1),
+        [i2] "r"(2)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10",
+        "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20",
+        "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30",
+        "v31", "vtype", "vl", "memory");
 }
 
 /* Computes A * B (accum == false) or C + A * B (accum == true) and applies a

--- a/src/gemm/xsfmm/gemm_f32c_f32_f32_xsfmm32a32f.c
+++ b/src/gemm/xsfmm/gemm_f32c_f32_f32_xsfmm32a32f.c
@@ -993,11 +993,39 @@ skl_gemm_inner_loop_2x2_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f(
                    "vle32.v v0, (%[a0])\n"
                    "add %[a0], %[a0], %[csa1]\n"
 
-                   "bltu %[k], %[i2], 1f\n"
+                   "sf.vsettn x0, %[tn1]\n"
+                   "bltu %[k], %[i2], 2f\n"
+
+                   "bne %[tm0], %[tm1], 1f\n"
+                   "bne %[tn0], %[tn1], 1f\n"
+                   "bne %[tm0], %[tn0], 1f\n"
 
                    "0:\n"
                    "addi %[k], %[k], -1\n"
-                   "sf.vsettn x0, %[tn1]\n"
+                   "vle32.v v24, (%[b1])\n"
+                   "add %[b1], %[b1], %[rsb1]\n"
+
+                   "sf.mm.f.f mt0, v0, v16\n"
+
+                   "vle32.v v8, (%[a1])\n"
+                   "add %[a1], %[a1], %[csa1]\n"
+
+                   "sf.mm.f.f mt4, v0, v24\n"
+
+                   "vle32.v v0, (%[a0])\n"
+                   "add %[a0], %[a0], %[csa1]\n"
+
+                   "sf.mm.f.f mt8, v8, v16\n"
+
+                   "vle32.v v16, (%[b0])\n"
+                   "add %[b0], %[b0], %[rsb1]\n"
+
+                   "sf.mm.f.f mt12, v8, v24\n"
+                   "bgeu %[k], %[i2], 0b\n"
+                   "j 2f\n"
+
+                   "1:\n"
+                   "addi %[k], %[k], -1\n"
                    "vle32.v v24, (%[b1])\n"
                    "add %[b1], %[b1], %[rsb1]\n"
 
@@ -1025,10 +1053,9 @@ skl_gemm_inner_loop_2x2_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f(
 
                    "sf.vsettn x0, %[tn1]\n"
                    "sf.mm.f.f mt12, v8, v24\n"
-                   "bgeu %[k], %[i2], 0b\n"
+                   "bgeu %[k], %[i2], 1b\n"
 
-                   "1:\n"
-                   "sf.vsettn x0, %[tn1]\n"
+                   "2:\n"
                    "vle32.v v24, (%[b1])\n"
 
                    "sf.vsettm x0, %[tm0]\n"
@@ -1046,7 +1073,7 @@ skl_gemm_inner_loop_2x2_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f(
                    "sf.vsettn x0, %[tn1]\n"
                    "sf.mm.f.f mt12, v8, v24\n"
 
-                   "2:\n"
+                   "3:\n"
                    : [a0] "+&r"(a0), [a1] "+&r"(a1), [b0] "+&r"(b0),
                      [b1] "+&r"(b1), [k] "+&r"(k)
                    : [csa1] "r"(csa1 * sizeof(float)),

--- a/src/gemm/xsfmm/gemm_f32c_f32_f32_xsfmm32a32f.h
+++ b/src/gemm/xsfmm/gemm_f32c_f32_f32_xsfmm32a32f.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfmm/gemm_f32c_f32_f32_xsfmm32a32f.h
+++ b/src/gemm/xsfmm/gemm_f32c_f32_f32_xsfmm32a32f.h
@@ -16,8 +16,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Xsfmm float32 A * B matrix-matrix multiplication (SGEMM) for
- * column-major A and row-major B.
+ * @brief Xsfmm float32 GEMM.
  *
  * @param m - Number of rows in matrices A and C.
  * @param n - Number of columns in matrices B and C.
@@ -79,7 +78,8 @@ void skl_gemm_f32c_f32_f32_xsfmm32a32f(size_t m, size_t n, size_t k,
  * @param rsc1 - Row stride between blocks of C in elements.
  * @param csc1 - Column stride between blocks of C in elements.
  *
- * Computes `C = alpha * A * B + beta * C`.
+ * Computes `C = alpha * A * B + beta * C` for packed float32 matrices A, B, and
+ * C.
  *
  * Equivalent to calling:
  * ```

--- a/test/gemm/xsfmm/skl_gemm_f32c_f32_f32_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_f32c_f32_f32_xsfmm32a32f.c
@@ -21,8 +21,6 @@
  *  - Matrix A is column-major (rsa1 == 1)
  *  - Matrix B is row-major (csb1 == 1)
  *  - Matrix C is row-major (csc1 == 1)
- *
- * The kernel computes C = alpha * A * B + beta * C.
  */
 
 #define TEST                                                                   \
@@ -117,9 +115,6 @@ static void execute(skl_test_t *t) {
   const gemm_f32rcprc_f32rcprc_f32rcprc_t *h =
       (gemm_f32rcprc_f32rcprc_f32rcprc_t *)t->harness;
 
-  // Call the kernel with the appropriate parameters
-  // The kernel signature is: (m, n, k, a, csa, b, rsb, c, rsc, accum)
-  // where accum = (beta != 0)
   skl_gemm_f32c_f32_f32_xsfmm32a32f(h->m1, h->n1, h->k1, h->alpha,
                                     h->a_pack.data, h->csa1, h->b_pack.data,
                                     h->rsb1, h->beta, h->c_pack.data, h->rsc1);

--- a/test/gemm/xsfmm/skl_gemm_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f.c
@@ -21,8 +21,6 @@
  *  - The block dimensions are m0 = TE, n0 = TE, and k0 = 1
  *  - Matrix A_pack has column-major blocks (rsa0 == 1)
  *  - Matrix B_pack has row-major blocks (csb0 == 1)
- *
- * The kernel computes C_pack = alpha * A_pack * B_pack + beta * C_pack.
  */
 
 #define TEST                                                                   \
@@ -179,9 +177,6 @@ static void execute(skl_test_t *t) {
   const gemm_f32rcprc_f32rcprc_f32rcprc_t *h =
       (gemm_f32rcprc_f32rcprc_f32rcprc_t *)t->harness;
 
-  // Call the kernel with the appropriate parameters
-  // The kernel signature is: (m1, n1, k, alpha, a_pack, rsa1, csa1, b_pack,
-  // rsb1, csb1, beta, c_pack, rsc0, rsc1, csc1)
   skl_gemm_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f(
       h->m1, h->n1, h->k1 * h->k0, h->alpha, h->a_pack.data, h->rsa1, h->csa1,
       h->b_pack.data, h->rsb1, h->csb1, h->beta, h->c_pack.data, h->rsc0,


### PR DESCRIPTION
Due to the insertion of additional `sf.vsett{m,n}` instructions in the inner loop code in #14 to handle flexible tile sizes, the performance of the 2x2 inner loop regressed. This PR adds a special branch to the Xsfmm f32 2x2 inner loop when `tm0 == tm1 == tn0 == tn1` for improved performance in this important case. Some comments were cleaned up in the test harnesses as well.