### PR TITLE
[GEMM] Clean up reference GEMM kernels

### DIFF
--- a/ref/gemm/gemm_bf16rc_bf16rc_f32rc.h
+++ b/ref/gemm/gemm_bf16rc_bf16rc_f32rc.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "skl-common.h"
 #include <stddef.h>
 
 #if defined(__cplusplus)

--- a/ref/gemm/gemm_bf16rc_bf16rc_f32rc.h
+++ b/ref/gemm/gemm_bf16rc_bf16rc_f32rc.h
@@ -13,8 +13,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference bfloat16 matrix-matrix multiplication with float32
- * accumulator.
+ * @brief Reference widening bfloat16 GEMM.
  *
  * @param m - Number of rows in matrices A and C.
  * @param n - Number of columns in matrices B and C.
@@ -32,8 +31,8 @@ extern "C" {
  * @param csc - Column stride of matrix C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized BF16 GEMM
- * kernels with FP32 accumulators in SKL.
+ * This generic GEMM function defines the semantics of all optimized widening
+ * bfloat16 GEMM kernels in SKL.
  *
  * Matrices may be in row-major or column-major order, depending on the strides.
  * For row-major matrices, the column stride is 1, and the row stride is the

--- a/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -14,21 +14,21 @@ SKL_FUNC void skl_gemm_bf16rcprc_bf16rcprc_f32rcprc_ref(
     size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      float *cp_block = c + ii1 * rsc1 + jj1 * csc1;
+      float *c_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           float acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const __bf16 *ap_block = a + ii1 * rsa1 + kk1 * csa1;
-            const __bf16 *bp_block = b + kk1 * rsb1 + jj1 * csb1;
+            const __bf16 *a_block = a + ii1 * rsa1 + kk1 * csa1;
+            const __bf16 *b_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
-              __bf16 a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
-              __bf16 b_val = bp_block[kk0 * rsb0 + jj0 * csb0];
+              __bf16 a_val = a_block[ii0 * rsa0 + kk0 * csa0];
+              __bf16 b_val = b_block[kk0 * rsb0 + jj0 * csb0];
               acc += (float)a_val * (float)b_val;
             }
           }
-          cp_block[ii0 * rsc0 + jj0 * csc0] =
-              beta * cp_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
+          c_block[ii0 * rsc0 + jj0 * csc0] =
+              beta * c_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
         }
       }
     }

--- a/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.c
@@ -8,19 +8,19 @@
 
 SKL_FUNC void skl_gemm_bf16rcprc_bf16rcprc_f32rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    float alpha, const __bf16 *a_pack, size_t rsa0, size_t csa0, size_t rsa1,
