### PR TITLE
[Infra] Add guard around `include(CPack)`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,6 @@ set(CPACK_SOURCE_IGNORE_FILES
   "*.orig$"  # Git mergetool backup files
 )
 set(CPACK_VERBATIM_VARIABLES YES)
-if(CMAKE_CPACK_INCLUDED STREQUAL 1)
+if(NOT CPack_CMake_INCLUDED STREQUAL 1)
   include(CPack)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,4 +249,6 @@ set(CPACK_SOURCE_IGNORE_FILES
   "*.orig$"  # Git mergetool backup files
 )
 set(CPACK_VERBATIM_VARIABLES YES)
-include(CPack)
+if(CMAKE_CPACK_INCLUDED STREQUAL 1)
+  include(CPack)
+endif()


### PR DESCRIPTION
This adds a guard around `include(CPack)` to only include `CPack` if it hasn't already been included. This avoids the warning
```
CPack.cmake has already been included!!
```
when using SKL as a subproject with `add_subdirectory(skl)`.

I used the value of `CPack_CMake_INCLUDED` as a check, which I can't find mentioned in the CMake documentation but looks to be the recommended check based on [the source code](https://github.com/Kitware/CMake/blob/ba5c65333755237707a386a3ded4effb71f38337/Modules/CPack.cmake#L539-L544).

There are also includes for `GNUInstallDirs` and `CMakePackageConfigHelpers`, which I haven't noticed causing issues but we could consider adding guards for also. Or maybe these files have internal include guards?