### PR TITLE
[GEMM] Add Zvdot4a8i GEMM kernels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ add_skl_src(src/gemm/xsfmm/gemm_f8e4m3c_f8e4m3_f32_xsfmm32a8f.c "xsfmm32a8f")
 add_skl_src(src/gemm/xsfmm/gemm_f8e5m2c_f8e5m2_f32_xsfmm32a8f.c "xsfmm32a8f")
 add_skl_src(src/gemm/xsfmm/gemm_i8c_i8_i32_xsfmm32a8i.c "xsfmm32a8i")
 add_skl_src(src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.c "xsfvqdotq")
+add_skl_src(src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i.c "zvdot4a8i")
 
 add_skl_src(src/logistic/logistic_bf16_xsfvfbfa.c "xsfvfbfa")
 add_skl_src(src/logistic/logistic_bf16_xsfvfbfexp16e_xsfvfbfa.c "xsfvfbfexp16e;xsfvfbfa")

--- a/cmake/detect_riscv_extensions.cmake
+++ b/cmake/detect_riscv_extensions.cmake
@@ -88,6 +88,7 @@ detect_riscv_extension("xsfvfexp16e" "x-xsfvfexp16e=true")
 detect_riscv_extension("xsfvfbfexp16e" "x-xsfvfbfexp16e=true")
 detect_riscv_extension("xsfvfexp32e" "x-xsfvfexp32e=true")
 detect_riscv_extension("xsfvqdotq" "x-xsfvqdotq=true")
+detect_riscv_extension("zvdot4a8i" "x-zvdot4a8i=true")
 
 string(JOIN "," SKL_QEMU_CPU_OPTIONS ${SKL_QEMU_CPU_OPTIONS})
 set(SKL_QEMU_OPTIONS -cpu ${SKL_QEMU_CPU_OPTIONS})