-    size_t csa1, const __bf16 *b_pack, size_t rsb0, size_t csb0, size_t rsb1,
-    size_t csb1, float beta, float *c_pack, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1) {
+    float alpha, const __bf16 *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const __bf16 *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, float beta, float *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      float *cp_block = c_pack + ii1 * rsc1 + jj1 * csc1;
+      float *cp_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           float acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const __bf16 *ap_block = a_pack + ii1 * rsa1 + kk1 * csa1;
-            const __bf16 *bp_block = b_pack + kk1 * rsb1 + jj1 * csb1;
+            const __bf16 *ap_block = a + ii1 * rsa1 + kk1 * csa1;
+            const __bf16 *bp_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
               __bf16 a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
               __bf16 b_val = bp_block[kk0 * rsb0 + jj0 * csb0];

--- a/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
@@ -3,7 +3,8 @@
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT
 
-#include "skl-common.h"
+#pragma once
+
 #include <stddef.h>
 
 #if defined(__cplusplus)

--- a/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
@@ -21,18 +21,18 @@ extern "C" {
  * @param n1 - Number of columns in B and C as block matrices.
  * @param k1 - Number of columns in A and rows in B as block matrices.
  * @param alpha - Scalar multiplier for A * B product.
- * @param a_pack - Pointer to matrix A.
+ * @param a - Pointer to matrix A.
  * @param rsa0 - Row stride within each block of A in elements.
  * @param csa0 - Column stride within each block of A in elements.
  * @param rsa1 - Row stride between blocks of A in elements.
  * @param csa1 - Column stride between blocks of A in elements.
- * @param b_pack - Pointer to matrix B.
+ * @param b - Pointer to matrix B.
  * @param rsb0 - Row stride within each block of B in elements.
  * @param csb0 - Column stride within each block of B in elements.
  * @param rsb1 - Row stride between blocks of B in elements.
  * @param csb1 - Column stride between blocks of B in elements.
  * @param beta - Scalar multiplier for matrix C.
- * @param c_pack - Pointer to matrix C.
+ * @param c - Pointer to matrix C.
  * @param rsc0 - Row stride within each block of C in elements.
  * @param csc0 - Column stride within each block of C in elements.
  * @param rsc1 - Row stride between blocks of C in elements.
@@ -48,10 +48,10 @@ extern "C" {
  */
 void skl_gemm_bf16rcprc_bf16rcprc_f32rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    float alpha, const __bf16 *a_pack, size_t rsa0, size_t csa0, size_t rsa1,
-    size_t csa1, const __bf16 *b_pack, size_t rsb0, size_t csb0, size_t rsb1,
-    size_t csb1, float beta, float *c_pack, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1);
+    float alpha, const __bf16 *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const __bf16 *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, float beta, float *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_bf16rcprc_bf16rcprc_f32rcprc.h
@@ -11,8 +11,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference bfloat16 packed matrix-matrix multiplication with float32
- * accumulator.
+ * @brief Reference packed widening bfloat16 GEMM.
  *
  * @param m0 - Number of rows in each block of matrices A and C.
  * @param n0 - Number of columns in each block of matrices B and C.
@@ -39,8 +38,8 @@ extern "C" {
  * @param csc1 - Column stride between blocks of C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for packed matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized BF16 packed
- * GEMM kernels with FP32 accumulators in SKL.
+ * This generic GEMM function defines the semantics of all optimized packed
+ * widening bfloat16 GEMM kernels in SKL.
  *
  * @note
  * This function is for API documentation purposes only, and should not be used

--- a/ref/gemm/gemm_f16rc_f16rc_f16rc.h
+++ b/ref/gemm/gemm_f16rc_f16rc_f16rc.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "skl-common.h"
 #include <stddef.h>
 
 #if defined(__cplusplus)

--- a/ref/gemm/gemm_f16rc_f16rc_f16rc.h
+++ b/ref/gemm/gemm_f16rc_f16rc_f16rc.h
@@ -13,7 +13,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference float16 matrix-matrix multiplication (HGEMM).
+ * @brief Reference float16 GEMM (HGEMM).
  *
  * @param m - Number of rows in matrices A and C.
  * @param n - Number of columns in matrices B and C.
@@ -31,8 +31,8 @@ extern "C" {
  * @param csc - Column stride of matrix C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized FP16 GEMM
- * kernels in SKL.
+ * This generic GEMM function defines the semantics of all optimized float16
+ * GEMM kernels in SKL.
  *
  * Matrices may be in row-major or column-major order, depending on the strides.
  * For row-major matrices, the column stride is 1, and the row stride is the

--- a/ref/gemm/gemm_f16rc_f16rc_f32rc.h
+++ b/ref/gemm/gemm_f16rc_f16rc_f32rc.h
@@ -13,8 +13,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference float16 matrix-matrix multiplication with float32
- * accumulator.
+ * @brief Reference widening float16 GEMM.
  *
  * @param m - Number of rows in matrices A and C.
  * @param n - Number of columns in matrices B and C.
@@ -32,8 +31,8 @@ extern "C" {
  * @param csc - Column stride of matrix C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized FP16 GEMM
- * kernels with FP32 accumulators in SKL.
+ * This generic GEMM function defines the semantics of all optimized widening
+ * float16 GEMM kernels in SKL.
  *
  * Matrices may be in row-major or column-major order, depending on the strides.
  * For row-major matrices, the column stride is 1, and the row stride is the

--- a/ref/gemm/gemm_f16rc_f16rc_f32rc.h
+++ b/ref/gemm/gemm_f16rc_f16rc_f32rc.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "skl-common.h"
 #include <stddef.h>
 
 #if defined(__cplusplus)

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f16rcprc.c
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f16rcprc.c
@@ -14,21 +14,21 @@ SKL_FUNC void skl_gemm_f16rcprc_f16rcprc_f16rcprc_ref(
     size_t rsc1, size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      _Float16 *cp_block = c + ii1 * rsc1 + jj1 * csc1;
+      _Float16 *c_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           _Float16 acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const _Float16 *ap_block = a + ii1 * rsa1 + kk1 * csa1;
-            const _Float16 *bp_block = b + kk1 * rsb1 + jj1 * csb1;
+            const _Float16 *a_block = a + ii1 * rsa1 + kk1 * csa1;
+            const _Float16 *b_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
-              _Float16 a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
-              _Float16 b_val = bp_block[kk0 * rsb0 + jj0 * csb0];
+              _Float16 a_val = a_block[ii0 * rsa0 + kk0 * csa0];
+              _Float16 b_val = b_block[kk0 * rsb0 + jj0 * csb0];
               acc += a_val * b_val;
             }
           }
-          cp_block[ii0 * rsc0 + jj0 * csc0] =
-              beta * cp_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
+          c_block[ii0 * rsc0 + jj0 * csc0] =
+              beta * c_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
         }
       }
     }

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f16rcprc.c
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f16rcprc.c
@@ -8,19 +8,19 @@
 
 SKL_FUNC void skl_gemm_f16rcprc_f16rcprc_f16rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    _Float16 alpha, const _Float16 *a_pack, size_t rsa0, size_t csa0,
-    size_t rsa1, size_t csa1, const _Float16 *b_pack, size_t rsb0, size_t csb0,
-    size_t rsb1, size_t csb1, _Float16 beta, _Float16 *c_pack, size_t rsc0,
-    size_t csc0, size_t rsc1, size_t csc1) {
+    _Float16 alpha, const _Float16 *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const _Float16 *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, _Float16 beta, _Float16 *c, size_t rsc0, size_t csc0,
+    size_t rsc1, size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      _Float16 *cp_block = c_pack + ii1 * rsc1 + jj1 * csc1;
+      _Float16 *cp_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           _Float16 acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const _Float16 *ap_block = a_pack + ii1 * rsa1 + kk1 * csa1;
-            const _Float16 *bp_block = b_pack + kk1 * rsb1 + jj1 * csb1;
+            const _Float16 *ap_block = a + ii1 * rsa1 + kk1 * csa1;
+            const _Float16 *bp_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
               _Float16 a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
               _Float16 b_val = bp_block[kk0 * rsb0 + jj0 * csb0];

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f16rcprc.h
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f16rcprc.h
@@ -3,7 +3,8 @@
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT
 
-#include "skl-common.h"
+#pragma once
+
 #include <stddef.h>
 
 #if defined(__cplusplus)

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f16rcprc.h
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f16rcprc.h
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference float16 packed matrix-matrix multiplication.
+ * @brief Reference packed float16 GEMM.
  *
  * @param m0 - Number of rows in each block of matrices A and C.
  * @param n0 - Number of columns in each block of matrices B and C.
@@ -38,8 +38,8 @@ extern "C" {
  * @param csc1 - Column stride between blocks of C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for packed matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized FP16 packed
- * GEMM kernels in SKL.
+ * This generic GEMM function defines the semantics of all optimized packed
+ * float16 GEMM kernels in SKL.
  *
  * @note
  * This function is for API documentation purposes only, and should not be used

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f16rcprc.h
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f16rcprc.h
@@ -20,18 +20,18 @@ extern "C" {
  * @param n1 - Number of columns in B and C as block matrices.
  * @param k1 - Number of columns in A and rows in B as block matrices.
  * @param alpha - Scalar multiplier for A * B product.
- * @param a_pack - Pointer to matrix A.
+ * @param a - Pointer to matrix A.
  * @param rsa0 - Row stride within each block of A in elements.
  * @param csa0 - Column stride within each block of A in elements.
  * @param rsa1 - Row stride between blocks of A in elements.
  * @param csa1 - Column stride between blocks of A in elements.
- * @param b_pack - Pointer to matrix B.
+ * @param b - Pointer to matrix B.
  * @param rsb0 - Row stride within each block of B in elements.
  * @param csb0 - Column stride within each block of B in elements.
  * @param rsb1 - Row stride between blocks of B in elements.
  * @param csb1 - Column stride between blocks of B in elements.
  * @param beta - Scalar multiplier for matrix C.
- * @param c_pack - Pointer to matrix C.
+ * @param c - Pointer to matrix C.
  * @param rsc0 - Row stride within each block of C in elements.
  * @param csc0 - Column stride within each block of C in elements.
  * @param rsc1 - Row stride between blocks of C in elements.
@@ -47,10 +47,10 @@ extern "C" {
  */
 void skl_gemm_f16rcprc_f16rcprc_f16rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    _Float16 alpha, const _Float16 *a_pack, size_t rsa0, size_t csa0,
-    size_t rsa1, size_t csa1, const _Float16 *b_pack, size_t rsb0, size_t csb0,
-    size_t rsb1, size_t csb1, _Float16 beta, _Float16 *c_pack, size_t rsc0,
-    size_t csc0, size_t rsc1, size_t csc1);
+    _Float16 alpha, const _Float16 *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const _Float16 *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, _Float16 beta, _Float16 *c, size_t rsc0, size_t csc0,
+    size_t rsc1, size_t csc1);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -8,19 +8,19 @@
 
 SKL_FUNC void skl_gemm_f16rcprc_f16rcprc_f32rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    float alpha, const _Float16 *a_pack, size_t rsa0, size_t csa0, size_t rsa1,
-    size_t csa1, const _Float16 *b_pack, size_t rsb0, size_t csb0, size_t rsb1,
-    size_t csb1, float beta, float *c_pack, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1) {
+    float alpha, const _Float16 *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const _Float16 *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, float beta, float *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      float *cp_block = c_pack + ii1 * rsc1 + jj1 * csc1;
+      float *cp_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           float acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const _Float16 *ap_block = a_pack + ii1 * rsa1 + kk1 * csa1;
-            const _Float16 *bp_block = b_pack + kk1 * rsb1 + jj1 * csb1;
+            const _Float16 *ap_block = a + ii1 * rsa1 + kk1 * csa1;
+            const _Float16 *bp_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
               _Float16 a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
               _Float16 b_val = bp_block[kk0 * rsb0 + jj0 * csb0];

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.c
@@ -14,21 +14,21 @@ SKL_FUNC void skl_gemm_f16rcprc_f16rcprc_f32rcprc_ref(
     size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      float *cp_block = c + ii1 * rsc1 + jj1 * csc1;
+      float *c_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           float acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const _Float16 *ap_block = a + ii1 * rsa1 + kk1 * csa1;
-            const _Float16 *bp_block = b + kk1 * rsb1 + jj1 * csb1;
+            const _Float16 *a_block = a + ii1 * rsa1 + kk1 * csa1;
+            const _Float16 *b_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
-              _Float16 a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
-              _Float16 b_val = bp_block[kk0 * rsb0 + jj0 * csb0];
+              _Float16 a_val = a_block[ii0 * rsa0 + kk0 * csa0];
+              _Float16 b_val = b_block[kk0 * rsb0 + jj0 * csb0];
               acc += (float)a_val * (float)b_val;
             }
           }
-          cp_block[ii0 * rsc0 + jj0 * csc0] =
-              beta * cp_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
+          c_block[ii0 * rsc0 + jj0 * csc0] =
+              beta * c_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
         }
       }
     }

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.h
@@ -11,8 +11,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference float16 packed matrix-matrix multiplication with float32
- * accumulator.
+ * @brief Reference packed widening float16 GEMM.
  *
  * @param m0 - Number of rows in each block of matrices A and C.
  * @param n0 - Number of columns in each block of matrices B and C.
