### PR TITLE
[GEMM][Pack] Replace Xsfmm ABI macros

### DIFF
--- a/include/skl-common.h
+++ b/include/skl-common.h
@@ -57,29 +57,6 @@
  */
 #define SKL_FUNC_UTIL static inline
 
-/*
- * Xsfmm ABI macros:
- *
- * Placeholders for function attributes that indicate how Xsfmm matrix tile
- * state is used. These will be replaced with appropriate function attributes
- * once they are provided by the compiler.
- */
-
-/** Xsfmm state shared with caller. Function reads state but does not modify. */
-#define SKL_XSFMM_IN
-
-/**
- * Xsfmm state shared with caller. Function ignores incoming state and
- * overwrites it.
- */
-#define SKL_XSFMM_OUT
-
-/** Xsfmm state shared with caller. Function reads and modifies state. */
-#define SKL_XSFMM_INOUT
-
-/** Function creates a new scope for Xsfmm state. */
-#define SKL_XSFMM_NEW
-
 /** Portable restrict pointer qualifier for C and C++ */
 #if !defined(__cplusplus)
 #define SKL_RESTRICT restrict

--- a/src/gemm/gemm_bf16c_bf16_f32_xsfmm32a16f.c
+++ b/src/gemm/gemm_bf16c_bf16_f32_xsfmm32a16f.c
@@ -13,16 +13,16 @@
 #include "skl-common.h"
 
 typedef void (*skl_gemm_tile_zero_bf16_f32_xsfmmbase_t)(size_t tm, size_t tn)
