### PR TITLE
[Docs] Fix incorrect file paths in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Whenever significant deviations from the above assumptions are required, users a
 
 SKL's kernels can also be used individually by copying just a few source files into the target project.
 To use a particular kernel, copy the following three files from the SKL repository into the target project:
-- The kernel's source file (e.g., `src/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.c`)
-- The kernel's declaration header (e.g., `src/gemm/rvv/skl_gemm_f32_f32_f32_zve32f_x390.h`)
+- The kernel's source file (e.g., `src/gemm/gemm_f32_f32_f32_zve32f_x390.c`)
+- The kernel's declaration header (e.g., `src/gemm/gemm_f32_f32_f32_zve32f_x390.h`)
 - The common header `include/skl-common.h`, which must be in the include search path for the kernel's source file.
 
 Indvidual kernel source files should only be added to the build if the target system supports the ISA extensions required by that kernel, and will result in a preprocessor error otherwise.
@@ -134,7 +134,7 @@ SKL kernels can be used as header-only inline functions by defining `SKL_FUNC` a
 ```c
 #define SKL_FUNC static inline
 #define SKL_FUNC_PRIVATE static inline
-#include "src/gemm/rvv/skl_gemm_f32_f32_f32_zve32f.c"
+#include "src/gemm/gemm_f32_f32_f32_zve32f.c"
 ```
 
 C++ projects must wrap includes in `extern "C"` blocks:
@@ -142,7 +142,7 @@ C++ projects must wrap includes in `extern "C"` blocks:
 extern "C" {
 #define SKL_FUNC static inline
 #define SKL_FUNC_PRIVATE static inline
-#include "src/gemm/rvv/skl_gemm_f32_f32_f32_zve32f.c"
+#include "src/gemm/gemm_f32_f32_f32_zve32f.c"
 }
 ```
 

--- a/src/gemm/README.md
+++ b/src/gemm/README.md
@@ -104,20 +104,6 @@ These are separate kernels, and not automatically applied by the GEMM functions 
 
 To the extent possible, their layouts depend only on ISA parameters, not on register tiling decisions or machine-specific parameters such as VLEN or cache sizes.
 
-## File Organization
-
-Due to the large number of targets and data types supported by SKL GEMM kernels, the `skl/src/gemm/` directory is further subdivided by ISA:
-```
-skl/src/gemm/
-├── rvv/
-│   ├── ...
-└── xsfmm/
-    ├── ...
-...
-```
-
-Note that, because of the number of subsets of the "V" extension, all such kernels are placed in a single `rvv/` directory.
-
 ## Implementation Details & Performance Considerations
 
 SKL GEMM kernels do not expose register tiling parameters as part of their public API.

--- a/src/gemm/fused-kernel-API.md
+++ b/src/gemm/fused-kernel-API.md
@@ -5,7 +5,7 @@ The former compute a GEMM and store the result to memory, while the latter opera
 An alternate approach for GEMM kernels using SiFive's Xsfmm extension is to leave the matrix product in the tile state and pass it directly to the post-GEMM operator, which avoids storing and reloading the matrix.
 This document describes an API for post-GEMM kernels that allows them to be "fused" in this way to the Xsfmm GEMM kernels.
 Such an API is only possible due to the existence of [C ABI attributes for Xsfmm functions](https://www.sifive.com/document-file/xsfmm-matrix-extensions-specification).
-It is assumed that readers are familiar with [SKL's packed GEMM API](../packed-gemm.md) and SiFive's Xsfmm extension.
+It is assumed that readers are familiar with [SKL's packed GEMM API](packed-gemm.md) and SiFive's Xsfmm extension.
 
 ## Inner Loop Functions
 We first describe the Xsfmm GEMM inner loop functions, which accumulate a partial matrix product `A * B` into the current tile state for a specific matrix register tiling, and return this result in matrix registers.

--- a/test/README.md
+++ b/test/README.md
@@ -30,7 +30,7 @@ This abstraction is implemented in the form of a test driver framework, consisti
 ### Test Harness
 
 A harness encapsulates all of the test logic for a given kernel family, and defines a _test configuration_ structure that is used to parametrize individual test cases.
-For example, the `gemm_f32rc_f32rc_f32rc` [harness](gemm/gemm_f32rc_f32rc_f32rc.h) defines a configuration structure that contains the matrix dimensions, strides, and scaling factors for a GEMM test case:
+For example, the `gemm_f32rc_f32rc_f32rc` [harness](../ref/gemm/gemm_f32rc_f32rc_f32rc.h) defines a configuration structure that contains the matrix dimensions, strides, and scaling factors for a GEMM test case:
 ```c
 typedef struct {
   // Test function pointers for various steps

--- a/test/README.md
+++ b/test/README.md
@@ -30,7 +30,7 @@ This abstraction is implemented in the form of a test driver framework, consisti
 ### Test Harness
 
 A harness encapsulates all of the test logic for a given kernel family, and defines a _test configuration_ structure that is used to parametrize individual test cases.
-For example, the `gemm_f32rc_f32rc_f32rc` [harness](../ref/gemm/gemm_f32rc_f32rc_f32rc.h) defines a configuration structure that contains the matrix dimensions, strides, and scaling factors for a GEMM test case:
+For example, the `gemm_f32rc_f32rc_f32rc` [harness](gemm/gemm_f32rcprc_f32rcprc_f32rcprc.h) defines a configuration structure that contains the matrix dimensions, strides, and scaling factors for a GEMM test case:
 ```c
 typedef struct {
   // Test function pointers for various steps


### PR DESCRIPTION
Fixes broken links in docs.

-  In`README.md`, GEMM examples pointed at `src/gemm/rvv/` with an `skl_` prefix. In `src/` there's no `rvv/` subdir and no prefix, so it's `gemm_f32_f32_f32_zve32f_x390.c`.

- In `src/gemm/fused-kernel-API.md`, `../packed-gemm.md` → `packed-gemm.md` since its the same dir.

- In `test/README.md`, harness linked at `gemm/` but lives in `ref/gemm/`.

All now resolve correctly. I'm not sure if we want to keep the gemm kernels divided or not but updated the README to match what's inside the folder.