@@ -39,8 +38,8 @@ extern "C" {
  * @param csc1 - Column stride between blocks of C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for packed matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized FP16 packed
- * GEMM kernels with FP32 accumulators in SKL.
+ * This generic GEMM function defines the semantics of all optimized packed
+ * widening float16 GEMM kernels in SKL.
  *
  * @note
  * This function is for API documentation purposes only, and should not be used

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.h
@@ -3,7 +3,8 @@
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT
 
-#include "skl-common.h"
+#pragma once
+
 #include <stddef.h>
 
 #if defined(__cplusplus)

--- a/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f16rcprc_f16rcprc_f32rcprc.h
@@ -21,18 +21,18 @@ extern "C" {
  * @param n1 - Number of columns in B and C as block matrices.
  * @param k1 - Number of columns in A and rows in B as block matrices.
  * @param alpha - Scalar multiplier for A * B product.
- * @param a_pack - Pointer to matrix A.
+ * @param a - Pointer to matrix A.
  * @param rsa0 - Row stride within each block of A in elements.
  * @param csa0 - Column stride within each block of A in elements.
  * @param rsa1 - Row stride between blocks of A in elements.
  * @param csa1 - Column stride between blocks of A in elements.
- * @param b_pack - Pointer to matrix B.
+ * @param b - Pointer to matrix B.
  * @param rsb0 - Row stride within each block of B in elements.
  * @param csb0 - Column stride within each block of B in elements.
  * @param rsb1 - Row stride between blocks of B in elements.
  * @param csb1 - Column stride between blocks of B in elements.
  * @param beta - Scalar multiplier for matrix C.
- * @param c_pack - Pointer to matrix C.
+ * @param c - Pointer to matrix C.
  * @param rsc0 - Row stride within each block of C in elements.
  * @param csc0 - Column stride within each block of C in elements.
  * @param rsc1 - Row stride between blocks of C in elements.
@@ -48,10 +48,10 @@ extern "C" {
  */
 void skl_gemm_f16rcprc_f16rcprc_f32rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    float alpha, const _Float16 *a_pack, size_t rsa0, size_t csa0, size_t rsa1,
-    size_t csa1, const _Float16 *b_pack, size_t rsb0, size_t csb0, size_t rsb1,
-    size_t csb1, float beta, float *c_pack, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1);
+    float alpha, const _Float16 *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const _Float16 *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, float beta, float *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/ref/gemm/gemm_f32rc_f32rc_f32rc.h
+++ b/ref/gemm/gemm_f32rc_f32rc_f32rc.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "skl-common.h"
 #include <stddef.h>
 
 #if defined(__cplusplus)

--- a/ref/gemm/gemm_f32rc_f32rc_f32rc.h
+++ b/ref/gemm/gemm_f32rc_f32rc_f32rc.h
@@ -13,7 +13,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference float32 matrix-matrix multiplication (SGEMM).
+ * @brief Reference float32 GEMM (SGEMM).
  *
  * @param m - Number of rows in matrices A and C.
  * @param n - Number of columns in matrices B and C.
@@ -31,8 +31,8 @@ extern "C" {
  * @param csc - Column stride of matrix C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized FP32 GEMM
- * kernels in SKL.
+ * This generic GEMM function defines the semantics of all optimized float32
+ * GEMM kernels in SKL.
  *
  * Matrices may be in row-major or column-major order, depending on the strides.
  * For row-major matrices, the column stride is 1, and the row stride is the

--- a/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -8,19 +8,19 @@
 
 SKL_FUNC void skl_gemm_f32rcprc_f32rcprc_f32rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    float alpha, const float *a_pack, size_t rsa0, size_t csa0, size_t rsa1,
-    size_t csa1, const float *b_pack, size_t rsb0, size_t csb0, size_t rsb1,
-    size_t csb1, float beta, float *c_pack, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1) {
+    float alpha, const float *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const float *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, float beta, float *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      float *cp_block = c_pack + ii1 * rsc1 + jj1 * csc1;
+      float *cp_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           float acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const float *ap_block = a_pack + ii1 * rsa1 + kk1 * csa1;
-            const float *bp_block = b_pack + kk1 * rsb1 + jj1 * csb1;
+            const float *ap_block = a + ii1 * rsa1 + kk1 * csa1;
+            const float *bp_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
               float a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
               float b_val = bp_block[kk0 * rsb0 + jj0 * csb0];

--- a/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -14,21 +14,21 @@ SKL_FUNC void skl_gemm_f32rcprc_f32rcprc_f32rcprc_ref(
     size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      float *cp_block = c + ii1 * rsc1 + jj1 * csc1;
+      float *c_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           float acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const float *ap_block = a + ii1 * rsa1 + kk1 * csa1;
-            const float *bp_block = b + kk1 * rsb1 + jj1 * csb1;
+            const float *a_block = a + ii1 * rsa1 + kk1 * csa1;
+            const float *b_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
-              float a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
-              float b_val = bp_block[kk0 * rsb0 + jj0 * csb0];
+              float a_val = a_block[ii0 * rsa0 + kk0 * csa0];
+              float b_val = b_block[kk0 * rsb0 + jj0 * csb0];
               acc += a_val * b_val;
             }
           }
-          cp_block[ii0 * rsc0 + jj0 * csc0] =
-              beta * cp_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
+          c_block[ii0 * rsc0 + jj0 * csc0] =
+              beta * c_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
         }
       }
     }

