### PR TITLE
[Infra] Avoid upward propagation of clang-tidy checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,8 @@ if(SKL_ENABLE_CLANG_TIDY)
     )
     set(SKL_CLANG_TIDY_EXE "${SKL_CLANG_TIDY_EXE}" CACHE FILEPATH "Path to clang-tidy")
     if(SKL_CLANG_TIDY_EXE)
-        set(CMAKE_C_CLANG_TIDY "${SKL_CLANG_TIDY_EXE}" CACHE STRING "clang-tidy command")
+        set(SKL_CLANG_TIDY_CMD "${SKL_CLANG_TIDY_EXE}" CACHE STRING "clang-tidy command")
     endif()
-else()
-    unset(CMAKE_C_CLANG_TIDY CACHE)
 endif()
 
 # Build the library itself
@@ -47,6 +45,12 @@ set_target_properties(${SKL_LIBRARY}
 )
 # But do require at least C99.
 target_compile_features(${SKL_LIBRARY} PUBLIC c_std_99)
+
+if(SKL_CLANG_TIDY_CMD)
+  set_target_properties(${SKL_LIBRARY} PROPERTIES
+    C_CLANG_TIDY ${SKL_CLANG_TIDY_CMD}
+  )
+endif()
 
 set(SKL_COMPILE_OPTIONS
     -Wall

--- a/ref/CMakeLists.txt
+++ b/ref/CMakeLists.txt
@@ -54,3 +54,9 @@ add_library(skl-ref
 target_include_directories(skl-ref PUBLIC ../include ..)
 target_compile_options(skl-ref PRIVATE ${SKL_COMPILE_OPTIONS})
 target_link_libraries(skl-ref PUBLIC m)
+
+if(SKL_CLANG_TIDY_CMD)
+  set_target_properties(skl-ref PROPERTIES
+    C_CLANG_TIDY ${SKL_CLANG_TIDY_CMD}
+  )
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,11 @@ function(skl_add_test TEST_NAME HARNESS_SRC TEST_SRC REQUIRED_EXTENSIONS OPTS)
     PRIVATE ${SKL_COMPILE_OPTIONS} ${SKL_TEST_COMPILE_OPTIONS} ${OPTS}
   )
   target_include_directories(test-${TEST_NAME} PRIVATE .)
+  if(SKL_CLANG_TIDY_CMD)
+    set_target_properties(test-${TEST_NAME} PROPERTIES
+      C_CLANG_TIDY ${SKL_CLANG_TIDY_CMD}
+    )
+  endif()
 
   if(SKL_ENABLE_TESTS)
     target_compile_definitions(test-${TEST_NAME} PRIVATE SKL_ENABLE_TESTS)


### PR DESCRIPTION
Setting the `CMAKE_C_CLANG_TIDY` cache variable can cause clang-tidy checks to propagate upward into any project that uses SKL via CMake's `add_subdirectory`. This PR replaces the usage of that variable with setting the `C_CLANG_TIDY` property of targets manually.