### PR TITLE
[CI] Update runner for public CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,7 @@ env:
 
 jobs:
   CI:
-    runs-on:
-      group: linux-runners
-      labels: ubuntu-22.04-x64-2
+    runs-on: ubuntu-22.04
 
     env:
       SKL_TAG: v3.0.0


### PR DESCRIPTION
This PR updates the CI workflow to use a GitHub-hosted runner. It should be merged when the repo is made public.