--- a/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
@@ -3,7 +3,8 @@
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT
 
-#include "skl-common.h"
+#pragma once
+
 #include <stddef.h>
 
 #if defined(__cplusplus)

--- a/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
@@ -20,18 +20,18 @@ extern "C" {
  * @param n1 - Number of columns in B and C as block matrices.
  * @param k1 - Number of columns in A and rows in B as block matrices.
  * @param alpha - Scalar multiplier for A * B product.
- * @param a_pack - Pointer to matrix A.
+ * @param a - Pointer to matrix A.
  * @param rsa0 - Row stride within each block of A in elements.
  * @param csa0 - Column stride within each block of A in elements.
  * @param rsa1 - Row stride between blocks of A in elements.
  * @param csa1 - Column stride between blocks of A in elements.
- * @param b_pack - Pointer to matrix B.
+ * @param b - Pointer to matrix B.
  * @param rsb0 - Row stride within each block of B in elements.
  * @param csb0 - Column stride within each block of B in elements.
  * @param rsb1 - Row stride between blocks of B in elements.
  * @param csb1 - Column stride between blocks of B in elements.
  * @param beta - Scalar multiplier for matrix C.
- * @param c_pack - Pointer to matrix C.
+ * @param c - Pointer to matrix C.
  * @param rsc0 - Row stride within each block of C in elements.
  * @param csc0 - Column stride within each block of C in elements.
  * @param rsc1 - Row stride between blocks of C in elements.
@@ -47,10 +47,10 @@ extern "C" {
  */
 void skl_gemm_f32rcprc_f32rcprc_f32rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    float alpha, const float *a_pack, size_t rsa0, size_t csa0, size_t rsa1,
-    size_t csa1, const float *b_pack, size_t rsb0, size_t csb0, size_t rsb1,
-    size_t csb1, float beta, float *c_pack, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1);
+    float alpha, const float *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const float *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, float beta, float *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference float32 packed matrix-matrix multiplication.
+ * @brief Reference packed float32 GEMM.
  *
  * @param m0 - Number of rows in each block of matrices A and C.
  * @param n0 - Number of columns in each block of matrices B and C.
@@ -38,8 +38,8 @@ extern "C" {
  * @param csc1 - Column stride between blocks of C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for packed matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized FP32 packed
- * GEMM kernels in SKL.
+ * This generic GEMM function defines the semantics of all optimized packed
+ * float32 GEMM kernels in SKL.
  *
  * @note
  * This function is for API documentation purposes only, and should not be used

--- a/ref/gemm/gemm_f64rc_f64rc_f64rc.h
+++ b/ref/gemm/gemm_f64rc_f64rc_f64rc.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "skl-common.h"
 #include <stddef.h>
 
 #if defined(__cplusplus)

--- a/ref/gemm/gemm_f64rc_f64rc_f64rc.h
+++ b/ref/gemm/gemm_f64rc_f64rc_f64rc.h
@@ -13,7 +13,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference float64 matrix-matrix multiplication (DGEMM).
+ * @brief Reference float64 GEMM (DGEMM).
  *
  * @param m - Number of rows in matrices A and C.
  * @param n - Number of columns in matrices B and C.
@@ -31,8 +31,8 @@ extern "C" {
  * @param csc - Column stride of matrix C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized FP64 GEMM
- * kernels in SKL.
+ * This generic GEMM function defines the semantics of all optimized float64
+ * GEMM kernels in SKL.
  *
  * Matrices may be in row-major or column-major order, depending on the strides.
  * For row-major matrices, the column stride is 1, and the row stride is the

--- a/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.c
+++ b/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.c
@@ -14,21 +14,21 @@ SKL_FUNC void skl_gemm_f64rcprc_f64rcprc_f64rcprc_ref(
     size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      double *cp_block = c + ii1 * rsc1 + jj1 * csc1;
+      double *c_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           double acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const double *ap_block = a + ii1 * rsa1 + kk1 * csa1;
-            const double *bp_block = b + kk1 * rsb1 + jj1 * csb1;
+            const double *a_block = a + ii1 * rsa1 + kk1 * csa1;
+            const double *b_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
-              double a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
-              double b_val = bp_block[kk0 * rsb0 + jj0 * csb0];
+              double a_val = a_block[ii0 * rsa0 + kk0 * csa0];
+              double b_val = b_block[kk0 * rsb0 + jj0 * csb0];
               acc += a_val * b_val;
             }
           }
-          cp_block[ii0 * rsc0 + jj0 * csc0] =
-              beta * cp_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
+          c_block[ii0 * rsc0 + jj0 * csc0] =
+              beta * c_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
         }
       }
     }

