### PR TITLE
[Test] Clean up f32 GEMM tests 

### DIFF
--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -54,42 +54,39 @@ void gemm_f32rcprc_f32rcprc_f32rcprc_init(skl_test_t *t) {
   }
 
   if (m1 == 0 || k1 == 0) {
-    h->a_pack.len = 0;
+    h->a.len = 0;
   } else {
-    h->a_pack.len = (m1 - 1) * rsa1 + (k1 - 1) * csa1 + (m0 - 1) * rsa0 +
-                    (k0 - 1) * csa0 + 1;
+    h->a.len = (m1 - 1) * rsa1 + (k1 - 1) * csa1 + (m0 - 1) * rsa0 +
+               (k0 - 1) * csa0 + 1;
   }
 
   if (k1 == 0 || n1 == 0) {
-    h->b_pack.len = 0;
+    h->b.len = 0;
   } else {
-    h->b_pack.len = (k1 - 1) * rsb1 + (n1 - 1) * csb1 + (k0 - 1) * rsb0 +
-                    (n0 - 1) * csb0 + 1;
+    h->b.len = (k1 - 1) * rsb1 + (n1 - 1) * csb1 + (k0 - 1) * rsb0 +
+               (n0 - 1) * csb0 + 1;
   }
 
   if (m1 == 0 || n1 == 0) {
-    h->c_pack.len = 0;
+    h->c.len = 0;
   } else {
-    h->c_pack.len = (m1 - 1) * rsc1 + (n1 - 1) * csc1 + (m0 - 1) * rsc0 +
-                    (n0 - 1) * csc0 + 1;
+    h->c.len = (m1 - 1) * rsc1 + (n1 - 1) * csc1 + (m0 - 1) * rsc0 +
+               (n0 - 1) * csc0 + 1;
   }
 
   // Allocate buffers
-  SKL_TEST_BUF_CREATE(t, float, &h->a_pack);
-  SKL_TEST_BUF_CREATE(t, float, &h->b_pack);
-  SKL_TEST_BUF_CREATE(t, float, &h->c_pack);
+  SKL_TEST_BUF_CREATE(t, float, &h->a);
+  SKL_TEST_BUF_CREATE(t, float, &h->b);
+  SKL_TEST_BUF_CREATE(t, float, &h->c);
   if (h->steps.verify) {
     h->ctx.a_wide =
-        h->a_pack.len ? malloc(h->a_pack.len * sizeof(*(h->ctx.a_wide))) : NULL;
+        h->a.len ? malloc(h->a.len * sizeof(*(h->ctx.a_wide))) : NULL;
     h->ctx.b_wide =
-        h->b_pack.len ? malloc(h->b_pack.len * sizeof(*(h->ctx.b_wide))) : NULL;
-    h->ctx.ref_c =
-        h->c_pack.len ? malloc(h->c_pack.len * sizeof(*(h->ctx.ref_c))) : NULL;
-    h->ctx.bound =
-        h->c_pack.len ? malloc(h->c_pack.len * sizeof(*(h->ctx.bound))) : NULL;
-    if (h->c_pack.len) {
-      memcpy(h->ctx.ref_c, h->c_pack.data,
-             h->c_pack.len * sizeof(*(h->c_pack.data)));
+        h->b.len ? malloc(h->b.len * sizeof(*(h->ctx.b_wide))) : NULL;
+    h->ctx.ref_c = h->c.len ? malloc(h->c.len * sizeof(*(h->ctx.ref_c))) : NULL;
+    h->ctx.bound = h->c.len ? malloc(h->c.len * sizeof(*(h->ctx.bound))) : NULL;
+    if (h->c.len) {
+      memcpy(h->ctx.ref_c, h->c.data, h->c.len * sizeof(*(h->c.data)));
     }
   }
 }