--- a/cmake/riscv.cmake
+++ b/cmake/riscv.cmake
@@ -30,6 +30,7 @@ set(SKL_ARCH_EXTENSIONS
   # zvfofp8min0p2
   # zvfofp4min0p1
   # xsfvqdotq
+  # zvdot4a8i0p1
   zvfbfmin
   zvfbfwma
   zihintntl

--- a/include/skl.h
+++ b/include/skl.h
@@ -59,6 +59,10 @@
 #include "gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_xsfvqdotq.h"
 #endif
 
+#if defined(__riscv_zvdot4a8i)
+#include "gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i.h"
+#endif
+
 /*
  * Exponential Function Kernels
  */

--- a/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i.c
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
 // Licensed under the MIT License.
 // See LICENSE file in the project root for full license information.
 // SPDX-License-Identifier: MIT

--- a/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i.c
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i.c
@@ -1,0 +1,727 @@
+// Copyright (c) 2025-2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#if !defined(__riscv_zve32x)
+#error This source file requires compiler support for the RISC-V Zve32x extension.
+#endif
+
+#if !defined(__riscv_zvdot4a8i)
+#error This source file requires compiler support for the Zvdot4a8i extension.
+#endif
+
+#include <riscv_vector.h>
+#include <sifive_vector.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "skl-common.h"
+
+#if defined(__riscv_zihintntl)
+#define NTL_P1 "ntl.p1\n"
+#else
+#define NTL_P1
+#endif
+
+// a is 4-byte aligned and rsa1 and csa1 are multiples of 4
+SKL_FUNC_PRIVATE void skl_gemm_6xm4_aligned_i8rcp1x4_i8p4x1c_i32_zvdot4a8i(
+    size_t n, size_t k1, int32_t alpha, const int8_t *a, size_t rsa1,
+    size_t csa1, const int8_t *b, size_t rsb1, int32_t beta, int32_t *c,
+    size_t rsc) {
+  if (n == 0) {
+    return;
+  }
+
+  vint32m4_t vec0 = __riscv_vmv_v_x_i32m4(0, n);
+  vint32m4_t vec1 = __riscv_vmv_v_x_i32m4(0, n);
+  vint32m4_t vec2 = __riscv_vmv_v_x_i32m4(0, n);
+  vint32m4_t vec3 = __riscv_vmv_v_x_i32m4(0, n);
+  vint32m4_t vec4 = __riscv_vmv_v_x_i32m4(0, n);
+  vint32m4_t vec5 = __riscv_vmv_v_x_i32m4(0, n);
+
+  const int8_t *a0 = a + 0 * rsa1;
+  const int8_t *a1 = a + 1 * rsa1;
+
+  if (k1) {
+    uint32_t a0_0;
+    uint32_t a0_1;
+    uint32_t a0_2;
+    uint32_t a0_3;
+    uint32_t a0_4;
+    uint32_t a0_5;
+    uint32_t a1_0;
+    uint32_t a1_1;
+    uint32_t a1_2;
+    uint32_t a1_3;
+    uint32_t a1_4;
+    uint32_t a1_5;
+    vint8m4_t bvec0;
+    vint8m4_t bvec1;
+
+    __asm__ volatile(
+        // clang-format off
+        NTL_P1
+        "lw %[a0_0], 0(%[a0])\n"
+        "add %[a0], %[a0], %[rsa1_0]\n"
+
+        NTL_P1
+        "lw %[a0_1], 0(%[a1])\n"
+        "add %[a1], %[a1], %[rsa1_0]\n"
+
+        NTL_P1
+        "lw %[a0_2], 0(%[a0])\n"
+        "add %[a0], %[a0], %[rsa1_0]\n"
+
+        NTL_P1
+        "lw %[a0_3], 0(%[a1])\n"
+        "add %[a1], %[a1], %[rsa1_0]\n"
+
+        NTL_P1
+        "lw %[a0_4], 0(%[a0])\n"
+        "add %[a0], %[a0], %[rsa1_1]\n"
+
+        NTL_P1
+        "lw %[a0_5], 0(%[a1])\n"
+        "add %[a1], %[a1], %[rsa1_1]\n"
+
+        // load first B tile (4xn)
+        "vsetvli x0, %[n4], e8, m4, ta, ma\n"
+        "vle8.v %[bvec0], (%[b])\n"
+        "add %[b], %[b], %[rsb1]\n"
+        // clang-format on
+        : [bvec0] "=&vr"(bvec0), [a0_0] "=&r"(a0_0), [a0_1] "=&r"(a0_1),
+          [a0_2] "=&r"(a0_2), [a0_3] "=&r"(a0_3), [a0_4] "=&r"(a0_4),
+          [a0_5] "=&r"(a0_5), [a0] "+&r"(a0), [a1] "+&r"(a1), [b] "+&r"(b)
+        : [rsa1_0] "rI"(2 * rsa1 * sizeof(int8_t)),
+          [rsa1_1] "rI"(csa1 - 4 * rsa1 * sizeof(int8_t)),
+          [rsb1] "rI"(rsb1 * sizeof(int8_t)), [n4] "r"(4 * n)
+        : "vl", "vtype", "memory");
+
+    while (k1 >= 3) {
+      __asm__ volatile(
+          // clang-format off
+          NTL_P1
+          "lw %[a1_0], 0(%[a0])\n"
+          "add %[a0], %[a0], %[rsa1_0]\n"
+
+          NTL_P1
+          "lw %[a1_1], 0(%[a1])\n"
+          "add %[a1], %[a1], %[rsa1_0]\n"
+
+          NTL_P1
+          "lw %[a1_2], 0(%[a0])\n"
+          "add %[a0], %[a0], %[rsa1_0]\n"
+
+          NTL_P1
+          "lw %[a1_3], 0(%[a1])\n"
+          "add %[a1], %[a1], %[rsa1_0]\n"
+
+          NTL_P1
+          "lw %[a1_4], 0(%[a0])\n"
+          "add %[a0], %[a0], %[rsa1_1]\n"
+
+          NTL_P1
+          "lw %[a1_5], 0(%[a1])\n"
+          "add %[a1], %[a1], %[rsa1_1]\n"
+
+          // load second B tile (4xn)
+          "vsetvli x0, %[n4], e8, m4, ta, ma\n"
+          "vle8.v %[bvec1], (%[b])\n"
+          "add %[b], %[b], %[rsb1]\n"
+
+          // compute first tile
+          "vsetvli x0, %[n], e32, m4, ta, ma\n"
+          "vdot4a.vx %[vec0], %[bvec0], %[a0_0]\n"
+          "vdot4a.vx %[vec1], %[bvec0], %[a0_1]\n"
+          "vdot4a.vx %[vec2], %[bvec0], %[a0_2]\n"
+          "vdot4a.vx %[vec3], %[bvec0], %[a0_3]\n"
+          "vdot4a.vx %[vec4], %[bvec0], %[a0_4]\n"
+          "vdot4a.vx %[vec5], %[bvec0], %[a0_5]\n"
+
+          NTL_P1
+          "lw %[a0_0], 0(%[a0])\n"
+          "add %[a0], %[a0], %[rsa1_0]\n"
+
+          NTL_P1
+          "lw %[a0_1], 0(%[a1])\n"
+          "add %[a1], %[a1], %[rsa1_0]\n"
+
+          NTL_P1
+          "lw %[a0_2], 0(%[a0])\n"
+          "add %[a0], %[a0], %[rsa1_0]\n"
+
+          NTL_P1
+          "lw %[a0_3], 0(%[a1])\n"
+          "add %[a1], %[a1], %[rsa1_0]\n"
+
+          NTL_P1
+          "lw %[a0_4], 0(%[a0])\n"
+          "add %[a0], %[a0], %[rsa1_1]\n"
+
+          NTL_P1
+          "lw %[a0_5], 0(%[a1])\n"
+          "add %[a1], %[a1], %[rsa1_1]\n"
+
+          // pre-load first B tile (4xn) of next iteration
+          "vsetvli x0, %[n4], e8, m4, ta, ma\n"
+          "vle8.v %[bvec0], (%[b])\n"
+          "add %[b], %[b], %[rsb1]\n"
+
+          // compute second tile
+          "vsetvli x0, %[n], e32, m4, ta, ma\n"
+          "vdot4a.vx %[vec0], %[bvec1], %[a1_0]\n"
+          "vdot4a.vx %[vec1], %[bvec1], %[a1_1]\n"
+          "vdot4a.vx %[vec2], %[bvec1], %[a1_2]\n"
+          "vdot4a.vx %[vec3], %[bvec1], %[a1_3]\n"
+          "vdot4a.vx %[vec4], %[bvec1], %[a1_4]\n"
+          "vdot4a.vx %[vec5], %[bvec1], %[a1_5]\n"
+          // clang-format on
+          : [vec0] "+&vr"(vec0), [vec1] "+&vr"(vec1), [vec2] "+&vr"(vec2),
+            [vec3] "+&vr"(vec3), [vec4] "+&vr"(vec4), [vec5] "+&vr"(vec5),
+            [bvec0] "+&vr"(bvec0), [bvec1] "=&vr"(bvec1), [a0_0] "+&r"(a0_0),
+            [a0_1] "+&r"(a0_1), [a0_2] "+&r"(a0_2), [a0_3] "+&r"(a0_3),
+            [a0_4] "+&r"(a0_4), [a0_5] "+&r"(a0_5), [a1_0] "=&r"(a1_0),
+            [a1_1] "=&r"(a1_1), [a1_2] "=&r"(a1_2), [a1_3] "=&r"(a1_3),
+            [a1_4] "=&r"(a1_4), [a1_5] "=&r"(a1_5), [a0] "+&r"(a0),
+            [a1] "+&r"(a1), [b] "+&r"(b)
+          : [rsa1_0] "rI"(2 * rsa1 * sizeof(int8_t)),
+            [rsa1_1] "rI"(csa1 - 4 * rsa1 * sizeof(int8_t)),
+            [rsb1] "rI"(rsb1 * sizeof(int8_t)), [n] "r"(n), [n4] "r"(4 * n)
+          : "vl", "vtype", "memory");
+
+      k1 -= 2;
+    }
+
+    if (k1 == 2) {
+      __asm__ volatile(
+          // clang-format off
+          NTL_P1
+          "lw %[a1_0], 0(%[a0])\n"
+          "add %[a0], %[a0], %[rsa1_0]\n"
+
+          NTL_P1
+          "lw %[a1_1], 0(%[a1])\n"
+          "add %[a1], %[a1], %[rsa1_0]\n"
+
+          NTL_P1
+          "lw %[a1_2], 0(%[a0])\n"
+          "add %[a0], %[a0], %[rsa1_0]\n"
+
+          NTL_P1
+          "lw %[a1_3], 0(%[a1])\n"
+          "add %[a1], %[a1], %[rsa1_0]\n"
+
+          NTL_P1
+          "lw %[a1_4], 0(%[a0])\n"
+          "add %[a0], %[a0], %[rsa1_1]\n"
+
+          NTL_P1
+          "lw %[a1_5], 0(%[a1])\n"
+          "add %[a1], %[a1], %[rsa1_1]\n"
+
+          // load second B tile (4xn)
+          "vsetvli x0, %[n4], e8, m4, ta, ma\n"
+          "vle8.v %[bvec1], (%[b])\n"
+          "add %[b], %[b], %[rsb1]\n"
+
+          // compute first tile
+          "vsetvli x0, %[n], e32, m4, ta, ma\n"
+          "vdot4a.vx %[vec0], %[bvec0], %[a0_0]\n"
+          "vdot4a.vx %[vec1], %[bvec0], %[a0_1]\n"
+          "vdot4a.vx %[vec2], %[bvec0], %[a0_2]\n"
+          "vdot4a.vx %[vec3], %[bvec0], %[a0_3]\n"
+          "vdot4a.vx %[vec4], %[bvec0], %[a0_4]\n"
+          "vdot4a.vx %[vec5], %[bvec0], %[a0_5]\n"
+
+          // compute second tile
+          "vdot4a.vx %[vec0], %[bvec1], %[a1_0]\n"
+          "vdot4a.vx %[vec1], %[bvec1], %[a1_1]\n"
+          "vdot4a.vx %[vec2], %[bvec1], %[a1_2]\n"
+          "vdot4a.vx %[vec3], %[bvec1], %[a1_3]\n"
+          "vdot4a.vx %[vec4], %[bvec1], %[a1_4]\n"
+          "vdot4a.vx %[vec5], %[bvec1], %[a1_5]\n"
+          // clang-format on
+          : [vec0] "+&vr"(vec0), [vec1] "+&vr"(vec1), [vec2] "+&vr"(vec2),
+            [vec3] "+&vr"(vec3), [vec4] "+&vr"(vec4), [vec5] "+&vr"(vec5),
+            [bvec1] "=&vr"(bvec1), [a1_0] "=&r"(a1_0), [a1_1] "=&r"(a1_1),
+            [a1_2] "=&r"(a1_2), [a1_3] "=&r"(a1_3), [a1_4] "=&r"(a1_4),
+            [a1_5] "=&r"(a1_5), [a0] "+&r"(a0), [a1] "+&r"(a1), [b] "+&r"(b)
+          : [bvec0] "vr"(bvec0), [a0_0] "r"(a0_0), [a0_1] "r"(a0_1),
+            [a0_2] "r"(a0_2), [a0_3] "r"(a0_3), [a0_4] "r"(a0_4),
+            [a0_5] "r"(a0_5), [rsa1_0] "rI"(2 * rsa1 * sizeof(int8_t)),
+            [rsa1_1] "rI"(csa1 - 4 * rsa1 * sizeof(int8_t)),
+            [rsb1] "rI"(rsb1 * sizeof(int8_t)), [n] "r"(n), [n4] "r"(4 * n)
+          : "vl", "vtype", "memory");
+    } else { // k1 == 1
+      __asm__ volatile(
+          // compute first tile
+          "vsetvli x0, %[n], e32, m4, ta, ma\n"
+          "vdot4a.vx %[vec0], %[bvec0], %[a0_0]\n"
+          "vdot4a.vx %[vec1], %[bvec0], %[a0_1]\n"
+          "vdot4a.vx %[vec2], %[bvec0], %[a0_2]\n"
+          "vdot4a.vx %[vec3], %[bvec0], %[a0_3]\n"
+          "vdot4a.vx %[vec4], %[bvec0], %[a0_4]\n"
+          "vdot4a.vx %[vec5], %[bvec0], %[a0_5]\n"
+          : [vec0] "+&vr"(vec0), [vec1] "+&vr"(vec1), [vec2] "+&vr"(vec2),
+            [vec3] "+&vr"(vec3), [vec4] "+&vr"(vec4), [vec5] "+&vr"(vec5)
+          : [bvec0] "vr"(bvec0), [a0_0] "r"(a0_0), [a0_1] "r"(a0_1),
+            [a0_2] "r"(a0_2), [a0_3] "r"(a0_3), [a0_4] "r"(a0_4),
+            [a0_5] "r"(a0_5), [n] "r"(n)
+          : "vl", "vtype");
+    }
+  }
+
+  if (beta != 0) {
+    if (alpha != 1) {
+      vec0 = __riscv_vmul_vx_i32m4(vec0, alpha, n);
+      vec1 = __riscv_vmul_vx_i32m4(vec1, alpha, n);
+      vec2 = __riscv_vmul_vx_i32m4(vec2, alpha, n);
+      vec3 = __riscv_vmul_vx_i32m4(vec3, alpha, n);
+      vec4 = __riscv_vmul_vx_i32m4(vec4, alpha, n);
+      vec5 = __riscv_vmul_vx_i32m4(vec5, alpha, n);
+    }
+    int32_t *c_read = c;
+    vint32m4_t cvec0 = __riscv_vle32_v_i32m4(c_read, n);
+    c_read += rsc;
+    vec0 = __riscv_vmacc_vx_i32m4(vec0, beta, cvec0, n);
+
+    vint32m4_t cvec1 = __riscv_vle32_v_i32m4(c_read, n);
+    c_read += rsc;
+    vec1 = __riscv_vmacc_vx_i32m4(vec1, beta, cvec1, n);
+
+    vint32m4_t cvec2 = __riscv_vle32_v_i32m4(c_read, n);
+    c_read += rsc;
+    vec2 = __riscv_vmacc_vx_i32m4(vec2, beta, cvec2, n);
+
+    vint32m4_t cvec3 = __riscv_vle32_v_i32m4(c_read, n);
+    c_read += rsc;
+    vec3 = __riscv_vmacc_vx_i32m4(vec3, beta, cvec3, n);
+
+    vint32m4_t cvec4 = __riscv_vle32_v_i32m4(c_read, n);
+    c_read += rsc;
+    vec4 = __riscv_vmacc_vx_i32m4(vec4, beta, cvec4, n);
+
+    vint32m4_t cvec5 = __riscv_vle32_v_i32m4(c_read, n);
+    vec5 = __riscv_vmacc_vx_i32m4(vec5, beta, cvec5, n);
+  } else {
+    if (alpha != 1) {
+      vec0 = __riscv_vmul_vx_i32m4(vec0, alpha, n);
+      vec1 = __riscv_vmul_vx_i32m4(vec1, alpha, n);
+      vec2 = __riscv_vmul_vx_i32m4(vec2, alpha, n);
+      vec3 = __riscv_vmul_vx_i32m4(vec3, alpha, n);
+      vec4 = __riscv_vmul_vx_i32m4(vec4, alpha, n);
+      vec5 = __riscv_vmul_vx_i32m4(vec5, alpha, n);
+    }
+  }
+
+  // write result back to C tile
+  __riscv_vse32_v_i32m4(c, vec0, n);
+  c += rsc;
+  __riscv_vse32_v_i32m4(c, vec1, n);
+  c += rsc;
+  __riscv_vse32_v_i32m4(c, vec2, n);
+  c += rsc;
+  __riscv_vse32_v_i32m4(c, vec3, n);
+  c += rsc;
+  __riscv_vse32_v_i32m4(c, vec4, n);
+  c += rsc;
+  __riscv_vse32_v_i32m4(c, vec5, n);
+}
+
+// a is 4-byte aligned and rsa1 and csa1 are multiples of 4
+SKL_FUNC_PRIVATE void skl_gemm_lt6xm4_aligned_i8rcp1x4_i8p4x1c_i32_zvdot4a8i(
+    size_t m, size_t n, size_t k1, int32_t alpha, const int8_t *a, size_t rsa1,
+    size_t csa1, const int8_t *b, size_t rsb1, int32_t beta, int32_t *c,
+    size_t rsc) {
+  if (m == 0 || n == 0) {
+    return;
+  }
+
+  vint32m4_t vec0 = __riscv_vmv_v_x_i32m4(0, n);
+  vint32m4_t vec1 = __riscv_vmv_v_x_i32m4(0, n);
+  vint32m4_t vec2 = __riscv_vmv_v_x_i32m4(0, n);
+  vint32m4_t vec3 = __riscv_vmv_v_x_i32m4(0, n);
+  vint32m4_t vec4 = __riscv_vmv_v_x_i32m4(0, n);
+
+  const int8_t *a0 = a + 0 * rsa1;
+  const int8_t *a1 = a + 1 * rsa1;
+  const int8_t *a2 = a + 2 * rsa1;
+  const int8_t *a3 = a + 3 * rsa1;
+  const int8_t *a4 = a + 4 * rsa1;
+
+  // compute 1 micro-tile at once
+  while (k1) {
+    // load one B tile (4xn)
+    vint8m4_t bvec = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
+
+    // compute micro-tile
+    switch (m) {
+    case 5:
+      vec4 = __riscv_vdot4a_vx_i32m4(vec4, bvec, *(uint32_t *)a4, n);
+      a4 += csa1;
+      __attribute__((fallthrough));
+    case 4:
+      vec3 = __riscv_vdot4a_vx_i32m4(vec3, bvec, *(uint32_t *)a3, n);
+      a3 += csa1;
+      __attribute__((fallthrough));
+    case 3:
+      vec2 = __riscv_vdot4a_vx_i32m4(vec2, bvec, *(uint32_t *)a2, n);
+      a2 += csa1;
+      __attribute__((fallthrough));
+    case 2:
+      vec1 = __riscv_vdot4a_vx_i32m4(vec1, bvec, *(uint32_t *)a1, n);
+      a1 += csa1;
+      __attribute__((fallthrough));
+    case 1:
+      vec0 = __riscv_vdot4a_vx_i32m4(vec0, bvec, *(uint32_t *)a0, n);
+      a0 += csa1;
+      __attribute__((fallthrough));
+    default:
+      break;
+    }
+
+    k1 -= 1;
+  }
+
+  if (beta != 0) {
+    if (alpha != 1) {
+      switch (m) {
+      case 5:
+        vec4 = __riscv_vmul_vx_i32m4(vec4, alpha, n);
+        __attribute__((fallthrough));
+      case 4:
+        vec3 = __riscv_vmul_vx_i32m4(vec3, alpha, n);
+        __attribute__((fallthrough));
+      case 3:
+        vec2 = __riscv_vmul_vx_i32m4(vec2, alpha, n);
+        __attribute__((fallthrough));
+      case 2:
+        vec1 = __riscv_vmul_vx_i32m4(vec1, alpha, n);
+        __attribute__((fallthrough));
+      case 1:
+        vec0 = __riscv_vmul_vx_i32m4(vec0, alpha, n);
+        __attribute__((fallthrough));
+      default:
+        break;
+      }
+    }
+
+    int32_t *c_read = c + (m - 1) * rsc;
+    // NOLINTBEGIN(clang-analyzer-deadcode.DeadStores)
+    vint32m4_t cvec0 = __riscv_vundefined_i32m4();
+    vint32m4_t cvec1 = __riscv_vundefined_i32m4();
+    vint32m4_t cvec2 = __riscv_vundefined_i32m4();
+    vint32m4_t cvec3 = __riscv_vundefined_i32m4();
+    vint32m4_t cvec4 = __riscv_vundefined_i32m4();
+    // NOLINTEND(clang-analyzer-deadcode.DeadStores)
+    switch (m) {
+    case 5:
+      cvec4 = __riscv_vle32_v_i32m4(c_read, n);
+      c_read -= rsc;
+      vec4 = __riscv_vmacc_vx_i32m4(vec4, beta, cvec4, n);
+      __attribute__((fallthrough));
+    case 4:
+      cvec3 = __riscv_vle32_v_i32m4(c_read, n);
+      c_read -= rsc;
+      vec3 = __riscv_vmacc_vx_i32m4(vec3, beta, cvec3, n);
+      __attribute__((fallthrough));
+    case 3:
+      cvec2 = __riscv_vle32_v_i32m4(c_read, n);
+      c_read -= rsc;
+      vec2 = __riscv_vmacc_vx_i32m4(vec2, beta, cvec2, n);
+      __attribute__((fallthrough));
+    case 2:
+      cvec1 = __riscv_vle32_v_i32m4(c_read, n);
+      c_read -= rsc;
+      vec1 = __riscv_vmacc_vx_i32m4(vec1, beta, cvec1, n);
+      __attribute__((fallthrough));
+    case 1:
+      cvec0 = __riscv_vle32_v_i32m4(c_read, n);
+      vec0 = __riscv_vmacc_vx_i32m4(vec0, beta, cvec0, n);
+      __attribute__((fallthrough));
+    default:
+      break;
+    }
+  } else {
+    if (alpha != 1) {
+      switch (m) {
+      case 5:
+        vec4 = __riscv_vmul_vx_i32m4(vec4, alpha, n);
+        __attribute__((fallthrough));
+      case 4:
+        vec3 = __riscv_vmul_vx_i32m4(vec3, alpha, n);
+        __attribute__((fallthrough));
+      case 3:
+        vec2 = __riscv_vmul_vx_i32m4(vec2, alpha, n);
+        __attribute__((fallthrough));
+      case 2:
+        vec1 = __riscv_vmul_vx_i32m4(vec1, alpha, n);
+        __attribute__((fallthrough));
+      case 1:
+        vec0 = __riscv_vmul_vx_i32m4(vec0, alpha, n);
+        __attribute__((fallthrough));
+      default:
+        break;
+      }
+    }
+  }
+
+  // write result back to C tile
+  c += (m - 1) * rsc;
+  switch (m) {
+  case 5:
+    __riscv_vse32_v_i32m4(c, vec4, n);
+    c -= rsc;
+    __attribute__((fallthrough));
+  case 4:
+    __riscv_vse32_v_i32m4(c, vec3, n);
+    c -= rsc;
+    __attribute__((fallthrough));
+  case 3:
+    __riscv_vse32_v_i32m4(c, vec2, n);
+    c -= rsc;
+    __attribute__((fallthrough));
+  case 2:
+    __riscv_vse32_v_i32m4(c, vec1, n);
+    c -= rsc;
+    __attribute__((fallthrough));
+  case 1:
+    __riscv_vse32_v_i32m4(c, vec0, n);
+    __attribute__((fallthrough));
+  default:
+    break;
+  }
+}
+
+// a need not be 4-byte-aligned nor csa1 a multiple of 4
+SKL_FUNC_PRIVATE void skl_gemm_1xm4_unaligned_i8rcp1x4_i8p4x1c_i32_zvdot4a8i(
+    size_t n, size_t k1, int32_t alpha, const int8_t *a, size_t csa1,
+    const int8_t *b, size_t rsb1, int32_t beta, int32_t *c) {
+  if (n == 0) {
+    return;
+  }
+
+  // init 1 int32m4_t accumulator
+  vint32m4_t vec0 = __riscv_vmv_v_x_i32m4(0, n);
+
+  uint32_t a0;
+
+  while (k1) {
+    // load 1 word from A
+    skl_memcpy(&a0, a, 4);
+    a += csa1;
+
+    // load 1 B tile (4xn)
+    vint8m4_t bvec0 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
+
+    vec0 = __riscv_vdot4a_vx_i32m4(vec0, bvec0, a0, n);
+
+    k1 -= 1;
+  }
+
+  if (beta != 0) {
+    if (alpha != 1) {
+      vec0 = __riscv_vmul_vx_i32m4(vec0, alpha, n);
+    }
+    int32_t *c_read = c;
+    vint32m4_t cvec = __riscv_vle32_v_i32m4(c_read, n);
+    vec0 = __riscv_vmacc_vx_i32m4(vec0, beta, cvec, n);
+  } else {
+    if (alpha != 1) {
+      vec0 = __riscv_vmul_vx_i32m4(vec0, alpha, n);
+    }
+  }
+
+  __riscv_vse32_v_i32m4(c, vec0, n);
+}
+
+// a is 4-byte aligned and csa1 is a multiple of 4
+SKL_FUNC_PRIVATE void skl_gemm_1xm4_aligned_i8rcp1x4_i8p4x1c_i32_zvdot4a8i(
+    size_t n, size_t k1, int32_t alpha, const int8_t *a, size_t csa1,
+    const int8_t *b, size_t rsb1, int32_t beta, int32_t *c) {
+  if (n == 0) {
+    return;
+  }
+
+  // init 2 int32m4_t accumulators
+  vint32m4_t vec0 = __riscv_vmv_v_x_i32m4(0, n);
+  vint32m4_t vec1 = __riscv_vmv_v_x_i32m4(0, n);
+
+  while (k1 >= 4) {
+    // load 4 words from A
+    uint32_t a0 = *(uint32_t *)a;
+    a += csa1;
+    uint32_t a1 = *(uint32_t *)a;
+    a += csa1;
+    uint32_t a2 = *(uint32_t *)a;
+    a += csa1;
+    uint32_t a3 = *(uint32_t *)a;
+    a += csa1;
+
+    // load 4 B tiles (4xn)
+    vint8m4_t bvec0 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
+    vint8m4_t bvec1 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
+    vint8m4_t bvec2 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
+    vint8m4_t bvec3 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
+
+    vec0 = __riscv_vdot4a_vx_i32m4(vec0, bvec0, a0, n);
+    vec1 = __riscv_vdot4a_vx_i32m4(vec1, bvec1, a1, n);
+    vec0 = __riscv_vdot4a_vx_i32m4(vec0, bvec2, a2, n);
+    vec1 = __riscv_vdot4a_vx_i32m4(vec1, bvec3, a3, n);
+
+    k1 -= 4;
+  }
+
+  while (k1 >= 2) {
+    // load 2 words from A
+    uint32_t a0 = *(uint32_t *)a;
+    a += csa1;
+    uint32_t a1 = *(uint32_t *)a;
+    a += csa1;
+
+    // load 2 B tiles (4xn)
+    vint8m4_t bvec0 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
+    vint8m4_t bvec1 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
+
+    vec0 = __riscv_vdot4a_vx_i32m4(vec0, bvec0, a0, n);
+    vec1 = __riscv_vdot4a_vx_i32m4(vec1, bvec1, a1, n);
+
+    k1 -= 2;
+  }
+
+  while (k1) {
+    // load 1 word from A
+    uint32_t a0 = *(uint32_t *)a;
+    a += csa1;
+
+    // load 1 B tile (4xn)
+    vint8m4_t bvec0 = __riscv_vle8_v_i8m4(b, 4 * n);
+    b += rsb1;
+
+    vec0 = __riscv_vdot4a_vx_i32m4(vec0, bvec0, a0, n);
+
+    k1 -= 1;
+  }
+
+  vec0 = __riscv_vadd_vv_i32m4(vec0, vec1, n);
+
+  if (beta != 0) {
+    if (alpha != 1) {
+      vec0 = __riscv_vmul_vx_i32m4(vec0, alpha, n);
+    }
+    int32_t *c_read = c;
+    vint32m4_t cvec = __riscv_vle32_v_i32m4(c_read, n);
+    vec0 = __riscv_vmacc_vx_i32m4(vec0, beta, cvec, n);
+  } else {
+    if (alpha != 1) {
+      vec0 = __riscv_vmul_vx_i32m4(vec0, alpha, n);
+    }
+  }
+
+  __riscv_vse32_v_i32m4(c, vec0, n);
+}
+
+SKL_FUNC_PRIVATE void skl_gemm_aligned_i8rcp1x4_i8p4x1c_i32_zvdot4a8i(
+    size_t m, size_t n, size_t k1, int32_t alpha, const int8_t *a, size_t rsa1,
+    size_t csa1, const int8_t *b, size_t rsb1, int32_t beta, int32_t *c,
+    size_t rsc) {
+  if (m == 0 || n == 0) {
+    return;
+  }
+
+  const size_t m0 = 6;
+  const size_t k0 = 4;
+
+  if (m == 1) {
+    // dispatch to GEMV kernel for better performance
+    int32_t *c_write = c;
+    const int8_t *a_tile_ptr = a;
+    const int8_t *b_tile_ptr = b;
+    size_t n_avl = n;
+    while (n_avl) {
+      size_t vl = __riscv_vsetvl_e32m4(n_avl);
+      skl_gemm_1xm4_aligned_i8rcp1x4_i8p4x1c_i32_zvdot4a8i(
+          vl, k1, alpha, a_tile_ptr, csa1, b_tile_ptr, rsb1, beta, c_write);
+      b_tile_ptr += k0 * vl;
+      c_write += vl;
+      n_avl -= vl;
+    }
+  } else {
+    size_t m_idx = 0;
+    for (; m_idx + m0 - 1 < m; m_idx += m0) {
+      int32_t *c_write = c + m_idx * rsc;
+      const int8_t *a_tile_ptr = a + m_idx * rsa1;
+      const int8_t *b_tile_ptr = b;
+      size_t n_avl = n;
+      while (n_avl) {
+        size_t vl = __riscv_vsetvl_e32m4(n_avl);
+        skl_gemm_6xm4_aligned_i8rcp1x4_i8p4x1c_i32_zvdot4a8i(
+            vl, k1, alpha, a_tile_ptr, rsa1, csa1, b_tile_ptr, rsb1, beta,
+            c_write, rsc);
+        b_tile_ptr += k0 * vl;
+        c_write += vl;
+        n_avl -= vl;
+      }
+    }
+
+    size_t m_left = m - m_idx;
+    if (m_left) {
+      int32_t *c_write = c + m_idx * rsc;
+      const int8_t *a_tile_ptr = a + m_idx * rsa1;
+      const int8_t *b_tile_ptr = b;
+      size_t n_avl = n;
+      while (n_avl) {
+        size_t vl = __riscv_vsetvl_e32m4(n_avl);
+        skl_gemm_lt6xm4_aligned_i8rcp1x4_i8p4x1c_i32_zvdot4a8i(
+            m_left, vl, k1, alpha, a_tile_ptr, rsa1, csa1, b_tile_ptr, rsb1,
+            beta, c_write, rsc);
+        b_tile_ptr += k0 * vl;
+        c_write += vl;
+        n_avl -= vl;
+      }
+    }
+  }
+}
+
+SKL_FUNC void skl_gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i(
+    size_t m, size_t n, size_t k1, int32_t alpha, const int8_t *a, size_t rsa1,
+    size_t csa1, const int8_t *b, size_t rsb1, int32_t beta, int32_t *c,
+    size_t rsc) {
+  if (m == 0 || n == 0) {
+    return;
+  }
+
+  const size_t k0 = 4;
+
+  if ((uintptr_t)a % (k0 * sizeof(int8_t)) == 0 && rsa1 % k0 == 0 &&
+      csa1 % k0 == 0) {
+    skl_gemm_aligned_i8rcp1x4_i8p4x1c_i32_zvdot4a8i(
+        m, n, k1, alpha, a, rsa1, csa1, b, rsb1, beta, c, rsc);
+  } else {
+    size_t m_idx = 0;
+    for (; m_idx < m; ++m_idx) {
+      int32_t *c_write = c + m_idx * rsc;
+      const int8_t *a_tile_ptr = a + m_idx * rsa1;
+      const int8_t *b_tile_ptr = b;
+      size_t n_avl = n;
+      while (n_avl) {
+        size_t vl = __riscv_vsetvl_e32m4(n_avl);
+        skl_gemm_1xm4_unaligned_i8rcp1x4_i8p4x1c_i32_zvdot4a8i(
+            vl, k1, alpha, a_tile_ptr, csa1, b_tile_ptr, rsb1, beta, c_write);
+        b_tile_ptr += k0 * vl;
+        c_write += vl;
+        n_avl -= vl;
+      }
+    }
+  }
+}

--- a/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i.h
+++ b/src/gemm/xsfvqdotq/gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i.h
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#if !defined(__riscv_zve32x)
+#error This source file requires compiler support for the RISC-V Zve32x extension.
+#endif
+
+#if !defined(__riscv_zvdot4a8i)
+#error This source file requires compiler support for the Zvdot4a8i extension.
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * @brief Zvdot4a8i int8 GEMM with int32 accumulator.
+ *
+ * @param m - Number of rows in A and C.
+ * @param n - Number of columns in B and C.
+ * @param k1 - Number of block-columns in A, block-rows in B.
+ * @param alpha - Scalar multiplier for A * B.
+ * @param a - Pointer to packed matrix A (m0 = 1, k0 = 4, csa0 = 1).
+ * @param rsa1 - Row stride between blocks of A in elements.
+ * @param csa1 - Column stride between blocks of A in elements.
+ * @param b - Pointer to packed matrix B (k0 = 4, n0 = 1, rsb0 = 1,
+ *            csb1 = 4).
+ * @param rsb1 - Row stride between blocks of B in elements.
+ * @param beta - Scalar multiplier for matrix C.
+ * @param c - Pointer to matrix C in row-major format.
+ * @param rsc - Stride between rows of matrix C in elements.
+ *
+ * Computes `C = alpha * A * B + beta * C` for packed int8 matrices
+ * A and B and int32 output matrix C.
+ *
+ * Equivalent to:
+ * ```
+ * skl_gemm_i8rcprc_i8rcprc_i32rcprc_ref(
+ *     1, 1, 4, m, n, k1,   // m0, n0, k0, m1, n1, k1
+ *     alpha,               // alpha
+ *     a, 0, 1, rsa1, csa1, // a, rsa0, csa0, rsa1, csa1
+ *     b, 1, 0, rsb1, 4,    // b, rsb0, csb0, rsb1, csb1
+ *     beta,                // beta
+ *     c, 0, 0, rsc, 1      // c, rsc0, csc0, rsc1, csc1
+ * );
+ * ```
+ *
+ * This kernel uses the SiFive Zvdot4a8i extension for vector quad widening 4D
+ * dot product operations to achieve high performance on 8-bit integer data.
+ * Works best when A is 4-byte aligned and rsa1 and csa1 are multiples of 4.
+ *
+ * @note
+ * If A does not meet the alignment requirements stated above, the kernel
+ * falls back to an unaligned implementation that is unlikely to get good
+ * performance since it must handle misaligned loads from A.
+ *
+ * @note
+ * The simplest way to pack a row-major A matrix into an A that meets the
+ * alignment requirements is to copy it into a 4-byte-aligned buffer, but insert
+ * padding between the rows so that the row stride is a multiple of 4. Then the
+ * kernel can be called by setting rsa1 to the row stride and csa1 = 4.
+ */
+void skl_gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i(size_t m, size_t n, size_t k1,
+                                             int32_t alpha, const int8_t *a,
+                                             size_t rsa1, size_t csa1,
+                                             const int8_t *b, size_t rsb1,
+                                             int32_t beta, int32_t *c,
+                                             size_t rsc);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -207,6 +207,13 @@ skl_add_test(
   ""
 )
 skl_add_test(
+  skl_gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i
+  gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
+  gemm/xsfvqdotq/skl_gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i.c
+  "zvdot4a8i"
+  ""
+)
+skl_add_test(
   skl_gemm_i8c_i8_i32_xsfmm32a8i
   gemm/gemm_i8rcprc_i8rcprc_i32rcprc.c
   gemm/xsfmm/skl_gemm_i8c_i8_i32_xsfmm32a8i.c

--- a/test/gemm/xsfvqdotq/skl_gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i.c
+++ b/test/gemm/xsfvqdotq/skl_gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i.c
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 SiFive, Inc. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
+
+#include "gemm/gemm_i8rcprc_i8rcprc_i32rcprc.h"
+#include "skl-test-driver.h"
+#include "skl.h"
+#include <stddef.h>
+
+#if !defined(__riscv_zvdot4a8i)
+#error This file requires the Zvdot4a8i extension
+#endif
+
+/**
+ * @brief Test cases for GEMM with Zvdot4a8i extension.
+ *
+ * This test uses the gemm_i8rcprc_i8rcprc_i32rcprc harness with the following
+ * restrictions on the input parameters:
+ *  - The block dimensions are m0 = 1, n0 = 1, and k0 = 4
+ *  - Matrix A_pack has row-major blocks (csa0 = 1)
+ *  - Matrix B_pack is block-row major with column-major blocks (rsb0 = 1, csb1
+ *    = k0 * n0)
+ *  - Matrix C is row-major (csc1 = 1)
+ */
+
+#define TEST                                                                   \
+  GEMM_I8RCPRC_I8RCPRC_I32RCPRC_DEFAULTS,                                      \
+      .steps = {                                                               \
+          .init = init,                                                        \
+          .warmup = NULL,                                                      \
+          .execute = execute,                                                  \
+          .verify = gemm_i8rcprc_i8rcprc_i32rcprc_verify,                      \
+          .report = gemm_i8rcprc_i8rcprc_i32rcprc_test_report,                 \
+          .cleanup = gemm_i8rcprc_i8rcprc_i32rcprc_cleanup,                    \
+  }
+
+#define BENCH                                                                  \
+  GEMM_I8RCPRC_I8RCPRC_I32RCPRC_DEFAULTS,                                      \
+      .steps = {                                                               \
+          .init = init,                                                        \
+          .warmup = execute,                                                   \
+          .execute = execute,                                                  \
+          .verify = NULL,                                                      \
+          .report = gemm_i8rcprc_i8rcprc_i32rcprc_benchmark_report,            \
+          .cleanup = gemm_i8rcprc_i8rcprc_i32rcprc_cleanup,                    \
+  }
+
+static void init(skl_test_t *t);
+static void execute(skl_test_t *t);
+
+// clang-format off
+gemm_i8rcprc_i8rcprc_i32rcprc_t tests[] = {
+#ifdef SKL_ENABLE_BENCHMARKS
+    // Benchmark tests
+    {BENCH, .m1 =  126, .n1 = 128, .k1 = 64, .alpha = 1},
+#endif // SKL_ENABLE_BENCHMARKS
+
+#ifdef SKL_ENABLE_TESTS
+    // Verification tests - comprehensive coverage for Zvdot4a8i GEMM
+    /* Zero-dimension edge cases */
+    {TEST, .m1 = 0,   .n1 = 0,     .k1 = 0,  .alpha = 1},
+    {TEST, .m1 = 0,   .n1 = 0,     .k1 = 4,  .alpha = 1},
+    {TEST, .m1 = 0,   .n1 = 128,   .k1 = 0,  .alpha = 1},
+    {TEST, .m1 = 1,   .n1 = 0,     .k1 = 0,  .alpha = 1},
+    {TEST, .m1 = 5,   .n1 = 0,     .k1 = 0,  .alpha = 1},
+    {TEST, .m1 = 6,   .n1 = 0,     .k1 = 0,  .alpha = 1},
+    {TEST, .m1 = 0,   .n1 = 128,   .k1 = 4,  .alpha = 1},
+    {TEST, .m1 = 1,   .n1 = 0,     .k1 = 4,  .alpha = 1},
+    {TEST, .m1 = 5,   .n1 = 0,     .k1 = 4,  .alpha = 1},
+    {TEST, .m1 = 6,   .n1 = 0,     .k1 = 4,  .alpha = 1},
+    /* Test tile functions (m == 1, m < 6, m == 6) */
+    {TEST, .m1 = 1,   .n1 = 128,   .k1 = 0,  .alpha = 1},
+    {TEST, .m1 = 1,   .n1 = 128,   .k1 = 1,  .alpha = 1},
+    {TEST, .m1 = 1,   .n1 = 128,   .k1 = 2,  .alpha = 1},
+    {TEST, .m1 = 1,   .n1 = 128,   .k1 = 3,  .alpha = 1},
+    {TEST, .m1 = 1,   .n1 = 128,   .k1 = 4,  .alpha = 1},
+    {TEST, .m1 = 1,   .n1 = 128,   .k1 = 4,  .alpha = 2,  .beta = 3},
+
+    {TEST, .m1 = 5,   .n1 = 128,   .k1 = 0,  .alpha = 1},
+    {TEST, .m1 = 5,   .n1 = 128,   .k1 = 1,  .alpha = 1},
+    {TEST, .m1 = 5,   .n1 = 128,   .k1 = 2,  .alpha = 1},
+    {TEST, .m1 = 5,   .n1 = 128,   .k1 = 3,  .alpha = 1},
+    {TEST, .m1 = 5,   .n1 = 128,   .k1 = 4,  .alpha = 1},
+    {TEST, .m1 = 5,   .n1 = 128,   .k1 = 4,  .alpha = 2,  .beta = 3},
+
+    {TEST, .m1 = 6,   .n1 = 128,   .k1 = 0,  .alpha = 1},
+    {TEST, .m1 = 6,   .n1 = 128,   .k1 = 1,  .alpha = 1},
+    {TEST, .m1 = 6,   .n1 = 128,   .k1 = 2,  .alpha = 1},
+    {TEST, .m1 = 6,   .n1 = 128,   .k1 = 3,  .alpha = 1},
+    {TEST, .m1 = 6,   .n1 = 128,   .k1 = 4,  .alpha = 1},
+    {TEST, .m1 = 6,   .n1 = 128,   .k1 = 4,  .alpha = 2,  .beta = 3},
+    /* Multiple tiles */
+    {TEST, .m1 = 29,   .n1 = 64,    .k1 = 4,  .alpha = 1},
+    {TEST, .m1 = 29,   .n1 = 127,   .k1 = 4,  .alpha = 1},
+    {TEST, .m1 = 29,   .n1 = 129,   .k1 = 4,  .alpha = 1},
+    {TEST, .m1 = 29,   .n1 = 192,   .k1 = 4,  .alpha = 1},
+    {TEST, .m1 = 29,   .n1 = 255,   .k1 = 4,  .alpha = 1},
+    /* Block-column-major A_pack */
+    {TEST, .m1 = 29,   .n1 = 128,    .k1 = 4,  .alpha = 1,  .rsa1 = 4,
+           .csa1 = (size_t)(29 * 4)},
+    /* A_pack with misaligned rows */
+    {TEST, .m1 = 29,   .n1 = 128,    .k1 = 4,  .alpha = 1,
+           .rsa1 = (size_t)(4 * 4 + 1),  .csa1 = 4},
+#endif // SKL_ENABLE_TESTS
+};
+// clang-format on
+
+static skl_test_suite_t suite = {
+    .name = "skl_gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i",
+    .num_tests = sizeof(tests) / sizeof(tests[0]),
+    .test_size = sizeof(gemm_i8rcprc_i8rcprc_i32rcprc_t),
+    .tests = tests};
+
+static void init(skl_test_t *t) {
+  const gemm_i8rcprc_i8rcprc_i32rcprc_t *h =
+      (gemm_i8rcprc_i8rcprc_i32rcprc_t *)t->harness;
+
+  SKL_TEST_REQUIRE(t, init_status, h->m0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->n0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->k0 == 4);
+  SKL_TEST_REQUIRE(t, init_status, h->csa0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->rsb0 == 1);
+  SKL_TEST_REQUIRE(t, init_status, h->csb1 == h->k0 * h->n0);
+  SKL_TEST_REQUIRE(t, init_status, h->csc1 == 1);
+
+  gemm_i8rcprc_i8rcprc_i32rcprc_init(t);
+}
+
+static void execute(skl_test_t *t) {
+  const gemm_i8rcprc_i8rcprc_i32rcprc_t *h =
+      (gemm_i8rcprc_i8rcprc_i32rcprc_t *)t->harness;
+
+  skl_gemm_i8rcp1x4_i8p4x1c_i32_zvdot4a8i(
+      h->m1, h->n1, h->k1, h->alpha, h->a_pack.data, h->rsa1, h->csa1,
+      h->b_pack.data, h->rsb1, h->beta, h->c_pack.data, h->rsc1);
+}
+
+int main(void) {
+  for (size_t i = 0; i < suite.num_tests; ++i) {
+    tests[i].m0 = 1;
+    tests[i].n0 = 1;
+    tests[i].k0 = 4;
+
+    tests[i].rsa0 = 4;
+    tests[i].csa0 = 1;
+    tests[i].csa1 = tests[i].csa1 ? tests[i].csa1 : tests[i].m0 * tests[i].k0;
+    tests[i].rsa1 = tests[i].rsa1 ? tests[i].rsa1 : tests[i].k1 * tests[i].csa1;
+
+    tests[i].rsb0 = 1;
+    tests[i].csb0 = 4;
+    tests[i].csb1 = tests[i].k0 * tests[i].n0;
+    tests[i].rsb1 = tests[i].rsb1 ? tests[i].rsb1 : tests[i].n1 * tests[i].csb1;
+
+    tests[i].rsc0 = 1;
+    tests[i].csc0 = 1;
+    tests[i].csc1 = 1;
+    tests[i].rsc1 = tests[i].rsc1 ? tests[i].rsc1 : tests[i].n1;
+  }
+
+  return skl_test_driver_run_suite(&suite);
+}


### PR DESCRIPTION
This PR adds Zvdot4a8i GEMM kernels. These are essentially the same as the Xsfvqdotq GEMM kernels but using different instruction names.

Temporarily placed them in the same directories as Xsfvqdotq. #161 may remove this directory structure.