### PR TITLE
[Infra][Test] Support using a custom `add_test` CMake command.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,38 +45,37 @@ function(skl_add_test_default TEST_NAME HARNESS_SRC TEST_SRC REQUIRED_EXTENSIONS
   endforeach()
 
   set(TEST_NAME test-${TEST_NAME})
-  set(TEST_EXEC ${TEST_NAME})
   set(TEST_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
   # Create the test executable
-  add_executable(${TEST_EXEC} ${HARNESS_SRC} ${TEST_SRC})
+  add_executable(${TEST_NAME} ${HARNESS_SRC} ${TEST_SRC})
   target_link_libraries(
-    ${TEST_EXEC}
+    ${TEST_NAME}
     PRIVATE ${SKL_LIBRARY} ${SKL_TEST_LIBS} skl-test-driver
   )
   target_compile_options(
-    ${TEST_EXEC}
+    ${TEST_NAME}
     PRIVATE ${SKL_COMPILE_OPTIONS} ${SKL_TEST_COMPILE_OPTIONS} ${OPTS}
   )
-  target_include_directories(${TEST_EXEC} PRIVATE .)
-  set_target_properties(${TEST_EXEC} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${TEST_DIR})
+  target_include_directories(${TEST_NAME} PRIVATE .)
+  set_target_properties(${TEST_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${TEST_DIR})
   if(SKL_CLANG_TIDY_CMD)
-    set_target_properties(${TEST_EXEC} PROPERTIES
+    set_target_properties(${TEST_NAME} PROPERTIES
       C_CLANG_TIDY ${SKL_CLANG_TIDY_CMD}
     )
   endif()
 
   if(SKL_ENABLE_TESTS)
-    target_compile_definitions(${TEST_EXEC} PRIVATE SKL_ENABLE_TESTS)
+    target_compile_definitions(${TEST_NAME} PRIVATE SKL_ENABLE_TESTS)
   endif()
   if(SKL_ENABLE_BENCHMARKS)
-    target_compile_definitions(${TEST_EXEC} PRIVATE SKL_ENABLE_BENCHMARKS)
+    target_compile_definitions(${TEST_NAME} PRIVATE SKL_ENABLE_BENCHMARKS)
   endif()
 
   # Create the test command
   add_test(
     NAME ${TEST_NAME}
-    COMMAND ${SKL_TESTER} ${SKL_TESTER_OPTIONS} ${TEST_EXEC}
+    COMMAND ${SKL_TESTER} ${SKL_TESTER_OPTIONS} ${TEST_NAME}
     WORKING_DIRECTORY ${TEST_DIR}
   )
 endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,7 +45,6 @@ function(skl_add_test_default TEST_NAME HARNESS_SRC TEST_SRC REQUIRED_EXTENSIONS
   endforeach()
 
   set(TEST_NAME test-${TEST_NAME})
-  set(TEST_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
   # Create the test executable
   add_executable(${TEST_NAME} ${HARNESS_SRC} ${TEST_SRC})
@@ -58,7 +57,6 @@ function(skl_add_test_default TEST_NAME HARNESS_SRC TEST_SRC REQUIRED_EXTENSIONS
     PRIVATE ${SKL_COMPILE_OPTIONS} ${SKL_TEST_COMPILE_OPTIONS} ${OPTS}
   )
   target_include_directories(${TEST_NAME} PRIVATE .)
-  set_target_properties(${TEST_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${TEST_DIR})
   if(SKL_CLANG_TIDY_CMD)
     set_target_properties(${TEST_NAME} PROPERTIES
       C_CLANG_TIDY ${SKL_CLANG_TIDY_CMD}
@@ -75,8 +73,7 @@ function(skl_add_test_default TEST_NAME HARNESS_SRC TEST_SRC REQUIRED_EXTENSIONS
   # Create the test command
   add_test(
     NAME ${TEST_NAME}
-    COMMAND ${SKL_TESTER} ${SKL_TESTER_OPTIONS} ${TEST_NAME}
-    WORKING_DIRECTORY ${TEST_DIR}
+    COMMAND ${SKL_TESTER} ${SKL_TESTER_OPTIONS} $<TARGET_FILE:${TEST_NAME}>
   )
 endfunction()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,13 +18,13 @@ target_compile_options(
   PRIVATE ${SKL_COMPILE_OPTIONS} ${SKL_TEST_COMPILE_OPTIONS}
 )
 
-function(skl_add_test_from_executable TEST_NAME TEST_EXEC)
+function(skl_add_test_from_executable TEST_NAME TEST_EXEC TEST_DIR)
   # Default test registration function for an executable that already exists.
   # Set SKL_CUSTOM_ADD_TEST to override with customized functionality.
   add_test(
     NAME ${TEST_NAME}
     COMMAND ${SKL_TESTER} ${SKL_TESTER_OPTIONS} ${TEST_EXEC}
-    WORKING_DIRECTORY $<TARGET_FILE_DIR:${TEST_EXEC}>
+    WORKING_DIRECTORY ${TEST_DIR}
   )
 endfunction()
 
@@ -45,6 +45,7 @@ function(skl_add_test TEST_NAME HARNESS_SRC TEST_SRC REQUIRED_EXTENSIONS OPTS)
 
   set(TEST_NAME test-${TEST_NAME})
   set(TEST_EXEC ${TEST_NAME})
+  set(TEST_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
   # Create the test executable
   add_executable(${TEST_EXEC} ${HARNESS_SRC} ${TEST_SRC})
@@ -57,6 +58,7 @@ function(skl_add_test TEST_NAME HARNESS_SRC TEST_SRC REQUIRED_EXTENSIONS OPTS)
     PRIVATE ${SKL_COMPILE_OPTIONS} ${SKL_TEST_COMPILE_OPTIONS} ${OPTS}
   )
   target_include_directories(${TEST_EXEC} PRIVATE .)
+  set_target_properties(${TEST_EXEC} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${TEST_DIR})
   if(SKL_CLANG_TIDY_CMD)
     set_target_properties(${TEST_EXEC} PROPERTIES
       C_CLANG_TIDY ${SKL_CLANG_TIDY_CMD}
@@ -71,7 +73,7 @@ function(skl_add_test TEST_NAME HARNESS_SRC TEST_SRC REQUIRED_EXTENSIONS OPTS)
   endif()
 
   # Create the test command
-  cmake_language(CALL ${SKL_CUSTOM_ADD_TEST} ${TEST_NAME} ${TEST_EXEC})
+  cmake_language(CALL ${SKL_CUSTOM_ADD_TEST} ${TEST_NAME} ${TEST_EXEC} ${TEST_DIR})
 endfunction()
 
 skl_add_test(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,21 +18,22 @@ target_compile_options(
   PRIVATE ${SKL_COMPILE_OPTIONS} ${SKL_TEST_COMPILE_OPTIONS}
 )
 
-function(skl_add_test_from_executable TEST_NAME TEST_EXEC TEST_DIR)
-  # Default test registration function for an executable that already exists.
-  # Set SKL_CUSTOM_ADD_TEST to override with customized functionality.
-  add_test(
-    NAME ${TEST_NAME}
-    COMMAND ${SKL_TESTER} ${SKL_TESTER_OPTIONS} ${TEST_EXEC}
-    WORKING_DIRECTORY ${TEST_DIR}
-  )
-endfunction()
-
-set(SKL_CUSTOM_ADD_TEST "skl_add_test_from_executable" CACHE
-  STRING "Name of the function used to add a test given an executable target."
+set(SKL_ADD_TEST_FUNC "skl_add_test_default" CACHE
+  STRING "Name of the function used to add a SKL test target."
 )
 
 function(skl_add_test TEST_NAME HARNESS_SRC TEST_SRC REQUIRED_EXTENSIONS OPTS)
+  # Set SKL_ADD_TEST_FUNC for customized functionality.
+  cmake_language(CALL ${SKL_ADD_TEST_FUNC}
+    ${TEST_NAME}
+    ${HARNESS_SRC}
+    ${TEST_SRC}
+    "${REQUIRED_EXTENSIONS}"
+    "${OPTS}"
+  )
+endfunction()
+
+function(skl_add_test_default TEST_NAME HARNESS_SRC TEST_SRC REQUIRED_EXTENSIONS OPTS)
   # Build a test executable from the given harness and test file, and add a ctest test for it.
 
   # Only add the test if all extensions in REQUIRED_EXTENSIONS are present.
@@ -73,7 +74,11 @@ function(skl_add_test TEST_NAME HARNESS_SRC TEST_SRC REQUIRED_EXTENSIONS OPTS)
   endif()
 
   # Create the test command
-  cmake_language(CALL ${SKL_CUSTOM_ADD_TEST} ${TEST_NAME} ${TEST_EXEC} ${TEST_DIR})
+  add_test(
+    NAME ${TEST_NAME}
+    COMMAND ${SKL_TESTER} ${SKL_TESTER_OPTIONS} ${TEST_EXEC}
+    WORKING_DIRECTORY ${TEST_DIR}
+  )
 endfunction()
 
 skl_add_test(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,23 @@ target_compile_options(
   PRIVATE ${SKL_COMPILE_OPTIONS} ${SKL_TEST_COMPILE_OPTIONS}
 )
 
+function(skl_add_test_from_executable TEST_NAME TEST_EXEC)
+  # Default test registration function for an executable that already exists.
+  # Set SKL_CUSTOM_ADD_TEST to override with customized functionality.
+  add_test(
+    NAME ${TEST_NAME}
+    COMMAND ${SKL_TESTER} ${SKL_TESTER_OPTIONS} ${TEST_EXEC}
+    WORKING_DIRECTORY $<TARGET_FILE_DIR:${TEST_EXEC}>
+  )
+endfunction()
+
+set(SKL_CUSTOM_ADD_TEST "skl_add_test_from_executable" CACHE
+  STRING "Name of the function used to add a test given an executable target."
+)
+
 function(skl_add_test TEST_NAME HARNESS_SRC TEST_SRC REQUIRED_EXTENSIONS OPTS)
+  # Build a test executable from the given harness and test file, and add a ctest test for it.
+
   # Only add the test if all extensions in REQUIRED_EXTENSIONS are present.
   foreach(EXT ${REQUIRED_EXTENSIONS})
     assert_extension_valid(${EXT})
@@ -27,34 +43,35 @@ function(skl_add_test TEST_NAME HARNESS_SRC TEST_SRC REQUIRED_EXTENSIONS OPTS)
     endif()
   endforeach()
 
-  add_executable(test-${TEST_NAME} ${HARNESS_SRC} ${TEST_SRC})
+  set(TEST_NAME test-${TEST_NAME})
+  set(TEST_EXEC ${TEST_NAME})
+
+  # Create the test executable
+  add_executable(${TEST_EXEC} ${HARNESS_SRC} ${TEST_SRC})
   target_link_libraries(
-    test-${TEST_NAME}
+    ${TEST_EXEC}
     PRIVATE ${SKL_LIBRARY} ${SKL_TEST_LIBS} skl-test-driver
   )
   target_compile_options(
-    test-${TEST_NAME}
+    ${TEST_EXEC}
     PRIVATE ${SKL_COMPILE_OPTIONS} ${SKL_TEST_COMPILE_OPTIONS} ${OPTS}
   )
-  target_include_directories(test-${TEST_NAME} PRIVATE .)
+  target_include_directories(${TEST_EXEC} PRIVATE .)
   if(SKL_CLANG_TIDY_CMD)
-    set_target_properties(test-${TEST_NAME} PROPERTIES
+    set_target_properties(${TEST_EXEC} PROPERTIES
       C_CLANG_TIDY ${SKL_CLANG_TIDY_CMD}
     )
   endif()
 
   if(SKL_ENABLE_TESTS)
-    target_compile_definitions(test-${TEST_NAME} PRIVATE SKL_ENABLE_TESTS)
+    target_compile_definitions(${TEST_EXEC} PRIVATE SKL_ENABLE_TESTS)
   endif()
   if(SKL_ENABLE_BENCHMARKS)
-    target_compile_definitions(test-${TEST_NAME} PRIVATE SKL_ENABLE_BENCHMARKS)
+    target_compile_definitions(${TEST_EXEC} PRIVATE SKL_ENABLE_BENCHMARKS)
   endif()
 
-  add_test(
-    NAME test-${TEST_NAME}
-    COMMAND
-      ${SKL_TESTER} ${SKL_TESTER_OPTIONS} $<TARGET_FILE:test-${TEST_NAME}>
-  )
+  # Create the test command
+  cmake_language(CALL ${SKL_CUSTOM_ADD_TEST} ${TEST_NAME} ${TEST_EXEC})
 endfunction()
 
 skl_add_test(


### PR DESCRIPTION
This adds support for overriding the default behavior of the existing `add_test` command.

There are already variables `SKL_TESTER` and `SKL_TESTER_OPTIONS` that allow some customization, such as setting the appropriate tester and any options it may need. However in some cases this may be insufficient, such as if the tester expects arguments in a different order, or if more complex steps are needed in order to prepare/run the test in a given environment. This PR enables swapping out the `add_test` call with a custom CMake function.

Specific changes:
- Extracted `add_test` out of `skl_add_test` into a separate function `skl_add_test_from_executable`.
- Add a new cache variable `SKL_CUSTOM_ADD_TEST` specifying which CMake function should be used to add the test, defaulting to `skl_add_test_from_executable`.
- Call `${SKL_CUSTOM_ADD_TEST}` instead of `add_test` in `skl_add_test`.
- Add `TEST_EXEC` variable to centralize the test executable name.