@@ -119,12 +116,12 @@ void gemm_f32rcprc_f32rcprc_f32rcprc_verify(skl_test_t *t) {
   size_t csc1 = h->csc1;
   float alpha = h->alpha;
   float beta = h->beta;
-  float *a_pack = h->a_pack.data;
-  float *b_pack = h->b_pack.data;
-  float *c_pack = h->c_pack.data;
-  size_t a_pack_len = h->a_pack.len;
-  size_t b_pack_len = h->b_pack.len;
-  size_t c_pack_len = h->c_pack.len;
+  float *a = h->a.data;
+  float *b = h->b.data;
+  float *c = h->c.data;
+  size_t a_len = h->a.len;
+  size_t b_len = h->b.len;
+  size_t c_len = h->c.len;
   double *a_wide = h->ctx.a_wide;
   double *b_wide = h->ctx.b_wide;
   float *ref_c = h->ctx.ref_c;
@@ -150,13 +147,13 @@ void gemm_f32rcprc_f32rcprc_f32rcprc_verify(skl_test_t *t) {
   // skl_test_init) which are needed for the |beta| * |C| term in the error
   // bound.
   //
-  for (size_t i = 0; i < a_pack_len; ++i) {
-    a_wide[i] = fabsf(a_pack[i]);
+  for (size_t i = 0; i < a_len; ++i) {
+    a_wide[i] = fabsf(a[i]);
   }
-  for (size_t i = 0; i < b_pack_len; ++i) {
-    b_wide[i] = fabsf(b_pack[i]);
+  for (size_t i = 0; i < b_len; ++i) {
+    b_wide[i] = fabsf(b[i]);
   }
-  for (size_t i = 0; i < c_pack_len; ++i) {
+  for (size_t i = 0; i < c_len; ++i) {
     bound[i] = fabsf(ref_c[i]);
   }
   const int P = 24; // 23 bits of mantissa for float32 accumulator
@@ -171,8 +168,8 @@ void gemm_f32rcprc_f32rcprc_f32rcprc_verify(skl_test_t *t) {
   // Compute the reference result using h->ctx.ref_c
   // h->ctx.ref_c contains the original C values (copied in skl_test_init)
   skl_gemm_f32rcprc_f32rcprc_f32rcprc_ref(
-      m0, n0, k0, m1, n1, k1, alpha, a_pack, rsa0, csa0, rsa1, csa1, b_pack,
-      rsb0, csb0, rsb1, csb1, beta, ref_c, rsc0, csc0, rsc1, csc1);
+      m0, n0, k0, m1, n1, k1, alpha, a, rsa0, csa0, rsa1, csa1, b, rsb0, csb0,
+      rsb1, csb1, beta, ref_c, rsc0, csc0, rsc1, csc1);
 
   /* Compare the reference and test outputs. */
   for (size_t i1 = 0; i1 < m1; ++i1) {
@@ -180,11 +177,11 @@ void gemm_f32rcprc_f32rcprc_f32rcprc_verify(skl_test_t *t) {
       for (size_t i0 = 0; i0 < m0; ++i0) {
         for (size_t j0 = 0; j0 < n0; ++j0) {
           size_t idx = i1 * rsc1 + j1 * csc1 + i0 * rsc0 + j0 * csc0;
-          if (fabs((double)c_pack[idx] - (double)ref_c[idx]) > bound[idx]) {
+          if (fabs((double)c[idx] - (double)ref_c[idx]) > bound[idx]) {
             SKL_TEST_LOG(t, SKL_TEST_LOG_ERROR,
                          "result [%zu, %zu, %zu, %zu] (%f) != reference (%f) "
                          "[bound = %f]\n",
-                         i1, j1, i0, j0, c_pack[idx], ref_c[idx], bound[idx]);
+                         i1, j1, i0, j0, c[idx], ref_c[idx], bound[idx]);
             t->status.verify_status = SKL_TEST_FAIL;
             return;
           }
@@ -194,9 +191,8 @@ void gemm_f32rcprc_f32rcprc_f32rcprc_verify(skl_test_t *t) {
   }
 
   /* Check for clobbered elements. */
-  skl_test_check_matrix_clobbered_rcprc(t, sizeof(*c_pack), c_pack_len, m0, n0,
-                                        m1, n1, c_pack, ref_c, rsc0, csc0, rsc1,
-                                        csc1);
+  skl_test_check_matrix_clobbered_rcprc(t, sizeof(*c), c_len, m0, n0, m1, n1, c,
+                                        ref_c, rsc0, csc0, rsc1, csc1);
 }
 
 void gemm_f32rcprc_f32rcprc_f32rcprc_test_report(skl_test_t *t) {
@@ -226,9 +222,9 @@ void gemm_f32rcprc_f32rcprc_f32rcprc_cleanup(skl_test_t *t) {
       (gemm_f32rcprc_f32rcprc_f32rcprc_t *)t->harness;
 
   // Free buffers
-  SKL_TEST_BUF_FREE(t, &h->a_pack);
-  SKL_TEST_BUF_FREE(t, &h->b_pack);
-  SKL_TEST_BUF_FREE(t, &h->c_pack);
+  SKL_TEST_BUF_FREE(t, &h->a);
+  SKL_TEST_BUF_FREE(t, &h->b);
+  SKL_TEST_BUF_FREE(t, &h->c);
   if (h->steps.verify) {
     free(h->ctx.a_wide);
     free(h->ctx.b_wide);

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -14,11 +14,8 @@
 #include "skl-ref.h"
 #include "skl-test-driver.h"
 #include "skl_test_gemm.h"
-#include <inttypes.h>
 #include <math.h>
 #include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.c
@@ -89,7 +89,6 @@ void gemm_f32rcprc_f32rcprc_f32rcprc_init(skl_test_t *t) {
 }
 
 void gemm_f32rcprc_f32rcprc_f32rcprc_verify(skl_test_t *t) {
-  /* Compute the reference matrix output. */
   gemm_f32rcprc_f32rcprc_f32rcprc_t *h =
       (gemm_f32rcprc_f32rcprc_f32rcprc_t *)t->harness;
 

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
@@ -4,8 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * @brief Test and benchmark for packed GEMM: C_pack = alpha * A_pack * B_pack +
- * beta * C_pack.
+ * @brief Test and benchmark for packed GEMM: C = alpha * A * B + beta * C.
  *
  * This test uses a table-driven approach where test configurations are defined
  * in the `tests` array. Each test specifies:
@@ -17,11 +16,11 @@
  *  - The GEMM kernel function to test
  *
  * Matrix layouts:
- *  - A_pack is packed m1 x k1 with block size m0 x k0 and strides rsa0, csa0,
+ *  - A is packed m1 x k1 with block size m0 x k0 and strides rsa0, csa0,
  *    rsa1, csa1
- *  - B_pack is packed k1 x n1 with block size k0 x n0 and strides rsb0, csb0,
+ *  - B is packed k1 x n1 with block size k0 x n0 and strides rsb0, csb0,
  *    rsb1, csb1
- *  - C_pack is packed m1 x n1 with block size m0 x n0 and strides rsc0, csc0,
+ *  - C is packed m1 x n1 with block size m0 x n0 and strides rsc0, csc0,
  *    rsc1, csc1
  */
 
@@ -46,8 +45,8 @@ typedef struct {
   float beta;
   size_t rsc0, csc0, rsc1, csc1;
 
-  // Buffer generation settings for A_pack, B_pack, C_pack
-  SKL_TEST_BUFFER(float) a_pack, b_pack, c_pack;
+  // Buffer generation settings for A, B, C
+  SKL_TEST_BUFFER(float) a, b, c;
 
   // Derived parameters & buffers (private to the test harness)
   struct {
@@ -64,6 +63,6 @@ void gemm_f32rcprc_f32rcprc_f32rcprc_benchmark_report(skl_test_t *t);
 void gemm_f32rcprc_f32rcprc_f32rcprc_cleanup(skl_test_t *t);
 
 #define GEMM_F32RCPRC_F32RCPRC_F32RCPRC_DEFAULTS                               \
-  .a_pack = {.min = -1.0f, .max = 1.0f, .mode = SKL_TEST_RANDOM},              \
-  .b_pack = {.min = -1.0f, .max = 1.0f, .mode = SKL_TEST_RANDOM},              \
-  .c_pack = {.min = -1.0f, .max = 1.0f, .mode = SKL_TEST_RANDOM}
+  .a = {.min = -1.0f, .max = 1.0f, .mode = SKL_TEST_RANDOM},                   \
+  .b = {.min = -1.0f, .max = 1.0f, .mode = SKL_TEST_RANDOM},                   \
+  .c = {.min = -1.0f, .max = 1.0f, .mode = SKL_TEST_RANDOM}

--- a/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
+++ b/test/gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h
@@ -27,9 +27,7 @@
 #pragma once
 
 #include "skl-test-driver.h"
-#include <stdbool.h>
 #include <stddef.h>
-#include <stdint.h>
 
 typedef struct {
   // Test function pointers for various steps

--- a/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f.c
+++ b/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f.c
@@ -107,9 +107,8 @@ static void execute(skl_test_t *t) {
   const gemm_f32rcprc_f32rcprc_f32rcprc_t *h =
       (gemm_f32rcprc_f32rcprc_f32rcprc_t *)t->harness;
 
-  skl_gemm_f32_f32_f32_zve32f(h->m1, h->n1, h->k1, h->alpha, h->a_pack.data,
-                              h->rsa1, h->b_pack.data, h->rsb1, h->beta,
-                              h->c_pack.data, h->rsc1);
+  skl_gemm_f32_f32_f32_zve32f(h->m1, h->n1, h->k1, h->alpha, h->a.data, h->rsa1,
+                              h->b.data, h->rsb1, h->beta, h->c.data, h->rsc1);
 }
 
 int main(void) {

--- a/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f.c
+++ b/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f.c
@@ -13,7 +13,7 @@
 #endif
 
 /**
- * @brief Test cases for GEMM with Zve32f extension.
+ * @brief Test cases for the skl_gemm_f32_f32_f32_zve32f kernel.
  *
  * This test uses the gemm_f32rcprc_f32rcprc_f32rcprc harness with the following
  * restrictions on the input parameters:

--- a/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
+++ b/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
@@ -13,7 +13,7 @@
 #endif
 
 /**
- * @brief Test cases for GEMM with Zve32f extension.
+ * @brief Test cases for the skl_gemm_f32_f32_f32_zve32f_x390 kernel.
  *
  * This test uses the gemm_f32rcprc_f32rcprc_f32rcprc harness with the following
  * restrictions on the input parameters:
@@ -122,17 +122,17 @@ int main(void) {
     tests[i].rsa0 = 1;
     tests[i].csa0 = 1;
     tests[i].rsa1 = tests[i].rsa1 ? tests[i].rsa1 : tests[i].k1;
-    tests[i].csa1 = tests[i].csa1 ? tests[i].csa1 : 1;
+    tests[i].csa1 = 1;
 
     tests[i].rsb0 = 1;
     tests[i].csb0 = 1;
     tests[i].rsb1 = tests[i].rsb1 ? tests[i].rsb1 : tests[i].n1;
-    tests[i].csb1 = tests[i].csb1 ? tests[i].csb1 : 1;
+    tests[i].csb1 = 1;
 
     tests[i].rsc0 = 1;
     tests[i].csc0 = 1;
     tests[i].rsc1 = tests[i].rsc1 ? tests[i].rsc1 : tests[i].n1;
-    tests[i].csc1 = tests[i].csc1 ? tests[i].csc1 : 1;
+    tests[i].csc1 = 1;
   }
 
   return skl_test_driver_run_suite(&suite);

--- a/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
+++ b/test/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c
@@ -107,9 +107,9 @@ static void execute(skl_test_t *t) {
   const gemm_f32rcprc_f32rcprc_f32rcprc_t *h =
       (gemm_f32rcprc_f32rcprc_f32rcprc_t *)t->harness;
 
-  skl_gemm_f32_f32_f32_zve32f_x390(h->m1, h->n1, h->k1, h->alpha,
-                                   h->a_pack.data, h->rsa1, h->b_pack.data,
-                                   h->rsb1, h->beta, h->c_pack.data, h->rsc1);
+  skl_gemm_f32_f32_f32_zve32f_x390(h->m1, h->n1, h->k1, h->alpha, h->a.data,
+                                   h->rsa1, h->b.data, h->rsb1, h->beta,
+                                   h->c.data, h->rsc1);
 }
 
 int main(void) {

--- a/test/gemm/skl_test_gemm.h
+++ b/test/gemm/skl_test_gemm.h
@@ -16,6 +16,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#if defined(__riscv_min_xsfmm_te)
+#define SKL_XSFMM_TE ((size_t)__riscv_min_xsfmm_te)
+#endif
+
 #ifdef __riscv_xsfmmbase
 /**
  * @brief Get the effective tile edge length.

--- a/test/gemm/skl_test_gemm.h
+++ b/test/gemm/skl_test_gemm.h
@@ -35,90 +35,87 @@ static inline size_t skl_get_ete_xsfmmbase(void) {
  * @brief Check for clobbered elements in a packed matrix
  *
  * @param t - Test context.
- * @param c_type_size - Size of the elements of C_pack0 and C_pack1 in bytes.
- * @param c_pack_len - Number of elements in the arrays for C_pack0 and C_pack1.
- * @param m0 - Number of rows in each block of C_pack0 and C_pack1.
- * @param n0 - Number of columns in each block of C_pack0 and C_pack1.
- * @param m1 - Number of block-rows in C_pack0 and C_pack1.
- * @param n1 - Number of block-columns in C_pack0 and C_pack1.
- * @param c_pack0 - Pointer to matrix C_pack0.
- * @param c_pack1 - Pointer to matrix C_pack1.
- * @param rsc0 - Row stride within each block of C_pack0 and C_pack1 in
- *               elements.
- * @param csc0 - Column stride within each block of C_pack0 and C_pack1 in
- *               elements.
- * @param rsc1 - Row stride between blocks of C_pack0 and C_pack1 in elements.
- * @param csc1 - Column stride between blocks of C_pack0 and C_pack1 in
- *               elements.
+ * @param element_size - Size of the elements of X and Y in bytes.
+ * @param len - Number of elements in the arrays for X and Y.
+ * @param m0 - Number of rows in each block of X and Y.
+ * @param n0 - Number of columns in each block of X and Y.
+ * @param m1 - Number of block-rows in X and Y.
+ * @param n1 - Number of block-columns in X and Y.
+ * @param x - Pointer to matrix X.
+ * @param y - Pointer to matrix Y.
+ * @param rs0 - Row stride within each block of X and Y in elements.
+ * @param cs0 - Column stride within each block of X and Y in elements.
+ * @param rs1 - Row stride between blocks of X and Y in elements.
+ * @param cs1 - Column stride between blocks of X and Y in elements.
  *
- * C_pack0 and C_pack1 are packed matrices stored in arrays with c_pack_len
- * elements of size c_type_size bytes. The elements of the matrices are indexed
- * by i1 * rsc1 + j1 * csc1 + i0 * rsc0 + j0 * csc0, 0 <= i1 < m1, 0 <= j1 < n1,
- * 0 <= i0 < m0, 0 <= j0 < n0. This function checks that the arrays pointed to
- * by c_pack0 and c_pack1 are identical outside of the above indices and updates
- * the verify_status of t.
+ * X and Y are packed matrices stored in arrays with len elements of size
+ * element_size bytes. The elements of the matrices are indexed by:
+ *   i1 * rs1 + j1 * cs1 + i0 * rs0 + j0 * cs0,
+ * for 0 <= i1 < m1, 0 <= j1 < n1, 0 <= i0 < m0, 0 <= j0 < n0. This function
+ * checks that the arrays pointed to by X and Y are identical outside of the
+ * above indices and updates the verify_status of t.
  */
 static inline void skl_test_check_matrix_clobbered_rcprc(
-    skl_test_t *t, size_t c_type_size, size_t c_pack_len, size_t m0, size_t n0,
-    size_t m1, size_t n1, void *c_pack0, void *c_pack1, size_t rsc0,
-    size_t csc0, size_t rsc1, size_t csc1) {
-  uint8_t *c_pack0_cast = (uint8_t *)c_pack0;
-  uint8_t *c_pack1_cast = (uint8_t *)c_pack1;
-  // When m0 == 1, rsc0 can be arbitrary. We adjust its value in this case to
-  // reflect the length of a row. csc0, rsc1, and csc1 are adjusted similarly.
-  size_t rsc0_adj = m0 == 1 ? (n0 - 1) * csc0 + 1 : rsc0;
-  size_t csc0_adj = n0 == 1 ? (m0 - 1) * rsc0 + 1 : csc0;
-  size_t c_block_min_len = (m0 - 1) * rsc0_adj + (n0 - 1) * csc0_adj + 1;
-  size_t rsc1_adj = m1 == 1 ? (n1 - 1) * csc1 + c_block_min_len : rsc1;
-  size_t csc1_adj = n1 == 1 ? (m1 - 1) * rsc1 + c_block_min_len : csc1;
-  // Each block of C_pack{0,1} lies in an ambient m0_amb x n0_amb row- or
-  // column-major matrix with row and column strides rsc0_amb and csc0_amb.
-  // Let bsc1 be the block stride of C_pack{0,1}, i.e. the distance from one
-  // block to the next in memory, in elements; bsc1 varies from block to block.
-  // Lastly, set layoutc0_row_major to true if blocks of C_pack{0,1} are row
-  // major and false otherwise. Similarly, set layoutc1_row_major to true if
-  // C_pack{0,1} is block-row-major and false otherwise.
+    skl_test_t *t, size_t element_size, size_t len, size_t m0, size_t n0,
+    size_t m1, size_t n1, void *x, void *y, size_t rs0, size_t cs0, size_t rs1,
+    size_t cs1) {
+  uint8_t *x_u8 = (uint8_t *)x;
+  uint8_t *y_u8 = (uint8_t *)y;
+  // When m0 == 1, rs0 can be arbitrary. We adjust its value in this case to
+  // reflect the length of a row. cs0, rs1, and cs1 are adjusted similarly.
+  size_t rs0_adj = m0 == 1 ? (n0 - 1) * cs0 + 1 : rs0;
+  size_t cs0_adj = n0 == 1 ? (m0 - 1) * rs0 + 1 : cs0;
+  size_t block_min_len = (m0 - 1) * rs0_adj + (n0 - 1) * cs0_adj + 1;
+  size_t rs1_adj = m1 == 1 ? (n1 - 1) * cs1 + block_min_len : rs1;
+  size_t cs1_adj = n1 == 1 ? (m1 - 1) * rs1 + block_min_len : cs1;
+  // Each block of X and Y lies in an ambient m0_amb x n0_amb row- or
+  // column-major matrix with row and column strides rs0_amb and cs0_amb.
+  // Let bs1 be the block stride of X and Y, i.e. the distance from one block to
+  // the next in memory, in elements; bs1 varies from block to block.
+  // Lastly, set layout0_row_major to true if blocks of X and Y are row major
+  // and false otherwise. Similarly, set layout1_row_major to true if X and Y
+  // are block-row-major and false otherwise.
   size_t m0_amb = 0;
   size_t n0_amb = 0;
-  size_t rsc0_amb = 0;
-  size_t csc0_amb = 0;
-  size_t bsc1 = 0;
-  bool layoutc0_row_major = rsc0_adj >= csc0_adj;
-  bool layoutc1_row_major = rsc1_adj >= csc1_adj;
-  if (layoutc0_row_major) {
-    rsc0_amb = rsc0_adj;
-    csc0_amb = 1;
+  size_t rs0_amb = 0;
+  size_t cs0_amb = 0;
+  size_t bs1 = 0;
+  bool layout0_row_major = rs0_adj >= cs0_adj;
+  bool layout1_row_major = rs1_adj >= cs1_adj;
+  if (layout0_row_major) {
+    rs0_amb = rs0_adj;
+    cs0_amb = 1;
     m0_amb = m0;
-    n0_amb = rsc0_amb;
+    n0_amb = rs0_amb;
   } else {
-    rsc0_amb = 1;
-    csc0_amb = csc0_adj;
-    m0_amb = csc0_amb;
+    rs0_amb = 1;
+    cs0_amb = cs0_adj;
+    m0_amb = cs0_amb;
     n0_amb = n0;
   }
 
   // Check each block.
   for (size_t i1 = 0; i1 < m1; ++i1) {
     for (size_t j1 = 0; j1 < n1; ++j1) {
-      // Check the first c_block_min_len elements.
+      // Check the first block_min_len elements.
       for (size_t i0 = 0; i0 < m0_amb; ++i0) {
         for (size_t j0 = 0; j0 < n0_amb; ++j0) {
-          if (layoutc0_row_major && j0 % csc0_adj == 0 && j0 < n0 * csc0_adj) {
+          if (layout0_row_major && j0 % cs0_adj == 0 && j0 < n0 * cs0_adj) {
             continue;
           }
-          if (!layoutc0_row_major && i0 % rsc0_adj == 0 && i0 < m0 * rsc0_adj) {
+          if (!layout0_row_major && i0 % rs0_adj == 0 && i0 < m0 * rs0_adj) {
             continue;
           }
-          if (i0 * rsc0_amb + j0 * csc0_amb >= c_block_min_len) {
+          if (i0 * rs0_amb + j0 * cs0_amb >= block_min_len) {
             continue;
           }
 
           size_t idx =
-              i1 * rsc1_adj + j1 * csc1_adj + i0 * rsc0_amb + j0 * csc0_amb;
+              i1 * rs1_adj + j1 * cs1_adj + i0 * rs0_amb + j0 * cs0_amb;
           int64_t element0 = 0;
           int64_t element1 = 0;
-          memcpy(&element0, &(c_pack0_cast[c_type_size * idx]), c_type_size);
-          memcpy(&element1, &(c_pack1_cast[c_type_size * idx]), c_type_size);
+          memcpy(&element0, &(x_u8[element_size * idx]), element_size);
+          memcpy(&element1, &(y_u8[element_size * idx]), element_size);
           if (element0 != element1) {
             SKL_TEST_LOG(t, SKL_TEST_LOG_ERROR,
                          "element [%zu, %zu, %zu, %zu] clobbered\n", i1, j1, i0,
@@ -130,20 +127,20 @@ static inline void skl_test_check_matrix_clobbered_rcprc(
       }
 
       // Check until the next block.
-      if (layoutc1_row_major) {
-        bsc1 = j1 < n1 - 1 ? csc1_adj : rsc1_adj - (n1 - 1) * csc1_adj;
+      if (layout1_row_major) {
+        bs1 = j1 < n1 - 1 ? cs1_adj : rs1_adj - (n1 - 1) * cs1_adj;
       } else {
-        bsc1 = i1 < m1 - 1 ? rsc1_adj : csc1_adj - (m1 - 1) * rsc1_adj;
+        bs1 = i1 < m1 - 1 ? rs1_adj : cs1_adj - (m1 - 1) * rs1_adj;
       }
       if (i1 == m1 - 1 && j1 == n1 - 1) {
-        bsc1 = c_block_min_len;
+        bs1 = block_min_len;
       }
-      for (size_t i = c_block_min_len; i < bsc1; ++i) {
-        size_t idx = i1 * rsc1_adj + j1 * csc1_adj + i;
+      for (size_t i = block_min_len; i < bs1; ++i) {
+        size_t idx = i1 * rs1_adj + j1 * cs1_adj + i;
         int64_t element0 = 0;
         int64_t element1 = 0;
-        memcpy(&element0, &(c_pack0_cast[c_type_size * idx]), c_type_size);
-        memcpy(&element1, &(c_pack1_cast[c_type_size * idx]), c_type_size);
+        memcpy(&element0, &(x_u8[element_size * idx]), element_size);
+        memcpy(&element1, &(y_u8[element_size * idx]), element_size);
         if (element0 != element1) {
           SKL_TEST_LOG(t, SKL_TEST_LOG_ERROR,
                        "element [%zu, %zu, %zu] clobbered\n", i1, j1, i);
@@ -155,15 +152,14 @@ static inline void skl_test_check_matrix_clobbered_rcprc(
   }
 
   // Check until the end of the array.
-  size_t c_pack_min_len =
-      m1 == 0 || n1 == 0
-          ? 0
-          : (m1 - 1) * rsc1_adj + (n1 - 1) * csc1_adj + c_block_min_len;
-  for (size_t idx = c_pack_min_len; idx < c_pack_len; ++idx) {
+  size_t min_len = m1 == 0 || n1 == 0 ? 0
+                                      : (m1 - 1) * rs1_adj +
+                                            (n1 - 1) * cs1_adj + block_min_len;
+  for (size_t idx = min_len; idx < len; ++idx) {
     int64_t element0 = 0;
     int64_t element1 = 0;
-    memcpy(&element0, &(c_pack0_cast[c_type_size * idx]), c_type_size);
-    memcpy(&element1, &(c_pack1_cast[c_type_size * idx]), c_type_size);
+    memcpy(&element0, &(x_u8[element_size * idx]), element_size);
+    memcpy(&element1, &(y_u8[element_size * idx]), element_size);
     if (element0 != element1) {
       SKL_TEST_LOG(t, SKL_TEST_LOG_ERROR, "element [%zu] clobbered\n", idx);
       t->status.verify_status = SKL_TEST_FAIL;

--- a/test/gemm/skl_test_gemm.h
+++ b/test/gemm/skl_test_gemm.h
@@ -50,7 +50,7 @@ static inline size_t skl_get_ete_xsfmmbase(void) {
  *
  * X and Y are packed matrices stored in arrays with len elements of size
  * element_size bytes. The elements of the matrices are indexed by:
- *   i1 * rs1 + j1 * cs1 + i0 * rs0 + j0 * cs0,
+ *     i1 * rs1 + j1 * cs1 + i0 * rs0 + j0 * cs0,
  * for 0 <= i1 < m1, 0 <= j1 < n1, 0 <= i0 < m0, 0 <= j0 < n0. This function
  * checks that the arrays pointed to by X and Y are identical outside of the
  * above indices and updates the verify_status of t.

--- a/test/gemm/xsfmm/skl_gemm_f32c_f32_f32_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_f32c_f32_f32_xsfmm32a32f.c
@@ -13,7 +13,7 @@
 #endif
 
 /**
- * @brief Test cases for GEMM with Xsfmm32a32f extension.
+ * @brief Test cases for the skl_gemm_f32c_f32_f32_xsfmm32a32f kernel.
  *
  * This test uses the gemm_f32rcprc_f32rcprc_f32rcprc harness with the following
  * restrictions on the input parameters:

--- a/test/gemm/xsfmm/skl_gemm_f32c_f32_f32_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_f32c_f32_f32_xsfmm32a32f.c
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h"
+#include "gemm/skl_test_gemm.h"
 #include "skl-test-driver.h"
 #include "skl.h"
 #include <stddef.h>
@@ -52,41 +53,41 @@ static void execute(skl_test_t *t);
 gemm_f32rcprc_f32rcprc_f32rcprc_t tests[] = {
 #ifdef SKL_ENABLE_BENCHMARKS
     // Benchmark tests
-    {BENCH, .m1 = 128, .n1 = 128, .k1 = 2048, .alpha = 1.f, .beta = 0.f},
-    {BENCH, .m1 = 128, .n1 = 128, .k1 = 2048, .alpha = 1.f, .beta = 1.f},
+    {BENCH, .m1 = 2 * SKL_XSFMM_TE, .n1 = 2 * SKL_XSFMM_TE, .k1 = 2048, .alpha = 1.f, .beta = 0.f},
+    {BENCH, .m1 = 2 * SKL_XSFMM_TE, .n1 = 2 * SKL_XSFMM_TE, .k1 = 2048, .alpha = 1.f, .beta = 1.f},
 #endif // SKL_ENABLE_BENCHMARKS
 
 #ifdef SKL_ENABLE_TESTS
-    // Verification tests - comprehensive coverage for Xsfmm (ETE=64)
+    // Verification tests - comprehensive coverage for Xsfmm
     /* Edge case: 1x1 matrix with k=0 (no computation, C = beta * C) */
-    {TEST, .m1 = 1,   .n1 = 1,   .k1 = 0, .alpha = 1.f},
+    {TEST, .m1 = 1, .n1 = 1, .k1 = 0, .alpha = 1.f},
     /* Edge case: 1x1 matrix with k=1 (minimal computation) */
-    {TEST, .m1 = 1,   .n1 = 1,   .k1 = 1, .alpha = 1.f},
-    /* ETE-1 boundary: 63 = 64-1, tests just below tile edge */
-    {TEST, .m1 = 63,  .n1 = 63,  .k1 = 1, .alpha = 1.f},
-    {TEST, .m1 = 63,  .n1 = 63,  .k1 = 2, .alpha = 1.f},
-    {TEST, .m1 = 63,  .n1 = 63,  .k1 = 5, .alpha = 1.f},
-    /* Exact ETE boundary: 64x64 tiles */
-    {TEST, .m1 = 64,  .n1 = 64,  .k1 = 1, .alpha = 1.f},
-    {TEST, .m1 = 64,  .n1 = 64,  .k1 = 5, .alpha = 1.f},
-    /* ETE+1 boundary: 65 = 64+1, tests just past tile edge */
-    {TEST, .m1 = 65,  .n1 = 65,  .k1 = 1, .alpha = 1.f},
-    {TEST, .m1 = 65,  .n1 = 65,  .k1 = 5, .alpha = 1.f},
-    /* Multi-tile: 2*ETE = 128 */
-    {TEST, .m1 = 128, .n1 = 128, .k1 = 1, .alpha = 1.f},
-    {TEST, .m1 = 128, .n1 = 128, .k1 = 5, .alpha = 1.f},
-    /* Multi-tile+1: 2*ETE+1 = 129 */
-    {TEST, .m1 = 129, .n1 = 129, .k1 = 1, .alpha = 1.f},
-    {TEST, .m1 = 129, .n1 = 129, .k1 = 5, .alpha = 1.f},
+    {TEST, .m1 = 1, .n1 = 1, .k1 = 1, .alpha = 1.f},
+    /* ETE-1 boundary: tests just below tile edge */
+    {TEST, .m1 = 1 * SKL_XSFMM_TE - 1, .n1 = 1 * SKL_XSFMM_TE - 1, .k1 = 1, .alpha = 1.f},
+    {TEST, .m1 = 1 * SKL_XSFMM_TE - 1, .n1 = 1 * SKL_XSFMM_TE - 1, .k1 = 2, .alpha = 1.f},
+    {TEST, .m1 = 1 * SKL_XSFMM_TE - 1, .n1 = 1 * SKL_XSFMM_TE - 1, .k1 = 5, .alpha = 1.f},
+    /* Exact ETE boundary: ETExETE tiles */
+    {TEST, .m1 = 1 * SKL_XSFMM_TE,     .n1 = 1 * SKL_XSFMM_TE,     .k1 = 1, .alpha = 1.f},
+    {TEST, .m1 = 1 * SKL_XSFMM_TE,     .n1 = 1 * SKL_XSFMM_TE,     .k1 = 5, .alpha = 1.f},
+    /* ETE+1 boundary: tests just past tile edge */
+    {TEST, .m1 = 1 * SKL_XSFMM_TE + 1, .n1 = 1 * SKL_XSFMM_TE + 1, .k1 = 1, .alpha = 1.f},
+    {TEST, .m1 = 1 * SKL_XSFMM_TE + 1, .n1 = 1 * SKL_XSFMM_TE + 1, .k1 = 5, .alpha = 1.f},
+    /* Multi-tile: 2*ETE */
+    {TEST, .m1 = 2 * SKL_XSFMM_TE,     .n1 = 2 * SKL_XSFMM_TE,     .k1 = 1, .alpha = 1.f},
+    {TEST, .m1 = 2 * SKL_XSFMM_TE,     .n1 = 2 * SKL_XSFMM_TE,     .k1 = 5, .alpha = 1.f},
+    /* Multi-tile+1: 2*ETE+1 */
+    {TEST, .m1 = 2 * SKL_XSFMM_TE + 1, .n1 = 2 * SKL_XSFMM_TE + 1, .k1 = 1, .alpha = 1.f},
+    {TEST, .m1 = 2 * SKL_XSFMM_TE + 1, .n1 = 2 * SKL_XSFMM_TE + 1, .k1 = 5, .alpha = 1.f},
     /* Non-square matrices (rectangular tiles) */
-    {TEST, .m1 = 129, .n1 = 63,  .k1 = 1, .alpha = 1.f},
-    {TEST, .m1 = 65,  .n1 = 129, .k1 = 2, .alpha = 1.f},
-    {TEST, .m1 = 64,  .n1 = 128, .k1 = 5, .alpha = 1.f},
+    {TEST, .m1 = 2 * SKL_XSFMM_TE + 1, .n1 = 1 * SKL_XSFMM_TE - 1, .k1 = 1, .alpha = 1.f},
+    {TEST, .m1 = 1 * SKL_XSFMM_TE + 1, .n1 = 2 * SKL_XSFMM_TE + 1, .k1 = 2, .alpha = 1.f},
+    {TEST, .m1 = 1 * SKL_XSFMM_TE,     .n1 = 2 * SKL_XSFMM_TE,     .k1 = 5, .alpha = 1.f},
     /* General Alpha and Beta tests */
-    {TEST, .m1 = 65,  .n1 = 65,  .k1 = 0,  .alpha = 2.f, .beta = 3.f},
-    {TEST, .m1 = 65,  .n1 = 65,  .k1 = 1,  .alpha = 2.f, .beta = 3.f},
-    {TEST, .m1 = 65,  .n1 = 65,  .k1 = 33, .alpha = 2.f, .beta = 3.f},
-    {TEST, .m1 = 128, .n1 = 128, .k1 = 33, .alpha = 2.f, .beta = 3.f},
+    {TEST, .m1 = 1 * SKL_XSFMM_TE + 1, .n1 = 1 * SKL_XSFMM_TE + 1, .k1 = 0,  .alpha = 2.f, .beta = 3.f},
+    {TEST, .m1 = 1 * SKL_XSFMM_TE + 1, .n1 = 1 * SKL_XSFMM_TE + 1, .k1 = 1,  .alpha = 2.f, .beta = 3.f},
+    {TEST, .m1 = 1 * SKL_XSFMM_TE + 1, .n1 = 1 * SKL_XSFMM_TE + 1, .k1 = 33, .alpha = 2.f, .beta = 3.f},
+    {TEST, .m1 = 2 * SKL_XSFMM_TE,     .n1 = 2 * SKL_XSFMM_TE,     .k1 = 33, .alpha = 2.f, .beta = 3.f},
 #endif // SKL_ENABLE_TESTS
 };
 // clang-format on

--- a/test/gemm/xsfmm/skl_gemm_f32c_f32_f32_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_f32c_f32_f32_xsfmm32a32f.c
@@ -115,9 +115,9 @@ static void execute(skl_test_t *t) {
   const gemm_f32rcprc_f32rcprc_f32rcprc_t *h =
       (gemm_f32rcprc_f32rcprc_f32rcprc_t *)t->harness;
 
-  skl_gemm_f32c_f32_f32_xsfmm32a32f(h->m1, h->n1, h->k1, h->alpha,
-                                    h->a_pack.data, h->csa1, h->b_pack.data,
-                                    h->rsb1, h->beta, h->c_pack.data, h->rsc1);
+  skl_gemm_f32c_f32_f32_xsfmm32a32f(h->m1, h->n1, h->k1, h->alpha, h->a.data,
+                                    h->csa1, h->b.data, h->rsb1, h->beta,
+                                    h->c.data, h->rsc1);
 }
 
 int main(void) {

--- a/test/gemm/xsfmm/skl_gemm_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f.c
@@ -149,7 +149,7 @@ gemm_f32rcprc_f32rcprc_f32rcprc_t tests[] = {
 
     {TEST, .m1 = 7, .n1 = 7, .k1 = 15, .alpha = 2.f, .beta = 3.f, .csc0 = 2},
     {TEST, .m1 = 7, .n1 = 7, .k1 = 15, .alpha = 2.f, .beta = 3.f, .rsc0 = 1,
-           .csc0 = __riscv_min_xsfmm_te},
+           .csc0 = SKL_XSFMM_TE},
 #endif // SKL_ENABLE_TESTS
 };
 // clang-format on
@@ -164,9 +164,8 @@ static void init(skl_test_t *t) {
   const gemm_f32rcprc_f32rcprc_f32rcprc_t *h =
       (gemm_f32rcprc_f32rcprc_f32rcprc_t *)t->harness;
 
-  size_t ete = skl_get_ete_xsfmmbase();
-  SKL_TEST_REQUIRE(t, init_status, h->m0 == ete);
-  SKL_TEST_REQUIRE(t, init_status, h->n0 == ete);
+  SKL_TEST_REQUIRE(t, init_status, h->m0 == SKL_XSFMM_TE);
+  SKL_TEST_REQUIRE(t, init_status, h->n0 == SKL_XSFMM_TE);
   SKL_TEST_REQUIRE(t, init_status, h->k0 == 1);
   SKL_TEST_REQUIRE(t, init_status, h->rsa0 == 1); // Note: column-major
   SKL_TEST_REQUIRE(t, init_status, h->csb0 == 1);
@@ -186,10 +185,9 @@ static void execute(skl_test_t *t) {
 
 int main(void) {
   // Set default strides: A has column-major blocks, B has row-major blocks
-  size_t ete = skl_get_ete_xsfmmbase();
   for (size_t i = 0; i < suite.num_tests; ++i) {
-    tests[i].m0 = ete;
-    tests[i].n0 = ete;
+    tests[i].m0 = SKL_XSFMM_TE;
+    tests[i].n0 = SKL_XSFMM_TE;
     tests[i].k0 = 1;
 
     tests[i].rsa0 = 1;

--- a/test/gemm/xsfmm/skl_gemm_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f.c
@@ -14,7 +14,8 @@
 #endif
 
 /**
- * @brief Test cases for GEMM with Xsfmm32a32f extension.
+ * @brief Test cases for the
+ * skl_gemm_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f kernel.
  *
  * This test uses the gemm_f32rcprc_f32rcprc_f32rcprc harness with the following
  * restrictions on the input parameters:

--- a/test/gemm/xsfmm/skl_gemm_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f.c
+++ b/test/gemm/xsfmm/skl_gemm_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f.c
@@ -19,8 +19,8 @@
  * This test uses the gemm_f32rcprc_f32rcprc_f32rcprc harness with the following
  * restrictions on the input parameters:
  *  - The block dimensions are m0 = TE, n0 = TE, and k0 = 1
- *  - Matrix A_pack has column-major blocks (rsa0 == 1)
- *  - Matrix B_pack has row-major blocks (csb0 == 1)
+ *  - Matrix A has column-major blocks (rsa0 == 1)
+ *  - Matrix B has row-major blocks (csb0 == 1)
  */
 
 #define TEST                                                                   \
@@ -178,9 +178,9 @@ static void execute(skl_test_t *t) {
       (gemm_f32rcprc_f32rcprc_f32rcprc_t *)t->harness;
 
   skl_gemm_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f(
-      h->m1, h->n1, h->k1 * h->k0, h->alpha, h->a_pack.data, h->rsa1, h->csa1,
-      h->b_pack.data, h->rsb1, h->csb1, h->beta, h->c_pack.data, h->rsc0,
-      h->csc0, h->rsc1, h->csc1);
+      h->m1, h->n1, h->k1 * h->k0, h->alpha, h->a.data, h->rsa1, h->csa1,
+      h->b.data, h->rsb1, h->csb1, h->beta, h->c.data, h->rsc0, h->csc0,
+      h->rsc1, h->csc1);
 }
 
 int main(void) {


### PR DESCRIPTION
This is a follow-up PR to #165 that cleans up the f32 GEMM tests:
- The `_pack` suffix has been removed from array names,
- Uncecessary headers were removed, comments updated, default strides fixed,
- The Xsfmm tests use SKL_XSFMM_TE rather than a hard-coded value of 64,
- The arguments of the function checking for clobbered matrix entries have been renamed.

Subsequent PRs will be opened for the other types.