--- a/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.c
+++ b/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.c
@@ -8,19 +8,19 @@
 
 SKL_FUNC void skl_gemm_f64rcprc_f64rcprc_f64rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    double alpha, const double *a_pack, size_t rsa0, size_t csa0, size_t rsa1,
-    size_t csa1, const double *b_pack, size_t rsb0, size_t csb0, size_t rsb1,
-    size_t csb1, double beta, double *c_pack, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1) {
+    double alpha, const double *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const double *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, double beta, double *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      double *cp_block = c_pack + ii1 * rsc1 + jj1 * csc1;
+      double *cp_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           double acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const double *ap_block = a_pack + ii1 * rsa1 + kk1 * csa1;
-            const double *bp_block = b_pack + kk1 * rsb1 + jj1 * csb1;
+            const double *ap_block = a + ii1 * rsa1 + kk1 * csa1;
+            const double *bp_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
               double a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
               double b_val = bp_block[kk0 * rsb0 + jj0 * csb0];

--- a/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.h
+++ b/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.h
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference FP64 packed matrix-matrix multiplication.
+ * @brief Reference packed float64 GEMM.
  *
  * @param m0 - Number of rows in each block of matrices A and C.
  * @param n0 - Number of columns in each block of matrices B and C.
@@ -38,8 +38,8 @@ extern "C" {
  * @param csc1 - Column stride between blocks of C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for packed matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized FP64
- * packed GEMM kernels in SKL.
+ * This generic GEMM function defines the semantics of all optimized packed
+ * float64 GEMM kernels in SKL.
  *
  * @note
  * This function is for API documentation purposes only, and should not be used

--- a/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.h
+++ b/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.h
@@ -3,7 +3,8 @@
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT
 
-#include "skl-common.h"
+#pragma once
+
 #include <stddef.h>
 
 #if defined(__cplusplus)

--- a/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.h
+++ b/ref/gemm/gemm_f64rcprc_f64rcprc_f64rcprc.h
@@ -20,18 +20,18 @@ extern "C" {
  * @param n1 - Number of columns in B and C as block matrices.
  * @param k1 - Number of columns in A and rows in B as block matrices.
  * @param alpha - Scalar multiplier for A * B product.
- * @param a_pack - Pointer to matrix A.
+ * @param a - Pointer to matrix A.
  * @param rsa0 - Row stride within each block of A in elements.
  * @param csa0 - Column stride within each block of A in elements.
  * @param rsa1 - Row stride between blocks of A in elements.
  * @param csa1 - Column stride between blocks of A in elements.
- * @param b_pack - Pointer to matrix B.
+ * @param b - Pointer to matrix B.
  * @param rsb0 - Row stride within each block of B in elements.
  * @param csb0 - Column stride within each block of B in elements.
  * @param rsb1 - Row stride between blocks of B in elements.
  * @param csb1 - Column stride between blocks of B in elements.
  * @param beta - Scalar multiplier for matrix C.
- * @param c_pack - Pointer to matrix C.
+ * @param c - Pointer to matrix C.
  * @param rsc0 - Row stride within each block of C in elements.
  * @param csc0 - Column stride within each block of C in elements.
  * @param rsc1 - Row stride between blocks of C in elements.
@@ -47,10 +47,10 @@ extern "C" {
  */
 void skl_gemm_f64rcprc_f64rcprc_f64rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    double alpha, const double *a_pack, size_t rsa0, size_t csa0, size_t rsa1,
-    size_t csa1, const double *b_pack, size_t rsb0, size_t csb0, size_t rsb1,
-    size_t csb1, double beta, double *c_pack, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1);
+    double alpha, const double *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const double *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, double beta, double *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.h
+++ b/ref/gemm/gemm_f8e4m3rc_f8e4m3rc_f32rc.h
@@ -13,8 +13,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference OFP8 E4M3 matrix-matrix multiplication with float32
- * accumulator.
+ * @brief Reference quad-widening OFP8 E4M3 GEMM.
  *
  * @param m - Number of rows in matrices A and C.
  * @param n - Number of columns in matrices B and C.
@@ -32,8 +31,8 @@ extern "C" {
  * @param csc - Column stride of matrix C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized OFP8 E4M3
- * GEMM kernels with FP32 accumulators in SKL.
+ * This generic GEMM function defines the semantics of all optimized
+ * quad-widening OFP8 E4M3 GEMM kernels in SKL.
  *
  * The entries of A and B are 8-bit floating point numbers in E4M3 format,
  * type-punned as 8-bit unsigned integers.

--- a/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -10,19 +10,19 @@
 
 SKL_FUNC void skl_gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    float alpha, const uint8_t *a_pack, size_t rsa0, size_t csa0, size_t rsa1,
-    size_t csa1, const uint8_t *b_pack, size_t rsb0, size_t csb0, size_t rsb1,
-    size_t csb1, float beta, float *c_pack, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1) {
+    float alpha, const uint8_t *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const uint8_t *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, float beta, float *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      float *cp_block = c_pack + ii1 * rsc1 + jj1 * csc1;
+      float *cp_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           float acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const uint8_t *ap_block = a_pack + ii1 * rsa1 + kk1 * csa1;
-            const uint8_t *bp_block = b_pack + kk1 * rsb1 + jj1 * csb1;
+            const uint8_t *ap_block = a + ii1 * rsa1 + kk1 * csa1;
+            const uint8_t *bp_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
               uint8_t a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
               uint8_t b_val = bp_block[kk0 * rsb0 + jj0 * csb0];

--- a/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.c
@@ -16,21 +16,21 @@ SKL_FUNC void skl_gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc_ref(
     size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      float *cp_block = c + ii1 * rsc1 + jj1 * csc1;
+      float *c_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           float acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const uint8_t *ap_block = a + ii1 * rsa1 + kk1 * csa1;
-            const uint8_t *bp_block = b + kk1 * rsb1 + jj1 * csb1;
+            const uint8_t *a_block = a + ii1 * rsa1 + kk1 * csa1;
+            const uint8_t *b_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
-              uint8_t a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
-              uint8_t b_val = bp_block[kk0 * rsb0 + jj0 * csb0];
+              uint8_t a_val = a_block[ii0 * rsa0 + kk0 * csa0];
+              uint8_t b_val = b_block[kk0 * rsb0 + jj0 * csb0];
               acc += skl_cvt_f8e4m3_f32(a_val) * skl_cvt_f8e4m3_f32(b_val);
             }
           }
-          cp_block[ii0 * rsc0 + jj0 * csc0] =
-              beta * cp_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
+          c_block[ii0 * rsc0 + jj0 * csc0] =
+              beta * c_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
         }
       }
     }