-    SKL_XSFMM_OUT;
+    __riscv_out("xsfmm");
 
 typedef void (*skl_gemm_inner_loop_bf16rcptex1c_bf16rcp1xte_f32_xsfmm32a16f_t)(
     size_t m, size_t n, size_t k, const __bf16 *a, size_t rsa1, size_t csa1,
-    const __bf16 *b, size_t rsb1, size_t csb1) SKL_XSFMM_INOUT;
+    const __bf16 *b, size_t rsb1, size_t csb1) __riscv_inout("xsfmm");
 
 typedef void (*skl_gemm_fused_kernel_bf16_f32_f32rcptexterc_xsfmmbase_t)(
     size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1, size_t row1, size_t col1,
-    void *params) SKL_XSFMM_IN;
+    size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
+    __riscv_in("xsfmm");
 
 /* params type for the alpha/beta scaling kernel */
 typedef struct {
@@ -31,8 +31,8 @@ typedef struct {
 } skl_gemm_alpha_beta_scaling_params_bf16_f32_f32rcptexterc_xsfmmbase_t;
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt0_bf16_f32_xsfmmbase(size_t tm,
-                                               size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt0_bf16_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt0\n"
@@ -42,8 +42,8 @@ void skl_gemm_tile_zero_mt0_bf16_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt4_bf16_f32_xsfmmbase(size_t tm,
-                                               size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt4_bf16_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt4\n"
@@ -53,8 +53,8 @@ void skl_gemm_tile_zero_mt4_bf16_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt8_bf16_f32_xsfmmbase(size_t tm,
-                                               size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt8_bf16_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt8\n"
@@ -64,8 +64,8 @@ void skl_gemm_tile_zero_mt8_bf16_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt12_bf16_f32_xsfmmbase(size_t tm,
-                                                size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt12_bf16_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt12\n"
@@ -80,8 +80,8 @@ void skl_gemm_tile_zero_mt12_bf16_f32_xsfmmbase(size_t tm,
  */
 SKL_FUNC_PRIVATE
 void skl_gemm_tile_zero_bf16_f32_xsfmmbase(size_t m, size_t n, size_t tss,
-                                           size_t rstss,
-                                           size_t cstss) SKL_XSFMM_OUT {
+                                           size_t rstss, size_t cstss)
+    __riscv_out("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -119,7 +119,7 @@ void skl_gemm_tile_zero_bf16_f32_xsfmmbase(size_t m, size_t n, size_t tss,
 SKL_FUNC_PRIVATE
 void skl_gemm_tile_load_bf16_f32rcptexterc_f32_xsfmmbase(
     size_t m, size_t n, const float *c, size_t rsc0, size_t csc0, size_t rsc1,
-    size_t csc1, size_t tss, size_t rstss, size_t cstss) SKL_XSFMM_OUT {
+    size_t csc1, size_t tss, size_t rstss, size_t cstss) __riscv_out("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -191,7 +191,7 @@ void skl_gemm_apply_fused_bf16_f32_f32rcptexterc_xsfmmbase(
     size_t rsc0, size_t csc0, size_t rsc1, size_t csc1, size_t row1,
     size_t col1,
     skl_gemm_fused_kernel_bf16_f32_f32rcptexterc_xsfmmbase_t kernel,
-    void *params) SKL_XSFMM_IN {
+    void *params) __riscv_in("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -228,7 +228,7 @@ void skl_gemm_apply_fused_bf16_f32_f32rcptexterc_xsfmmbase(
 SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m8_bf16_f32_f32rc_xsfmmbase(
     size_t tm, size_t tn, float alpha, size_t tss, float beta,
     float *c, // NOLINT(readability-non-const-parameter)
-    size_t rsc0, size_t csc0) SKL_XSFMM_IN {
+    size_t rsc0, size_t csc0) __riscv_in("xsfmm") {
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -292,7 +292,7 @@ SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m8_bf16_f32_f32rc_xsfmmbase(
  */
 SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m2_bf16_f32_f32_xsfmmbase(
     size_t tm, size_t tn, float alpha, size_t tss, float beta, float *c,
-    size_t rsc0) SKL_XSFMM_IN {
+    size_t rsc0) __riscv_in("xsfmm") {
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -603,8 +603,8 @@ SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m2_bf16_f32_f32_xsfmmbase(
 SKL_FUNC_PRIVATE
 void skl_gemm_alpha_beta_scaling_bf16_f32_f32rcptexterc_xsfmmbase(
     size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1, size_t row1, size_t col1,
-    void *params) SKL_XSFMM_IN {
+    size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
+    __riscv_in("xsfmm") {
   /* Use row-major code when rsc0 == 1 if possible. */
   // Check that tss specifies the first row or column of a tile (bits 23:0).
   if (rsc0 == 1 && csc0 != 1 && ((tss & (size_t)0xFFFFFF) == 0)) {
@@ -647,7 +647,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x1_bf16rcptex1c_bf16rcp1xte_f32_xsfmm32a16f(
     size_t m, size_t n, size_t k, const __bf16 *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const __bf16 *b,
-    size_t rsb1, __attribute__((unused)) size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, __attribute__((unused)) size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -710,7 +710,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x2_bf16rcptex1c_bf16rcp1xte_f32_xsfmm32a16f(
     size_t m, size_t n, size_t k, const __bf16 *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const __bf16 *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -854,7 +854,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x3_bf16rcptex1c_bf16rcp1xte_f32_xsfmm32a16f(
     size_t m, size_t n, size_t k, const __bf16 *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const __bf16 *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1036,7 +1036,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x4_bf16rcptex1c_bf16rcp1xte_f32_xsfmm32a16f(
     size_t m, size_t n, size_t k, const __bf16 *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const __bf16 *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1250,7 +1250,7 @@ skl_gemm_inner_loop_1x4_bf16rcptex1c_bf16rcp1xte_f32_xsfmm32a16f(
 SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_2x2_bf16rcptex1c_bf16rcp1xte_f32_xsfmm32a16f(
     size_t m, size_t n, size_t k, const __bf16 *a, size_t rsa1, size_t csa1,
-    const __bf16 *b, size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    const __bf16 *b, size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1501,7 +1501,7 @@ skl_gemm_apply_tiling_bf16rcptex1c_bf16rcp1xte_f32_f32rcptexterc_xsfmm32a16f(
     const __bf16 *b, size_t rsb1, size_t csb1, float *c, size_t rsc0,
     size_t csc0, size_t rsc1, size_t csc1, size_t row1, size_t col1, bool accum,
     skl_gemm_fused_kernel_bf16_f32_f32rcptexterc_xsfmmbase_t kernel,
-    void *params) SKL_XSFMM_NEW {
+    void *params) __riscv_new("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }

--- a/src/gemm/gemm_f16c_f16_f32_xsfmm32a16f.c
+++ b/src/gemm/gemm_f16c_f16_f32_xsfmm32a16f.c
@@ -12,17 +12,17 @@
 
 #include "skl-common.h"
 
-typedef void (*skl_gemm_tile_zero_f16_f32_xsfmmbase_t)(size_t tm,
-                                                       size_t tn) SKL_XSFMM_OUT;
+typedef void (*skl_gemm_tile_zero_f16_f32_xsfmmbase_t)(size_t tm, size_t tn)
+    __riscv_out("xsfmm");
 
 typedef void (*skl_gemm_inner_loop_f16rcptex1c_f16rcp1xte_f32_xsfmm32a16f_t)(
     size_t m, size_t n, size_t k, const _Float16 *a, size_t rsa1, size_t csa1,
-    const _Float16 *b, size_t rsb1, size_t csb1) SKL_XSFMM_INOUT;
+    const _Float16 *b, size_t rsb1, size_t csb1) __riscv_inout("xsfmm");
 
 typedef void (*skl_gemm_fused_kernel_f16_f32_f32rcptexterc_xsfmmbase_t)(
     size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1, size_t row1, size_t col1,
-    void *params) SKL_XSFMM_IN;
+    size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
+    __riscv_in("xsfmm");
 
 /* params type for the alpha/beta scaling kernel */
 typedef struct {
@@ -31,8 +31,8 @@ typedef struct {
 } skl_gemm_alpha_beta_scaling_params_f16_f32_f32rcptexterc_xsfmmbase_t;
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt0_f16_f32_xsfmmbase(size_t tm,
-                                              size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt0_f16_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt0\n"
@@ -42,8 +42,8 @@ void skl_gemm_tile_zero_mt0_f16_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt4_f16_f32_xsfmmbase(size_t tm,
-                                              size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt4_f16_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt4\n"
@@ -53,8 +53,8 @@ void skl_gemm_tile_zero_mt4_f16_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt8_f16_f32_xsfmmbase(size_t tm,
-                                              size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt8_f16_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt8\n"
@@ -64,8 +64,8 @@ void skl_gemm_tile_zero_mt8_f16_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt12_f16_f32_xsfmmbase(size_t tm,
-                                               size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt12_f16_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt12\n"
@@ -80,8 +80,8 @@ void skl_gemm_tile_zero_mt12_f16_f32_xsfmmbase(size_t tm,
  */
 SKL_FUNC_PRIVATE
 void skl_gemm_tile_zero_f16_f32_xsfmmbase(size_t m, size_t n, size_t tss,
-                                          size_t rstss,
-                                          size_t cstss) SKL_XSFMM_OUT {
+                                          size_t rstss, size_t cstss)
+    __riscv_out("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -119,7 +119,7 @@ void skl_gemm_tile_zero_f16_f32_xsfmmbase(size_t m, size_t n, size_t tss,
 SKL_FUNC_PRIVATE
 void skl_gemm_tile_load_f16_f32rcptexterc_f32_xsfmmbase(
     size_t m, size_t n, const float *c, size_t rsc0, size_t csc0, size_t rsc1,
-    size_t csc1, size_t tss, size_t rstss, size_t cstss) SKL_XSFMM_OUT {
+    size_t csc1, size_t tss, size_t rstss, size_t cstss) __riscv_out("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -190,7 +190,7 @@ void skl_gemm_apply_fused_f16_f32_f32rcptexterc_xsfmmbase(
     size_t m, size_t n, size_t tss, size_t rstss, size_t cstss, float *c,
     size_t rsc0, size_t csc0, size_t rsc1, size_t csc1, size_t row1,
     size_t col1, skl_gemm_fused_kernel_f16_f32_f32rcptexterc_xsfmmbase_t kernel,
-    void *params) SKL_XSFMM_IN {
+    void *params) __riscv_in("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -227,7 +227,7 @@ void skl_gemm_apply_fused_f16_f32_f32rcptexterc_xsfmmbase(
 SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m8_f16_f32_f32rc_xsfmmbase(
     size_t tm, size_t tn, float alpha, size_t tss, float beta,
     float *c, // NOLINT(readability-non-const-parameter)
-    size_t rsc0, size_t csc0) SKL_XSFMM_IN {
+    size_t rsc0, size_t csc0) __riscv_in("xsfmm") {
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -291,7 +291,7 @@ SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m8_f16_f32_f32rc_xsfmmbase(
  */
 SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m2_f16_f32_f32_xsfmmbase(
     size_t tm, size_t tn, float alpha, size_t tss, float beta, float *c,
-    size_t rsc0) SKL_XSFMM_IN {
+    size_t rsc0) __riscv_in("xsfmm") {
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -602,8 +602,8 @@ SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m2_f16_f32_f32_xsfmmbase(
 SKL_FUNC_PRIVATE
 void skl_gemm_alpha_beta_scaling_f16_f32_f32rcptexterc_xsfmmbase(
     size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1, size_t row1, size_t col1,
-    void *params) SKL_XSFMM_IN {
+    size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
+    __riscv_in("xsfmm") {
   /* Use row-major code when rsc0 == 1 if possible. */
   // Check that tss specifies the first row or column of a tile (bits 23:0).
   if (rsc0 == 1 && csc0 != 1 && ((tss & (size_t)0xFFFFFF) == 0)) {
@@ -646,7 +646,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x1_f16rcptex1c_f16rcp1xte_f32_xsfmm32a16f(
     size_t m, size_t n, size_t k, const _Float16 *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const _Float16 *b,
-    size_t rsb1, __attribute__((unused)) size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, __attribute__((unused)) size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -709,7 +709,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x2_f16rcptex1c_f16rcp1xte_f32_xsfmm32a16f(
     size_t m, size_t n, size_t k, const _Float16 *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const _Float16 *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -853,7 +853,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x3_f16rcptex1c_f16rcp1xte_f32_xsfmm32a16f(
     size_t m, size_t n, size_t k, const _Float16 *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const _Float16 *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1035,7 +1035,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x4_f16rcptex1c_f16rcp1xte_f32_xsfmm32a16f(
     size_t m, size_t n, size_t k, const _Float16 *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const _Float16 *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1249,7 +1249,7 @@ skl_gemm_inner_loop_1x4_f16rcptex1c_f16rcp1xte_f32_xsfmm32a16f(
 SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_2x2_f16rcptex1c_f16rcp1xte_f32_xsfmm32a16f(
     size_t m, size_t n, size_t k, const _Float16 *a, size_t rsa1, size_t csa1,
-    const _Float16 *b, size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    const _Float16 *b, size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1500,7 +1500,7 @@ skl_gemm_apply_tiling_f16rcptex1c_f16rcp1xte_f32_f32rcptexterc_xsfmm32a16f(
     const _Float16 *b, size_t rsb1, size_t csb1, float *c, size_t rsc0,
     size_t csc0, size_t rsc1, size_t csc1, size_t row1, size_t col1, bool accum,
     skl_gemm_fused_kernel_f16_f32_f32rcptexterc_xsfmmbase_t kernel,
-    void *params) SKL_XSFMM_NEW {
+    void *params) __riscv_new("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }

--- a/src/gemm/gemm_f32c_f32_f32_xsfmm32a32f.c
+++ b/src/gemm/gemm_f32c_f32_f32_xsfmm32a32f.c
@@ -12,17 +12,17 @@
 
 #include "skl-common.h"
 
-typedef void (*skl_gemm_tile_zero_f32_f32_xsfmmbase_t)(size_t tm,
-                                                       size_t tn) SKL_XSFMM_OUT;
+typedef void (*skl_gemm_tile_zero_f32_f32_xsfmmbase_t)(size_t tm, size_t tn)
+    __riscv_out("xsfmm");
 
 typedef void (*skl_gemm_inner_loop_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f_t)(
     size_t m, size_t n, size_t k, const float *a, size_t rsa1, size_t csa1,
-    const float *b, size_t rsb1, size_t csb1) SKL_XSFMM_INOUT;
+    const float *b, size_t rsb1, size_t csb1) __riscv_inout("xsfmm");
 
 typedef void (*skl_gemm_fused_kernel_f32_f32_f32rcptexterc_xsfmmbase_t)(
     size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1, size_t row1, size_t col1,
-    void *params) SKL_XSFMM_IN;
+    size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
+    __riscv_in("xsfmm");
 
 /* params type for the alpha/beta scaling kernel */
 typedef struct {
@@ -31,8 +31,8 @@ typedef struct {
 } skl_gemm_alpha_beta_scaling_params_f32_f32_f32rcptexterc_xsfmmbase_t;
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt0_f32_f32_xsfmmbase(size_t tm,
-                                              size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt0_f32_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt0\n"
@@ -42,8 +42,8 @@ void skl_gemm_tile_zero_mt0_f32_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt4_f32_f32_xsfmmbase(size_t tm,
-                                              size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt4_f32_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt4\n"
@@ -53,8 +53,8 @@ void skl_gemm_tile_zero_mt4_f32_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt8_f32_f32_xsfmmbase(size_t tm,
-                                              size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt8_f32_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt8\n"
@@ -64,8 +64,8 @@ void skl_gemm_tile_zero_mt8_f32_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt12_f32_f32_xsfmmbase(size_t tm,
-                                               size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt12_f32_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt12\n"
@@ -80,8 +80,8 @@ void skl_gemm_tile_zero_mt12_f32_f32_xsfmmbase(size_t tm,
  */
 SKL_FUNC_PRIVATE
 void skl_gemm_tile_zero_f32_f32_xsfmmbase(size_t m, size_t n, size_t tss,
-                                          size_t rstss,
-                                          size_t cstss) SKL_XSFMM_OUT {
+                                          size_t rstss, size_t cstss)
+    __riscv_out("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -119,7 +119,7 @@ void skl_gemm_tile_zero_f32_f32_xsfmmbase(size_t m, size_t n, size_t tss,
 SKL_FUNC_PRIVATE
 void skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase(
     size_t m, size_t n, const float *c, size_t rsc0, size_t csc0, size_t rsc1,
-    size_t csc1, size_t tss, size_t rstss, size_t cstss) SKL_XSFMM_OUT {
+    size_t csc1, size_t tss, size_t rstss, size_t cstss) __riscv_out("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -190,7 +190,7 @@ void skl_gemm_apply_fused_f32_f32_f32rcptexterc_xsfmmbase(
     size_t m, size_t n, size_t tss, size_t rstss, size_t cstss, float *c,
     size_t rsc0, size_t csc0, size_t rsc1, size_t csc1, size_t row1,
     size_t col1, skl_gemm_fused_kernel_f32_f32_f32rcptexterc_xsfmmbase_t kernel,
-    void *params) SKL_XSFMM_IN {
+    void *params) __riscv_in("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -227,7 +227,7 @@ void skl_gemm_apply_fused_f32_f32_f32rcptexterc_xsfmmbase(
 SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m8_f32_f32_f32rc_xsfmmbase(
     size_t tm, size_t tn, float alpha, size_t tss, float beta,
     float *c, // NOLINT(readability-non-const-parameter)
-    size_t rsc0, size_t csc0) SKL_XSFMM_IN {
+    size_t rsc0, size_t csc0) __riscv_in("xsfmm") {
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -291,7 +291,7 @@ SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m8_f32_f32_f32rc_xsfmmbase(
  */
 SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m2_f32_f32_f32_xsfmmbase(
     size_t tm, size_t tn, float alpha, size_t tss, float beta, float *c,
-    size_t rsc0) SKL_XSFMM_IN {
+    size_t rsc0) __riscv_in("xsfmm") {
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -602,8 +602,8 @@ SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m2_f32_f32_f32_xsfmmbase(
 SKL_FUNC_PRIVATE
 void skl_gemm_alpha_beta_scaling_f32_f32_f32rcptexterc_xsfmmbase(
     size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1, size_t row1, size_t col1,
-    void *params) SKL_XSFMM_IN {
+    size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
+    __riscv_in("xsfmm") {
   /* Use row-major code when rsc0 == 1 if possible. */
   // Check that tss specifies the first row or column of a tile (bits 23:0).
   if (rsc0 == 1 && csc0 != 1 && ((tss & (size_t)0xFFFFFF) == 0)) {
@@ -646,7 +646,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x1_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f(
     size_t m, size_t n, size_t k, const float *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const float *b,
-    size_t rsb1, __attribute__((unused)) size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, __attribute__((unused)) size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -686,7 +686,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x2_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f(
     size_t m, size_t n, size_t k, const float *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const float *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -761,7 +761,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x3_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f(
     size_t m, size_t n, size_t k, const float *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const float *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -855,7 +855,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x4_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f(
     size_t m, size_t n, size_t k, const float *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const float *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -964,7 +964,7 @@ skl_gemm_inner_loop_1x4_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f(
 SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_2x2_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f(
     size_t m, size_t n, size_t k, const float *a, size_t rsa1, size_t csa1,
-    const float *b, size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    const float *b, size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1113,7 +1113,7 @@ skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_f32rcptexterc_xsfmm32a32f(
     const float *b, size_t rsb1, size_t csb1, float *c, size_t rsc0,
     size_t csc0, size_t rsc1, size_t csc1, size_t row1, size_t col1, bool accum,
     skl_gemm_fused_kernel_f32_f32_f32rcptexterc_xsfmmbase_t kernel,
-    void *params) SKL_XSFMM_NEW {
+    void *params) __riscv_new("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }

--- a/src/gemm/gemm_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
+++ b/src/gemm/gemm_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c
@@ -14,17 +14,17 @@
 #include "skl-common.h"
 
 typedef void (*skl_gemm_tile_zero_f8e4m3_f32_xsfmmbase_t)(size_t tm, size_t tn)
-    SKL_XSFMM_OUT;
+    __riscv_out("xsfmm");
 
 typedef void (
     *skl_gemm_inner_loop_f8e4m3rcptex1c_f8e4m3rcp1xte_f32_xsfmm32a8f_t)(
     size_t m, size_t n, size_t k, const uint8_t *a, size_t rsa1, size_t csa1,
-    const uint8_t *b, size_t rsb1, size_t csb1) SKL_XSFMM_INOUT;
+    const uint8_t *b, size_t rsb1, size_t csb1) __riscv_inout("xsfmm");
 
 typedef void (*skl_gemm_fused_kernel_f8e4m3_f32_f32rcptexterc_xsfmmbase_t)(
     size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1, size_t row1, size_t col1,
-    void *params) SKL_XSFMM_IN;
+    size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
+    __riscv_in("xsfmm");
 
 /* params type for the alpha/beta scaling kernel */
 typedef struct {
@@ -33,8 +33,8 @@ typedef struct {
 } skl_gemm_alpha_beta_scaling_params_f8e4m3_f32_f32rcptexterc_xsfmmbase_t;
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt0_f8e4m3_f32_xsfmmbase(size_t tm,
-                                                 size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt0_f8e4m3_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt0\n"
@@ -44,8 +44,8 @@ void skl_gemm_tile_zero_mt0_f8e4m3_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt4_f8e4m3_f32_xsfmmbase(size_t tm,
-                                                 size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt4_f8e4m3_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt4\n"
@@ -55,8 +55,8 @@ void skl_gemm_tile_zero_mt4_f8e4m3_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt8_f8e4m3_f32_xsfmmbase(size_t tm,
-                                                 size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt8_f8e4m3_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt8\n"
@@ -66,8 +66,8 @@ void skl_gemm_tile_zero_mt8_f8e4m3_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt12_f8e4m3_f32_xsfmmbase(size_t tm,
-                                                  size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt12_f8e4m3_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt12\n"
@@ -82,8 +82,8 @@ void skl_gemm_tile_zero_mt12_f8e4m3_f32_xsfmmbase(size_t tm,
  */
 SKL_FUNC_PRIVATE
 void skl_gemm_tile_zero_f8e4m3_f32_xsfmmbase(size_t m, size_t n, size_t tss,
-                                             size_t rstss,
-                                             size_t cstss) SKL_XSFMM_OUT {
+                                             size_t rstss, size_t cstss)
+    __riscv_out("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -121,7 +121,7 @@ void skl_gemm_tile_zero_f8e4m3_f32_xsfmmbase(size_t m, size_t n, size_t tss,
 SKL_FUNC_PRIVATE
 void skl_gemm_tile_load_f8e4m3_f32rcptexterc_f32_xsfmmbase(
     size_t m, size_t n, const float *c, size_t rsc0, size_t csc0, size_t rsc1,
-    size_t csc1, size_t tss, size_t rstss, size_t cstss) SKL_XSFMM_OUT {
+    size_t csc1, size_t tss, size_t rstss, size_t cstss) __riscv_out("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -193,7 +193,7 @@ void skl_gemm_apply_fused_f8e4m3_f32_f32rcptexterc_xsfmmbase(
     size_t rsc0, size_t csc0, size_t rsc1, size_t csc1, size_t row1,
     size_t col1,
     skl_gemm_fused_kernel_f8e4m3_f32_f32rcptexterc_xsfmmbase_t kernel,
-    void *params) SKL_XSFMM_IN {
+    void *params) __riscv_in("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -230,7 +230,7 @@ void skl_gemm_apply_fused_f8e4m3_f32_f32rcptexterc_xsfmmbase(
 SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m8_f8e4m3_f32_f32rc_xsfmmbase(
     size_t tm, size_t tn, float alpha, size_t tss, float beta,
     float *c, // NOLINT(readability-non-const-parameter)
-    size_t rsc0, size_t csc0) SKL_XSFMM_IN {
+    size_t rsc0, size_t csc0) __riscv_in("xsfmm") {
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -294,7 +294,7 @@ SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m8_f8e4m3_f32_f32rc_xsfmmbase(
  */
 SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m2_f8e4m3_f32_f32_xsfmmbase(
     size_t tm, size_t tn, float alpha, size_t tss, float beta, float *c,
-    size_t rsc0) SKL_XSFMM_IN {
+    size_t rsc0) __riscv_in("xsfmm") {
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -605,8 +605,8 @@ SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m2_f8e4m3_f32_f32_xsfmmbase(
 SKL_FUNC_PRIVATE
 void skl_gemm_alpha_beta_scaling_f8e4m3_f32_f32rcptexterc_xsfmmbase(
     size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1, size_t row1, size_t col1,
-    void *params) SKL_XSFMM_IN {
+    size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
+    __riscv_in("xsfmm") {
   /* Use row-major code when rsc0 == 1 if possible. */
   // Check that tss specifies the first row or column of a tile (bits 23:0).
   if (rsc0 == 1 && csc0 != 1 && ((tss & (size_t)0xFFFFFF) == 0)) {
@@ -649,7 +649,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x1_f8e4m3rcptex1c_f8e4m3rcp1xte_f32_xsfmm32a8f(
     size_t m, size_t n, size_t k, const uint8_t *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const uint8_t *b,
-    size_t rsb1, __attribute__((unused)) size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, __attribute__((unused)) size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -750,7 +750,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x2_f8e4m3rcptex1c_f8e4m3rcp1xte_f32_xsfmm32a8f(
     size_t m, size_t n, size_t k, const uint8_t *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const uint8_t *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1059,7 +1059,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x3_f8e4m3rcptex1c_f8e4m3rcp1xte_f32_xsfmm32a8f(
     size_t m, size_t n, size_t k, const uint8_t *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const uint8_t *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1460,7 +1460,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x4_f8e4m3rcptex1c_f8e4m3rcp1xte_f32_xsfmm32a8f(
     size_t m, size_t n, size_t k, const uint8_t *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const uint8_t *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1946,7 +1946,7 @@ skl_gemm_inner_loop_1x4_f8e4m3rcptex1c_f8e4m3rcp1xte_f32_xsfmm32a8f(
 SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_2x2_f8e4m3rcptex1c_f8e4m3rcp1xte_f32_xsfmm32a8f(
     size_t m, size_t n, size_t k, const uint8_t *a, size_t rsa1, size_t csa1,
-    const uint8_t *b, size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    const uint8_t *b, size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -2405,7 +2405,7 @@ skl_gemm_apply_tiling_f8e4m3rcptex1c_f8e4m3rcp1xte_f32_f32rcptexterc_xsfmm32a8f(
     const uint8_t *b, size_t rsb1, size_t csb1, float *c, size_t rsc0,
     size_t csc0, size_t rsc1, size_t csc1, size_t row1, size_t col1, bool accum,
     skl_gemm_fused_kernel_f8e4m3_f32_f32rcptexterc_xsfmmbase_t kernel,
-    void *params) SKL_XSFMM_NEW {
+    void *params) __riscv_new("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }

--- a/src/gemm/gemm_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
+++ b/src/gemm/gemm_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c
@@ -14,17 +14,17 @@
 #include "skl-common.h"
 
 typedef void (*skl_gemm_tile_zero_f8e5m2_f32_xsfmmbase_t)(size_t tm, size_t tn)
-    SKL_XSFMM_OUT;
+    __riscv_out("xsfmm");
 
 typedef void (
     *skl_gemm_inner_loop_f8e5m2rcptex1c_f8e5m2rcp1xte_f32_xsfmm32a8f_t)(
     size_t m, size_t n, size_t k, const uint8_t *a, size_t rsa1, size_t csa1,
-    const uint8_t *b, size_t rsb1, size_t csb1) SKL_XSFMM_INOUT;
+    const uint8_t *b, size_t rsb1, size_t csb1) __riscv_inout("xsfmm");
 
 typedef void (*skl_gemm_fused_kernel_f8e5m2_f32_f32rcptexterc_xsfmmbase_t)(
     size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1, size_t row1, size_t col1,
-    void *params) SKL_XSFMM_IN;
+    size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
+    __riscv_in("xsfmm");
 
 /* params type for the alpha/beta scaling kernel */
 typedef struct {
@@ -33,8 +33,8 @@ typedef struct {
 } skl_gemm_alpha_beta_scaling_params_f8e5m2_f32_f32rcptexterc_xsfmmbase_t;
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt0_f8e5m2_f32_xsfmmbase(size_t tm,
-                                                 size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt0_f8e5m2_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt0\n"
@@ -44,8 +44,8 @@ void skl_gemm_tile_zero_mt0_f8e5m2_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt4_f8e5m2_f32_xsfmmbase(size_t tm,
-                                                 size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt4_f8e5m2_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt4\n"
@@ -55,8 +55,8 @@ void skl_gemm_tile_zero_mt4_f8e5m2_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt8_f8e5m2_f32_xsfmmbase(size_t tm,
-                                                 size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt8_f8e5m2_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt8\n"
@@ -66,8 +66,8 @@ void skl_gemm_tile_zero_mt8_f8e5m2_f32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt12_f8e5m2_f32_xsfmmbase(size_t tm,
-                                                  size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt12_f8e5m2_f32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt12\n"
@@ -82,8 +82,8 @@ void skl_gemm_tile_zero_mt12_f8e5m2_f32_xsfmmbase(size_t tm,
  */
 SKL_FUNC_PRIVATE
 void skl_gemm_tile_zero_f8e5m2_f32_xsfmmbase(size_t m, size_t n, size_t tss,
-                                             size_t rstss,
-                                             size_t cstss) SKL_XSFMM_OUT {
+                                             size_t rstss, size_t cstss)
+    __riscv_out("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -121,7 +121,7 @@ void skl_gemm_tile_zero_f8e5m2_f32_xsfmmbase(size_t m, size_t n, size_t tss,
 SKL_FUNC_PRIVATE
 void skl_gemm_tile_load_f8e5m2_f32rcptexterc_f32_xsfmmbase(
     size_t m, size_t n, const float *c, size_t rsc0, size_t csc0, size_t rsc1,
-    size_t csc1, size_t tss, size_t rstss, size_t cstss) SKL_XSFMM_OUT {
+    size_t csc1, size_t tss, size_t rstss, size_t cstss) __riscv_out("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -193,7 +193,7 @@ void skl_gemm_apply_fused_f8e5m2_f32_f32rcptexterc_xsfmmbase(
     size_t rsc0, size_t csc0, size_t rsc1, size_t csc1, size_t row1,
     size_t col1,
     skl_gemm_fused_kernel_f8e5m2_f32_f32rcptexterc_xsfmmbase_t kernel,
-    void *params) SKL_XSFMM_IN {
+    void *params) __riscv_in("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -230,7 +230,7 @@ void skl_gemm_apply_fused_f8e5m2_f32_f32rcptexterc_xsfmmbase(
 SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m8_f8e5m2_f32_f32rc_xsfmmbase(
     size_t tm, size_t tn, float alpha, size_t tss, float beta,
     float *c, // NOLINT(readability-non-const-parameter)
-    size_t rsc0, size_t csc0) SKL_XSFMM_IN {
+    size_t rsc0, size_t csc0) __riscv_in("xsfmm") {
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -294,7 +294,7 @@ SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m8_f8e5m2_f32_f32rc_xsfmmbase(
  */
 SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m2_f8e5m2_f32_f32_xsfmmbase(
     size_t tm, size_t tn, float alpha, size_t tss, float beta, float *c,
-    size_t rsc0) SKL_XSFMM_IN {
+    size_t rsc0) __riscv_in("xsfmm") {
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -605,8 +605,8 @@ SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m2_f8e5m2_f32_f32_xsfmmbase(
 SKL_FUNC_PRIVATE
 void skl_gemm_alpha_beta_scaling_f8e5m2_f32_f32rcptexterc_xsfmmbase(
     size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1, size_t row1, size_t col1,
-    void *params) SKL_XSFMM_IN {
+    size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
+    __riscv_in("xsfmm") {
   /* Use row-major code when rsc0 == 1 if possible. */
   // Check that tss specifies the first row or column of a tile (bits 23:0).
   if (rsc0 == 1 && csc0 != 1 && ((tss & (size_t)0xFFFFFF) == 0)) {
@@ -649,7 +649,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x1_f8e5m2rcptex1c_f8e5m2rcp1xte_f32_xsfmm32a8f(
     size_t m, size_t n, size_t k, const uint8_t *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const uint8_t *b,
-    size_t rsb1, __attribute__((unused)) size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, __attribute__((unused)) size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -750,7 +750,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x2_f8e5m2rcptex1c_f8e5m2rcp1xte_f32_xsfmm32a8f(
     size_t m, size_t n, size_t k, const uint8_t *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const uint8_t *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1059,7 +1059,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x3_f8e5m2rcptex1c_f8e5m2rcp1xte_f32_xsfmm32a8f(
     size_t m, size_t n, size_t k, const uint8_t *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const uint8_t *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1460,7 +1460,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x4_f8e5m2rcptex1c_f8e5m2rcp1xte_f32_xsfmm32a8f(
     size_t m, size_t n, size_t k, const uint8_t *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const uint8_t *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1946,7 +1946,7 @@ skl_gemm_inner_loop_1x4_f8e5m2rcptex1c_f8e5m2rcp1xte_f32_xsfmm32a8f(
 SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_2x2_f8e5m2rcptex1c_f8e5m2rcp1xte_f32_xsfmm32a8f(
     size_t m, size_t n, size_t k, const uint8_t *a, size_t rsa1, size_t csa1,
-    const uint8_t *b, size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    const uint8_t *b, size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -2405,7 +2405,7 @@ skl_gemm_apply_tiling_f8e5m2rcptex1c_f8e5m2rcp1xte_f32_f32rcptexterc_xsfmm32a8f(
     const uint8_t *b, size_t rsb1, size_t csb1, float *c, size_t rsc0,
     size_t csc0, size_t rsc1, size_t csc1, size_t row1, size_t col1, bool accum,
     skl_gemm_fused_kernel_f8e5m2_f32_f32rcptexterc_xsfmmbase_t kernel,
-    void *params) SKL_XSFMM_NEW {
+    void *params) __riscv_new("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }

--- a/src/gemm/gemm_i8c_i8_i32_xsfmm32a8i.c
+++ b/src/gemm/gemm_i8c_i8_i32_xsfmm32a8i.c
@@ -13,17 +13,17 @@
 
 #include "skl-common.h"
 
-typedef void (*skl_gemm_tile_zero_i8_i32_xsfmmbase_t)(size_t tm,
-                                                      size_t tn) SKL_XSFMM_OUT;
+typedef void (*skl_gemm_tile_zero_i8_i32_xsfmmbase_t)(size_t tm, size_t tn)
+    __riscv_out("xsfmm");
 
 typedef void (*skl_gemm_inner_loop_i8rcptex1c_i8rcp1xte_i32_xsfmm32a8i_t)(
     size_t m, size_t n, size_t k, const int8_t *a, size_t rsa1, size_t csa1,
-    const int8_t *b, size_t rsb1, size_t csb1) SKL_XSFMM_INOUT;
+    const int8_t *b, size_t rsb1, size_t csb1) __riscv_inout("xsfmm");
 
 typedef void (*skl_gemm_fused_kernel_i8_i32_i32rcptexterc_xsfmmbase_t)(
     size_t tm, size_t tn, size_t tss, int32_t *c, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1, size_t row1, size_t col1,
-    void *params) SKL_XSFMM_IN;
+    size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
+    __riscv_in("xsfmm");
 
 /* params type for the alpha/beta scaling kernel */
 typedef struct {
@@ -32,8 +32,8 @@ typedef struct {
 } skl_gemm_alpha_beta_scaling_params_i8_i32_i32rcptexterc_xsfmmbase_t;
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt0_i8_i32_xsfmmbase(size_t tm,
-                                             size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt0_i8_i32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt0\n"
@@ -43,8 +43,8 @@ void skl_gemm_tile_zero_mt0_i8_i32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt4_i8_i32_xsfmmbase(size_t tm,
-                                             size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt4_i8_i32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt4\n"
@@ -54,8 +54,8 @@ void skl_gemm_tile_zero_mt4_i8_i32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt8_i8_i32_xsfmmbase(size_t tm,
-                                             size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt8_i8_i32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt8\n"
@@ -65,8 +65,8 @@ void skl_gemm_tile_zero_mt8_i8_i32_xsfmmbase(size_t tm,
 }
 
 SKL_FUNC_PRIVATE
-void skl_gemm_tile_zero_mt12_i8_i32_xsfmmbase(size_t tm,
-                                              size_t tn) SKL_XSFMM_OUT {
+void skl_gemm_tile_zero_mt12_i8_i32_xsfmmbase(size_t tm, size_t tn)
+    __riscv_out("xsfmm") {
   __asm__ volatile("sf.vsettnt x0, %[tn], e32, w1\n"
                    "sf.vsettm x0, %[tm]\n"
                    "sf.vtzero.t mt12\n"
@@ -81,8 +81,8 @@ void skl_gemm_tile_zero_mt12_i8_i32_xsfmmbase(size_t tm,
  */
 SKL_FUNC_PRIVATE
 void skl_gemm_tile_zero_i8_i32_xsfmmbase(size_t m, size_t n, size_t tss,
-                                         size_t rstss,
-                                         size_t cstss) SKL_XSFMM_OUT {
+                                         size_t rstss, size_t cstss)
+    __riscv_out("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -120,7 +120,7 @@ void skl_gemm_tile_zero_i8_i32_xsfmmbase(size_t m, size_t n, size_t tss,
 SKL_FUNC_PRIVATE
 void skl_gemm_tile_load_i8_i32rcptexterc_i32_xsfmmbase(
     size_t m, size_t n, const int32_t *c, size_t rsc0, size_t csc0, size_t rsc1,
-    size_t csc1, size_t tss, size_t rstss, size_t cstss) SKL_XSFMM_OUT {
+    size_t csc1, size_t tss, size_t rstss, size_t cstss) __riscv_out("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -191,7 +191,7 @@ void skl_gemm_apply_fused_i8_i32_i32rcptexterc_xsfmmbase(
     size_t m, size_t n, size_t tss, size_t rstss, size_t cstss, int32_t *c,
     size_t rsc0, size_t csc0, size_t rsc1, size_t csc1, size_t row1,
     size_t col1, skl_gemm_fused_kernel_i8_i32_i32rcptexterc_xsfmmbase_t kernel,
-    void *params) SKL_XSFMM_IN {
+    void *params) __riscv_in("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -228,7 +228,7 @@ void skl_gemm_apply_fused_i8_i32_i32rcptexterc_xsfmmbase(
 SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m8_i8_i32_i32rc_xsfmmbase(
     size_t tm, size_t tn, int32_t alpha, size_t tss, int32_t beta,
     int32_t *c, // NOLINT(readability-non-const-parameter)
-    size_t rsc0, size_t csc0) SKL_XSFMM_IN {
+    size_t rsc0, size_t csc0) __riscv_in("xsfmm") {
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -292,7 +292,7 @@ SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m8_i8_i32_i32rc_xsfmmbase(
  */
 SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m2_i8_i32_i32_xsfmmbase(
     size_t tm, size_t tn, int32_t alpha, size_t tss, int32_t beta, int32_t *c,
-    size_t rsc0) SKL_XSFMM_IN {
+    size_t rsc0) __riscv_in("xsfmm") {
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -603,8 +603,8 @@ SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m2_i8_i32_i32_xsfmmbase(
 SKL_FUNC_PRIVATE
 void skl_gemm_alpha_beta_scaling_i8_i32_i32rcptexterc_xsfmmbase(
     size_t tm, size_t tn, size_t tss, int32_t *c, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1, size_t row1, size_t col1,
-    void *params) SKL_XSFMM_IN {
+    size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
+    __riscv_in("xsfmm") {
   /* Use row-major code when rsc0 == 1 if possible. */
   // Check that tss specifies the first row or column of a tile (bits 23:0).
   if (rsc0 == 1 && csc0 != 1 && ((tss & (size_t)0xFFFFFF) == 0)) {
@@ -647,7 +647,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x1_i8rcptex1c_i8rcp1xte_i32_xsfmm32a8i(
     size_t m, size_t n, size_t k, const int8_t *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const int8_t *b,
-    size_t rsb1, __attribute__((unused)) size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, __attribute__((unused)) size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -748,7 +748,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x2_i8rcptex1c_i8rcp1xte_i32_xsfmm32a8i(
     size_t m, size_t n, size_t k, const int8_t *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const int8_t *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1057,7 +1057,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x3_i8rcptex1c_i8rcp1xte_i32_xsfmm32a8i(
     size_t m, size_t n, size_t k, const int8_t *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const int8_t *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1458,7 +1458,7 @@ SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_1x4_i8rcptex1c_i8rcp1xte_i32_xsfmm32a8i(
     size_t m, size_t n, size_t k, const int8_t *a,
     __attribute__((unused)) size_t rsa1, size_t csa1, const int8_t *b,
-    size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1944,7 +1944,7 @@ skl_gemm_inner_loop_1x4_i8rcptex1c_i8rcp1xte_i32_xsfmm32a8i(
 SKL_FUNC_PRIVATE void
 skl_gemm_inner_loop_2x2_i8rcptex1c_i8rcp1xte_i32_xsfmm32a8i(
     size_t m, size_t n, size_t k, const int8_t *a, size_t rsa1, size_t csa1,
-    const int8_t *b, size_t rsb1, size_t csb1) SKL_XSFMM_INOUT {
+    const int8_t *b, size_t rsb1, size_t csb1) __riscv_inout("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }
@@ -2399,8 +2399,8 @@ skl_gemm_apply_tiling_i8rcptex1c_i8rcp1xte_i32_i32rcptexterc_xsfmm32a8i(
     size_t m, size_t n, size_t k, const int8_t *a, size_t rsa1, size_t csa1,
     const int8_t *b, size_t rsb1, size_t csb1, int32_t *c, size_t rsc0,
     size_t csc0, size_t rsc1, size_t csc1, size_t row1, size_t col1, bool accum,
-    skl_gemm_fused_kernel_i8_i32_i32rcptexterc_xsfmmbase_t kernel,
-    void *params) SKL_XSFMM_NEW {
+    skl_gemm_fused_kernel_i8_i32_i32rcptexterc_xsfmmbase_t kernel, void *params)
+    __riscv_new("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }

--- a/src/pack/pack_e16_xsfmmbase.c
+++ b/src/pack/pack_e16_xsfmmbase.c
@@ -12,11 +12,10 @@
 
 #include "skl-common.h"
 
-SKL_XSFMM_NEW
 SKL_FUNC void skl_transpose_e16_xsfmmbase(size_t m, size_t n,
                                           const uint16_t *SKL_RESTRICT a,
                                           size_t rsa, uint16_t *SKL_RESTRICT at,
-                                          size_t rsat) {
+                                          size_t rsat) __riscv_new("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }

--- a/src/pack/pack_e32_xsfmmbase.c
+++ b/src/pack/pack_e32_xsfmmbase.c
@@ -21,7 +21,8 @@
  */
 SKL_FUNC_PRIVATE void
 skl_pack_tile_load_e32_e32_xsfmmbase(size_t tm, size_t tn, const uint32_t *src,
-                                     size_t rs, size_t tss) SKL_XSFMM_INOUT {
+                                     size_t rs, size_t tss)
+    __riscv_inout("xsfmm") {
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -51,7 +52,7 @@ skl_pack_tile_load_e32_e32_xsfmmbase(size_t tm, size_t tn, const uint32_t *src,
 SKL_FUNC_PRIVATE void skl_pack_tile_store_pad_bottom_e32_e32_xsfmmbase(
     size_t tm, size_t tss, size_t m0, size_t n0,
     uint32_t *dst, // NOLINT(readability-non-const-parameter)
-    size_t rs, uint32_t pad) SKL_XSFMM_IN {
+    size_t rs, uint32_t pad) __riscv_in("xsfmm") {
   if (m0 == 0 || n0 == 0) {
     return;
   }
@@ -100,7 +101,7 @@ SKL_FUNC_PRIVATE void skl_pack_tile_store_load_e32_e32_xsfmmbase(
     size_t tm_store, size_t tss_store, size_t m0, size_t n0,
     uint32_t *dst, // NOLINT(readability-non-const-parameter)
     size_t rsdst, size_t tm_load, size_t tn_load, const uint32_t *src,
-    size_t rssrc, size_t tss_load, uint32_t pad) SKL_XSFMM_INOUT {
+    size_t rssrc, size_t tss_load, uint32_t pad) __riscv_inout("xsfmm") {
   if ((m0 == 0 || n0 == 0) && (tm_load == 0 || tn_load == 0)) {
     return;
   }
@@ -198,9 +199,9 @@ SKL_FUNC_PRIVATE void skl_pack_tile_store_load_e32_e32_xsfmmbase(
 /* Set the entries of the tm x tn tile specified by tss to pad.
  * Tiles may have loaded data, so marked as INOUT.
  */
-SKL_FUNC_PRIVATE void
-skl_pack_tile_set_e32_xsfmmbase(size_t tm, size_t tn, size_t tss,
-                                uint32_t pad) SKL_XSFMM_INOUT {
+SKL_FUNC_PRIVATE void skl_pack_tile_set_e32_xsfmmbase(size_t tm, size_t tn,
+                                                      size_t tss, uint32_t pad)
+    __riscv_inout("xsfmm") {
   if (tm == 0 || tn == 0) {
     return;
   }
@@ -228,7 +229,7 @@ skl_pack_tile_set_e32_xsfmmbase(size_t tm, size_t tn, size_t tss,
 SKL_FUNC_PRIVATE void skl_pack_padding_optional_e32_e32rcptextec_xsfmmbase(
     size_t m, size_t n, const uint32_t *src, size_t rs, uint32_t *dst,
     size_t cs0, size_t rs1, size_t cs1, bool pad_right, bool pad_bottom,
-    uint32_t pad) SKL_XSFMM_NEW {
+    uint32_t pad) __riscv_new("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }

--- a/src/pack/pack_e8_xsfmmbase.c
+++ b/src/pack/pack_e8_xsfmmbase.c
@@ -12,11 +12,10 @@
 
 #include "skl-common.h"
 
-SKL_XSFMM_NEW
 SKL_FUNC void skl_transpose_e8_xsfmmbase(size_t m, size_t n,
                                          const uint8_t *SKL_RESTRICT a,
                                          size_t rsa, uint8_t *SKL_RESTRICT at,
-                                         size_t rsat) {
+                                         size_t rsat) __riscv_new("xsfmm") {
   if (m == 0 || n == 0) {
     return;
   }


### PR DESCRIPTION
This PR replaces the Xsfmm ABI macros `SKL_XSFMM_{IN,OUT,INOUT,NEW}` with the appropriate attribute `__riscv_{in,out,inout,new}("xsfmm")`.

Currently, a work in progress as some Xsfmm kernels (f8e5m2 GEMM, e8 and e16 pack/transpose) will have updated implementations soon.