--- a/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.h
@@ -23,18 +23,18 @@ extern "C" {
  * @param n1 - Number of columns in B and C as block matrices.
  * @param k1 - Number of columns in A and rows in B as block matrices.
  * @param alpha - Scalar multiplier for A * B product.
- * @param a_pack - Pointer to matrix A.
+ * @param a - Pointer to matrix A.
  * @param rsa0 - Row stride within each block of A in elements.
  * @param csa0 - Column stride within each block of A in elements.
  * @param rsa1 - Row stride between blocks of A in elements.
  * @param csa1 - Column stride between blocks of A in elements.
- * @param b_pack - Pointer to matrix B.
+ * @param b - Pointer to matrix B.
  * @param rsb0 - Row stride within each block of B in elements.
  * @param csb0 - Column stride within each block of B in elements.
  * @param rsb1 - Row stride between blocks of B in elements.
  * @param csb1 - Column stride between blocks of B in elements.
  * @param beta - Scalar multiplier for matrix C.
- * @param c_pack - Pointer to matrix C.
+ * @param c - Pointer to matrix C.
  * @param rsc0 - Row stride within each block of C in elements.
  * @param csc0 - Column stride within each block of C in elements.
  * @param rsc1 - Row stride between blocks of C in elements.
@@ -53,10 +53,10 @@ extern "C" {
  */
 void skl_gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    float alpha, const uint8_t *a_pack, size_t rsa0, size_t csa0, size_t rsa1,
-    size_t csa1, const uint8_t *b_pack, size_t rsb0, size_t csb0, size_t rsb1,
-    size_t csb1, float beta, float *c_pack, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1);
+    float alpha, const uint8_t *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const uint8_t *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, float beta, float *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f8e4m3rcprc_f8e4m3rcprc_f32rcprc.h
@@ -13,8 +13,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference OFP8 E4M3 packed matrix-matrix multiplication with float32
- * accumulator.
+ * @brief Reference packed quad-widening OFP8 E4M3 GEMM.
  *
  * @param m0 - Number of rows in each block of matrices A and C.
  * @param n0 - Number of columns in each block of matrices B and C.
@@ -41,8 +40,8 @@ extern "C" {
  * @param csc1 - Column stride between blocks of C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for packed matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized OFP8 E4M3
- * packed GEMM kernels with FP32 accumulators in SKL.
+ * This generic GEMM function defines the semantics of all optimized packed
+ * quad-widening OFP8 E4M3 GEMM kernels in SKL.
  *
  * The entries of A and B are 8-bit floating point numbers in E4M3 format,
  * type-punned as 8-bit unsigned integers.

--- a/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.h
+++ b/ref/gemm/gemm_f8e5m2rc_f8e5m2rc_f32rc.h
@@ -13,8 +13,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference OFP8 E5M2 matrix-matrix multiplication with float32
- * accumulator.
+ * @brief Reference quad-widening OFP8 E5M2 GEMM.
  *
  * @param m - Number of rows in matrices A and C.
  * @param n - Number of columns in matrices B and C.
@@ -32,8 +31,8 @@ extern "C" {
  * @param csc - Column stride of matrix C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized OFP8 E5M2
- * GEMM kernels with FP32 accumulators in SKL.
+ * This generic GEMM function defines the semantics of all optimized
+ * quad-widening OFP8 E5M2 GEMM kernels in SKL.
  *
  * The entries of A and B are 8-bit floating point numbers in E5M2 format,
  * type-punned as 8-bit unsigned integers.

--- a/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
@@ -10,19 +10,19 @@
 
 SKL_FUNC void skl_gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    float alpha, const uint8_t *a_pack, size_t rsa0, size_t csa0, size_t rsa1,
-    size_t csa1, const uint8_t *b_pack, size_t rsb0, size_t csb0, size_t rsb1,
-    size_t csb1, float beta, float *c_pack, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1) {
+    float alpha, const uint8_t *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const uint8_t *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, float beta, float *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      float *cp_block = c_pack + ii1 * rsc1 + jj1 * csc1;
+      float *cp_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           float acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const uint8_t *ap_block = a_pack + ii1 * rsa1 + kk1 * csa1;
-            const uint8_t *bp_block = b_pack + kk1 * rsb1 + jj1 * csb1;
+            const uint8_t *ap_block = a + ii1 * rsa1 + kk1 * csa1;
+            const uint8_t *bp_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
               uint8_t a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
               uint8_t b_val = bp_block[kk0 * rsb0 + jj0 * csb0];

--- a/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
+++ b/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.c
@@ -16,21 +16,21 @@ SKL_FUNC void skl_gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc_ref(
     size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      float *cp_block = c + ii1 * rsc1 + jj1 * csc1;
+      float *c_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           float acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const uint8_t *ap_block = a + ii1 * rsa1 + kk1 * csa1;
-            const uint8_t *bp_block = b + kk1 * rsb1 + jj1 * csb1;
+            const uint8_t *a_block = a + ii1 * rsa1 + kk1 * csa1;
+            const uint8_t *b_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
-              uint8_t a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
-              uint8_t b_val = bp_block[kk0 * rsb0 + jj0 * csb0];
+              uint8_t a_val = a_block[ii0 * rsa0 + kk0 * csa0];
+              uint8_t b_val = b_block[kk0 * rsb0 + jj0 * csb0];
               acc += skl_cvt_f8e5m2_f32(a_val) * skl_cvt_f8e5m2_f32(b_val);
             }
           }
-          cp_block[ii0 * rsc0 + jj0 * csc0] =
-              beta * cp_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
+          c_block[ii0 * rsc0 + jj0 * csc0] =
+              beta * c_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
         }
       }
     }

--- a/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.h
@@ -13,8 +13,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference OFP8 E5M2 packed matrix-matrix multiplication with float32
- * accumulator.
+ * @brief Reference packed quad-widening OFP8 E5M2 GEMM.
  *
  * @param m0 - Number of rows in each block of matrices A and C.
  * @param n0 - Number of columns in each block of matrices B and C.
@@ -41,8 +40,8 @@ extern "C" {
  * @param csc1 - Column stride between blocks of C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for packed matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized OFP8 E5M2
- * packed GEMM kernels with FP32 accumulators in SKL.
+ * This generic GEMM function defines the semantics of all optimized packed
+ * quad-widening OFP8 E5M2 GEMM kernels in SKL.
  *
  * The entries of A and B are 8-bit floating point numbers in E5M2 format,
  * type-punned as 8-bit unsigned integers.

--- a/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.h
+++ b/ref/gemm/gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc.h
@@ -23,18 +23,18 @@ extern "C" {
  * @param n1 - Number of columns in B and C as block matrices.
  * @param k1 - Number of columns in A and rows in B as block matrices.
  * @param alpha - Scalar multiplier for A * B product.
- * @param a_pack - Pointer to matrix A.
+ * @param a - Pointer to matrix A.
  * @param rsa0 - Row stride within each block of A in elements.
  * @param csa0 - Column stride within each block of A in elements.
  * @param rsa1 - Row stride between blocks of A in elements.
  * @param csa1 - Column stride between blocks of A in elements.
- * @param b_pack - Pointer to matrix B.
+ * @param b - Pointer to matrix B.
  * @param rsb0 - Row stride within each block of B in elements.
  * @param csb0 - Column stride within each block of B in elements.
  * @param rsb1 - Row stride between blocks of B in elements.
  * @param csb1 - Column stride between blocks of B in elements.
  * @param beta - Scalar multiplier for matrix C.
- * @param c_pack - Pointer to matrix C.
+ * @param c - Pointer to matrix C.
  * @param rsc0 - Row stride within each block of C in elements.
  * @param csc0 - Column stride within each block of C in elements.
  * @param rsc1 - Row stride between blocks of C in elements.
@@ -53,10 +53,10 @@ extern "C" {
  */
 void skl_gemm_f8e5m2rcprc_f8e5m2rcprc_f32rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    float alpha, const uint8_t *a_pack, size_t rsa0, size_t csa0, size_t rsa1,
-    size_t csa1, const uint8_t *b_pack, size_t rsb0, size_t csb0, size_t rsb1,
-    size_t csb1, float beta, float *c_pack, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1);
+    float alpha, const uint8_t *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const uint8_t *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, float beta, float *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/ref/gemm/gemm_i8rc_i8rc_i32rc.h
+++ b/ref/gemm/gemm_i8rc_i8rc_i32rc.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "skl-common.h"
 #include <stddef.h>
 #include <stdint.h>
 

--- a/ref/gemm/gemm_i8rc_i8rc_i32rc.h
+++ b/ref/gemm/gemm_i8rc_i8rc_i32rc.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference int8 matrix-matrix multiplication with int32 accumulator.
+ * @brief Reference quad-widening int8 GEMM.
  *
  * @param m - Number of rows in matrices A and C.
  * @param n - Number of columns in matrices B and C.
@@ -32,8 +32,8 @@ extern "C" {
  * @param csc - Column stride of matrix C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized int8 GEMM
- * kernels with int32 accumulators in SKL.
+ * This generic GEMM function defines the semantics of all optimized
+ * quad-widening int8 GEMM kernels in SKL.
  *
  * Matrices may be in row-major or column-major order, depending on the strides.
  * For row-major matrices, the column stride is 1, and the row stride is the

--- a/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -9,19 +9,19 @@
 
 SKL_FUNC void skl_gemm_i8rcprc_i8rcprc_i32rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    int32_t alpha, const int8_t *a_pack, size_t rsa0, size_t csa0, size_t rsa1,
-    size_t csa1, const int8_t *b_pack, size_t rsb0, size_t csb0, size_t rsb1,
-    size_t csb1, int32_t beta, int32_t *c_pack, size_t rsc0, size_t csc0,
+    int32_t alpha, const int8_t *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const int8_t *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, int32_t beta, int32_t *c, size_t rsc0, size_t csc0,
     size_t rsc1, size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      int32_t *cp_block = c_pack + ii1 * rsc1 + jj1 * csc1;
+      int32_t *cp_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           int32_t acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const int8_t *ap_block = a_pack + ii1 * rsa1 + kk1 * csa1;
-            const int8_t *bp_block = b_pack + kk1 * rsb1 + jj1 * csb1;
+            const int8_t *ap_block = a + ii1 * rsa1 + kk1 * csa1;
+            const int8_t *bp_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
               int8_t a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
               int8_t b_val = bp_block[kk0 * rsb0 + jj0 * csb0];

--- a/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+++ b/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
@@ -15,21 +15,21 @@ SKL_FUNC void skl_gemm_i8rcprc_i8rcprc_i32rcprc_ref(
     size_t rsc1, size_t csc1) {
   for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t jj1 = 0; jj1 < n1; ++jj1) {
-      int32_t *cp_block = c + ii1 * rsc1 + jj1 * csc1;
+      int32_t *c_block = c + ii1 * rsc1 + jj1 * csc1;
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           int32_t acc = 0;
           for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-            const int8_t *ap_block = a + ii1 * rsa1 + kk1 * csa1;
-            const int8_t *bp_block = b + kk1 * rsb1 + jj1 * csb1;
+            const int8_t *a_block = a + ii1 * rsa1 + kk1 * csa1;
+            const int8_t *b_block = b + kk1 * rsb1 + jj1 * csb1;
             for (size_t kk0 = 0; kk0 < k0; ++kk0) {
-              int8_t a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
-              int8_t b_val = bp_block[kk0 * rsb0 + jj0 * csb0];
+              int8_t a_val = a_block[ii0 * rsa0 + kk0 * csa0];
+              int8_t b_val = b_block[kk0 * rsb0 + jj0 * csb0];
               acc += (int32_t)a_val * (int32_t)b_val;
             }
           }
-          cp_block[ii0 * rsc0 + jj0 * csc0] =
-              beta * cp_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
+          c_block[ii0 * rsc0 + jj0 * csc0] =
+              beta * c_block[ii0 * rsc0 + jj0 * csc0] + alpha * acc;
         }
       }
     }

--- a/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h
+++ b/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h
@@ -22,18 +22,18 @@ extern "C" {
  * @param n1 - Number of columns in B and C as block matrices.
  * @param k1 - Number of columns in A and rows in B as block matrices.
  * @param alpha - Scalar multiplier for A * B product.
- * @param a_pack - Pointer to matrix A.
+ * @param a - Pointer to matrix A.
  * @param rsa0 - Row stride within each block of A in elements.
  * @param csa0 - Column stride within each block of A in elements.
  * @param rsa1 - Row stride between blocks of A in elements.
  * @param csa1 - Column stride between blocks of A in elements.
- * @param b_pack - Pointer to matrix B.
+ * @param b - Pointer to matrix B.
  * @param rsb0 - Row stride within each block of B in elements.
  * @param csb0 - Column stride within each block of B in elements.
  * @param rsb1 - Row stride between blocks of B in elements.
  * @param csb1 - Column stride between blocks of B in elements.
  * @param beta - Scalar multiplier for matrix C.
- * @param c_pack - Pointer to matrix C.
+ * @param c - Pointer to matrix C.
  * @param rsc0 - Row stride within each block of C in elements.
  * @param csc0 - Column stride within each block of C in elements.
  * @param rsc1 - Row stride between blocks of C in elements.
@@ -49,9 +49,9 @@ extern "C" {
  */
 void skl_gemm_i8rcprc_i8rcprc_i32rcprc_ref(
     size_t m0, size_t n0, size_t k0, size_t m1, size_t n1, size_t k1,
-    int32_t alpha, const int8_t *a_pack, size_t rsa0, size_t csa0, size_t rsa1,
-    size_t csa1, const int8_t *b_pack, size_t rsb0, size_t csb0, size_t rsb1,
-    size_t csb1, int32_t beta, int32_t *c_pack, size_t rsc0, size_t csc0,
+    int32_t alpha, const int8_t *a, size_t rsa0, size_t csa0, size_t rsa1,
+    size_t csa1, const int8_t *b, size_t rsb0, size_t csb0, size_t rsb1,
+    size_t csb1, int32_t beta, int32_t *c, size_t rsc0, size_t csc0,
     size_t rsc1, size_t csc1);
 
 #if defined(__cplusplus)

--- a/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h
+++ b/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h
@@ -12,8 +12,7 @@ extern "C" {
 #endif
 
 /**
- * @brief Reference int8 packed matrix-matrix multiplication with int32
- * accumulator.
+ * @brief Reference packed quad-widening int8 GEMM.
  *
  * @param m0 - Number of rows in each block of matrices A and C.
  * @param n0 - Number of columns in each block of matrices B and C.
@@ -40,8 +39,8 @@ extern "C" {
  * @param csc1 - Column stride between blocks of C in elements.
  *
  * Computes `C = alpha * A * B + beta * C` for packed matrices A, B, and C.
- * This generic GEMM function defines the semantics of all optimized int8 packed
- * GEMM kernels with int32 accumulators in SKL.
+ * This generic GEMM function defines the semantics of all optimized packed
+ * quad-widening int8 GEMM kernels in SKL.
  *
  * @note
  * This function is for API documentation purposes only, and should not be used

--- a/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h
+++ b/ref/gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h
@@ -3,7 +3,8 @@
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT
 
-#include "skl-common.h"
+#pragma once
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/ref/pack/transpose_e16.h
+++ b/ref/pack/transpose_e16.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "skl-common.h"
 #include <stddef.h>
 #include <stdint.h>
 

--- a/ref/pack/transpose_e32.h
+++ b/ref/pack/transpose_e32.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "skl-common.h"
 #include <stddef.h>
 #include <stdint.h>
 

--- a/ref/pack/transpose_e8.h
+++ b/ref/pack/transpose_e8.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "skl-common.h"
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/gemm/packed-gemm.md
+++ b/src/gemm/packed-gemm.md
@@ -123,14 +123,14 @@ for (size_t ii1 = 0; ii1 < m1; ++ii1) {
     for (size_t idx = 0; idx < m0 * n0; ++idx)
       acc[idx] = 0;
     for (size_t kk1 = 0; kk1 < k1; ++kk1) {
-      const <type_a>* ap_block = a + ii1 * rsa1 + kk1 * csa1;
-      const <type_b>* bp_block = b + kk1 * rsb1 + jj1 * csb1;
+      const <type_a>* a_block = a + ii1 * rsa1 + kk1 * csa1;
+      const <type_b>* b_block = b + kk1 * rsb1 + jj1 * csb1;
       // Compute block product (loops usually map to 1 instruction)
       for (size_t ii0 = 0; ii0 < m0; ++ii0) {
         for (size_t jj0 = 0; jj0 < n0; ++jj0) {
           for (size_t kk0 = 0; kk0 < k0; ++kk0) {
-            <type_a> a_val = ap_block[ii0 * rsa0 + kk0 * csa0];
-            <type_b> b_val = bp_block[kk0 * rsb0 + jj0 * csb0];
+            <type_a> a_val = a_block[ii0 * rsa0 + kk0 * csa0];
+            <type_b> b_val = b_block[kk0 * rsb0 + jj0 * csb0];
             acc[ii0 * n0 + jj0] += a_val * b_val;
           }
         }


### PR DESCRIPTION
This PR cleans up the packed GEMM kernels and tests.
Proposed changes:
- Rename `{a,b,c}_pack` simply to `{a,b,c}` in kernel APIs and in test harnesses
- Clean up comments/headers (TODO)
- Use SKL_XSFMM_TE in Xsfmm tests rather than assume ETE=64 (TODO, perhaps appropriate to make a separate PR?)

Edit: I think this will touch too many files, so I will break this up into several PRs.
- This PR will be limited to the reference kernels.
- The Xsfmm source files are already handled by the alpha/beta scaling PRs.
- Renaming `{a,b,c}_pack` to `{a,b,c}` and comment/header clean up for test harnesses will be another PR.
- If there's time, I'll open one more PR for SKL_XSFMM_TE.