### PR TITLE
[GEMM] Use void * type for c in f32 Xsfmm fused kernel API

### DIFF
--- a/src/gemm/fused-kernel-API.md
+++ b/src/gemm/fused-kernel-API.md
@@ -87,9 +87,9 @@ Fused kernels operate on a single tile in the Xsfmm tile state and a single bloc
 Once a fused kernel has been implemented, the output of any inner loop function can be processed by applying it to each tile of the output.
 This single-tile API avoids the need for kernel authors to know how each inner loop function arranges data in matrix registers.
 
-The API for fused kernels is
+A fused kernel must have the following function signature:
 ```
-void kernel(size_t tm, size_t tn, size_t tss, <c type> *c, size_t rsc0,
+void kernel(size_t tm, size_t tn, size_t tss, void *c, size_t rsc0,
             size_t csc0, size_t rsc1, size_t csc1, size_t row1, size_t col1,
             void *params) __riscv_in("xsfmm");
 ```
@@ -97,7 +97,8 @@ where
 - `tss` is the tile subset specifier for the first row (column) of the subtile to be operated on
 - `tn` is the length of the row (resp. column) `tss` specifies
 - `tm` is the number of rows (resp. columns) in the subtile, i.e. the kernel operates on rows (resp. columns) `tss` to `tss + tm - 1`
-- `c + row1 * rsc1 + col1 * csc1` points to the block of `C` to be operated on
+- `c + row1 * rsc1 + col1 * csc1` points to the block of `C` to be operated on.
+Kernels should cast `c` to the appropriate type.
 - `rsc0` and `csc0` are the block's row and column strides
 - `params` points to a struct containing any other parameters the kernel needs.
 
@@ -110,6 +111,7 @@ Fused kernels will be called once for each block of `C`, and there is no guarant
 ### Examples
 We give some examples below of fused kernels for the `float` type.
 Pseudocode is given to illustrate the operation each kernel performs.
+In real code, elements `tss[i, j]` of the tile state are either stored directly to memory with `sf.vste*` or moved to the vector register file with `sf.vtmv.v.t`, where additional arithmetic operations can be applied to them.
 
 #### Alpha/beta scaling
 To compute a GEMM `C = alpha * A * B + beta * C`, the user can apply an alpha/beta scaling kernel:
@@ -120,7 +122,7 @@ typedef struct {
 } skl_gemm_alpha_beta_scaling_params_f32_f32_f32rcptexterc_xsfmmbase_t;
 
 void skl_gemm_alpha_beta_scaling_f32_f32_f32rcptexterc_xsfmmbase(
-    size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
+    size_t tm, size_t tn, size_t tss, void *c, size_t rsc0, size_t csc0,
     size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
     __riscv_in("xsfmm") {
   skl_gemm_alpha_beta_scaling_params_f32_f32_f32rcptexterc_xsfmmbase_t
@@ -130,7 +132,7 @@ void skl_gemm_alpha_beta_scaling_f32_f32_f32rcptexterc_xsfmmbase(
   float alpha = params_cast->alpha;
   float beta = params_cast->beta;
 
-  float *c_block = c + row1 * rsc1 + col1 * csc1;
+  float *c_block = (float *)c + row1 * rsc1 + col1 * csc1;
   for (size_t i = 0; i < tm; ++i)
     for (size_t j = 0; j < tn; ++j)
       c_block[i * rsc0 + j * csc0] =
@@ -166,23 +168,18 @@ __asm__ volatile(
     : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v16", "v17", "v18",
       "v19", "v20", "v21", "v22", "v23", "vtype", "vl", "memory");
 ```
+High-performance implementations may need to unroll and software pipeline this loop to hide the latency of the `sf.vtmv.v.t` instructions.
 
 #### Adding a bias
-The following kernel can be used to compute `C = A * B + bias`, where `bias` is a row vector that is added to each row of `A * B`:
+The following kernel can be used to compute `C = A * B + bias`, where `bias` is a row vector that is added to each row of `A * B`. Since this kernel requires one only pointer, `float *bias`, we can pass it directly as `params` to avoid defining an extra struct.
 ```
-typedef struct {
-  float *bias;
-} skl_gemm_add_bias_params_f32_f32_f32rcptexterc_xsfmmbase_t;
-
 void skl_gemm_add_bias_f32_f32_f32rcptexterc_xsfmmbase(
-    size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
+    size_t tm, size_t tn, size_t tss, void *c, size_t rsc0, size_t csc0,
     size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
     __riscv_in("xsfmm") {
-  skl_gemm_add_bias_params_f32_f32_f32rcptexterc_xsfmmbase_t *params_cast =
-      (skl_gemm_add_bias_params_f32_f32_f32rcptextexrc_xsfmmbase_t *)params;
-  float *bias = params_cast->bias;
+  float *bias = (float *)params;
 
-  float *c_block = c + row1 * rsc1 + col1 * csc1;
+  float *c_block = (float *)c + row1 * rsc1 + col1 * csc1;
   float *bias_block = bias + col1 * ETE;
   for (size_t i = 0; i < tm; ++i)
     for (size_t j = 0; j < tn; ++j)
@@ -192,21 +189,15 @@ void skl_gemm_add_bias_f32_f32_f32rcptexterc_xsfmmbase(
 Note that if `tss` specifies a column, then the bias is added to the *columns* of the subtile.
 
 #### Computing a global maximum
-To compute the maximum value of a matrix product, the following kernel can be used tile-by-tile to update the current maximum:
+To compute the maximum value of a matrix product, the following kernel can be used tile-by-tile to update the current maximum. As with the bias GEMM example, we can simply pass `float *max` directly as `params`.
 ```
-typedef struct {
-  float *max;
-} skl_gemm_matrix_max_params_f32_f32_f32rcptexterc_xsfmmbase_t;
-
 void skl_gemm_matrix_max_f32_f32_f32rcptexterc_xsfmmbase(
-    size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
+    size_t tm, size_t tn, size_t tss, void *c, size_t rsc0, size_t csc0,
     size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
     __riscv_in("xsfmm") {
-  skl_gemm_matrix_max_params_f32_f32_f32rcptexterc_xsfmmbase_t *params_cast =
-      (skl_gemm_matrix_max_params_f32_f32_f32rcptexterc_xsfmmbase_t *)params;
-  float *max = params_cast->max;
+  float *max = (float *)params;
 
-  float *c_block = c + row1 * rsc1 + col1 * csc1;
+  float *c_block = (float *)c + row1 * rsc1 + col1 * csc1;
   for (size_t i = 0; i < tm; ++i)
     for (size_t j = 0; j < tn; ++j) {
       if (tss[i, j] > *max)
@@ -220,18 +211,17 @@ void skl_gemm_matrix_max_f32_f32_f32rcptexterc_xsfmmbase(
 SKL provides (private) functions that apply a fused kernel to multiple tiles:
 ```
 typedef void (
-    *skl_gemm_fused_kernel_<a/b type>_<accum type>_<c type>rcptexterc_xsfmmbase_t)(
-    size_t tm, size_t tn, size_t tss, <c type> *c, size_t rsc0, size_t csc0,
+    *skl_gemm_fused_kernel_<a/b type>_<accum type>_rcptexterc_xsfmmbase_t)(
+    size_t tm, size_t tn, size_t tss, void *c, size_t rsc0, size_t csc0,
     size_t rsc1, size_t csc1, size_t row1, size_t col1, void *params)
     __riscv_in("xsfmm");
 
 SKL_FUNC_PRIVATE
-void skl_gemm_apply_fused_<a/b type>_<accum type>_<c type>rcptexterc_xsfmmbase(
-    size_t m, size_t n, size_t tss, size_t rstss, size_t cstss, <c type> *c,
+void skl_gemm_apply_fused_<a/b type>_<accum type>_rcptexterc_xsfmmbase(
+    size_t m, size_t n, size_t tss, size_t rstss, size_t cstss, void *c,
     size_t rsc0, size_t csc0, size_t rsc1, size_t csc1, size_t row1,
     size_t col1,
-    skl_gemm_fused_kernel_<a/b type>_<accum type>_<c type>rcptexterc_xsfmmbase_t
-        kernel,
+    skl_gemm_fused_kernel_<a/b type>_<accum type>_rcptexterc_xsfmmbase_t kernel,
     void *params) __riscv_in("xsfmm");
 ```
 `tss`, `rstss`, and `cstss` determine a tile layout analogous to the packed layout for matrices.
@@ -281,8 +271,8 @@ for (size_t i1 = 0; i1 < m1; ++i1) {
   size_t n_avl = n;
   for (size_t j1 = 0; j1 < n1; ++j1) {
     size_t tn = n_avl > ETE ? ETE : n_avl;
-    kernel(tm, tn, tss + i1 * rstss + j1 * cstss, c, rsc0, csc0, rsc1, csc1,
-           row1 + i1, col1 + j1, params);
+    (*kernel)(tm, tn, tss + i1 * rstss + j1 * cstss, c, rsc0, csc0, rsc1, csc1,
+              row1 + i1, col1 + j1, params);
     n_avl -= tn;
   }
   m_avl -= tm;
@@ -345,11 +335,11 @@ SKL provides the following (private) functions for loading a packed matrix into 
 ```
 SKL_FUNC_PRIVATE
 void skl_gemm_tile_load_<a/b type>_<c type>rcptexterc_<accum type>_xsfmmbase(
-    size_t m, size_t n, const <c type> *c, size_t rsc0, size_t csc0,
-    size_t rsc1, size_t csc1, size_t tss, size_t rstss, size_t cstss)
-    __riscv_out("xsfmm");
+    size_t m, size_t n, const void *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1, size_t row1, size_t col1, size_t tss, size_t rstss,
+    size_t cstss) __riscv_out("xsfmm");
 ```
-These functions load the leading `m` x `n` portion of `C` block-by-block into the tile layout determined by `tss`, `rstss`, and `cstss`.
+These functions load the leading `m` x `n` portion of `C` starting at block (`row1`, `col1`) block-by-block into the tile layout determined by `tss`, `rstss`, and `cstss`.
 The following pseudocode illustrates their operation:
 ```
 const size_t kShiftTile = 27;
@@ -364,7 +354,8 @@ for (size_t i1 = 0; i1 < m1; ++i1) {
   size_t tm = m_avl > ETE ? ETE : m_avl;
   size_t n_avl = n;
   for (size_t j1 = 0; j1 < n1; ++j1) {
-    const <type> *c_block = c + i1 * rsc1 + j1 * csc1;
+    const <c type> *c_block =
+        (<c type> *)c + (row1 + i1) * rsc1 + (col1 + j1) * csc1;
     size_t tss_tile = tss + i1 * rstss + j1 * cstss;
     size_t tn = n_avl > ETE ? ETE : n_avl;
     for (size_t i0 = 0; i0 < tm; ++i0) {
@@ -379,7 +370,8 @@ for (size_t i1 = 0; i1 < m1; ++i1) {
 Note that if `tss` has a column pattern, then the transpose of `C` is loaded into the tile layout with `rstss` interpreted as the column stride and `cstss` as the row stride, similar to the column pattern case for the fused kernel application functions.
 
 ## Applying a Tiling to `C`
-Now that we have described tile state initialization functions, inner loop functions, and fused kernels, we can put them all together to process parts of `C`.
+This section explains how the tile state initialization functions, inner loop functions, and fused kernels are combined to process parts of `C`.
+Note that SKL's GEMM tiling application functions `skl_gemm_apply_tiling_<a type>rcptex1c_<b type>rcp1xte_<accum type>_rcptexterc_<isa>` already provide this functionality; it is described in detail here for illustrative purposes.
 We will first initialize the tile state with zeros or by loading from `C`, then accumulate `A * B` into the tile state, and finally apply a fused kernel to the tile state.
 Applying an `m1` x `n1` tiling when `m1 <= n1` is relatively straightforward since transposition is not required.
 We can illustrate with a 1 x 2 tiling when `A`, `B`, and `C` are `float` matrices.
@@ -391,7 +383,7 @@ skl_gemm_tile_zero_f32_f32_xsfmmbase(m, n, 0, 0, 4);
 or
 ```
 skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase(
-    m, n, c + row1 * rsc1 + col1 * csc1, rsc0, csc0, rsc1, csc1, 0, 0, 4);
+    m, n, c, rsc0, csc0, rsc1, csc1, row1, col1, 0, 0, 4);
 ```
 `rstss` is set to 0 since the tiling has only one row and hence it is unused.
 Then accumulate `A * B` into the tile state:
@@ -402,9 +394,9 @@ skl_gemm_inner_loop_1x2_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f(m, n, k, a, rsa1,
 ```
 And finally apply the fused kernel:
 ```
-skl_gemm_apply_fused_f32_f32_f32rcptexterc_xsfmmbase(m, n, 0, 0, 4, c, rsc0,
-                                                     csc0, rsc1, csc1, row1,
-                                                     col1, kernel, params);
+skl_gemm_apply_fused_f32_f32_rcptexterc_xsfmmbase(m, n, 0, 0, 4, c, rsc0, csc0,
+                                                  rsc1, csc1, row1, col1,
+                                                  kernel, params);
 ```
 
 Tilings with `m1 > n1` are slightly more complicated because they involve transposition.
@@ -432,7 +424,7 @@ Recall that we can load the transpose of `C` by using a `tss` with a column patt
 So, we would call:
 ```
 skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase(
-    m, n, c + row1 * rsc1 + col1 * csc1, rsc0, csc0, rsc1, csc1,
+    m, n, c, rsc0, csc0, rsc1, csc1, row1, col1,
     1 << 24 /* mt0 with column pattern */, 4, 0);
 ```
 The inner loop function is called with `A` and `B` swapped and transposed:
@@ -443,8 +435,8 @@ skl_gemm_inner_loop_1x2_f32rcptex1c_f32rc1xtep_f32_xsfmm32a32f(n, m, k, b, csb1,
 ```
 Finally, we apply the fused kernel with a column pattern:
 ```
-skl_gemm_apply_fused_f32_f32_f32rcptexterc_xsfmmbase(m, n, 1 << 24, 4, 0, c,
-                                                     rsc0, csc0, rsc1, csc1,
-                                                     row1, col1, kernel,
-                                                     params);
+skl_gemm_apply_fused_f32_f32_rcptexterc_xsfmmbase(m, n, 1 << 24, 4, 0, c,
+                                                  rsc0, csc0, rsc1, csc1,
+                                                  row1, col1, kernel,
+                                                  params);
 ```

--- a/src/gemm/gemm_f32c_f32_f32_xsfmm32a32f.c
+++ b/src/gemm/gemm_f32c_f32_f32_xsfmm32a32f.c
@@ -113,7 +113,7 @@ void skl_gemm_tile_zero_f32_f32_xsfmmbase(size_t m, size_t n, size_t tss,
     size_t n_avl = n;
     for (size_t j1 = 0; j1 < n1; ++j1) {
       size_t tn = n_avl >= ete ? ete : n_avl;
-      tile_zero_functions[tzf0 + i1 * rstzf + j1 * cstzf](tm, tn);
+      (*tile_zero_functions[tzf0 + i1 * rstzf + j1 * cstzf])(tm, tn);
       n_avl -= tn;
     }
     m_avl -= tm;
@@ -1147,8 +1147,8 @@ skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_rcptexterc_xsfmm32a32f(
   }
 
   if (accum) {
-    tile_load(m, n, c, rsc0, csc0, rsc1, csc1, row1, col1, trans ? mt0c : mt0,
-              rstss, cstss);
+    (*tile_load)(m, n, c, rsc0, csc0, rsc1, csc1, row1, col1,
+                 trans ? mt0c : mt0, rstss, cstss);
   } else {
     if (trans) {
       // NOLINTBEGIN(readability-suspicious-call-argument)
@@ -1160,9 +1160,9 @@ skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_rcptexterc_xsfmm32a32f(
   }
 
   if (trans) {
-    inner_loop(n, m, k, b, csb1, rsb1, a, csa1, rsa1);
+    (*inner_loop)(n, m, k, b, csb1, rsb1, a, csa1, rsa1);
   } else {
-    inner_loop(m, n, k, a, rsa1, csa1, b, rsb1, csb1);
+    (*inner_loop)(m, n, k, a, rsa1, csa1, b, rsb1, csb1);
   }
 
   skl_gemm_apply_fused_f32_f32_rcptexterc_xsfmmbase(
@@ -1176,7 +1176,7 @@ skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_rcptexterc_xsfmm32a32f(
   do {                                                                         \
     skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_rcptexterc_xsfmm32a32f(   \
         tile_load, M1, N1,                                                     \
-        skl_gemm_inner_loop_##M1XN1##_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f,  \
+        &skl_gemm_inner_loop_##M1XN1##_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f, \
         M, N, k, a + (ROW1) * rsa1, rsa1, csa1, b + (COL1) * csb1, rsb1, csb1, \
         c, rsc0, csc0, rsc1, csc1, ROW1, COL1, accum, kernel, params);         \
   } while (0)
@@ -1271,9 +1271,9 @@ SKL_FUNC void skl_gemm_f32c_f32_f32_xsfmm32a32f(size_t m, size_t n, size_t k,
   __asm__ volatile("sf.vsettnt %0, x0, e32, w1" : "=r"(ete) : : "vtype", "vl");
 
   skl_gemm_fused_f32rcptex1c_f32rcp1xte_f32_rcptexterc_xsfmm32a32f(
-      skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase, m, n, k, a, ete, csa,
+      &skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase, m, n, k, a, ete, csa,
       b, rsb, ete, c, rsc, 1, ete * rsc, ete, false,
-      skl_gemm_alpha_beta_scaling_f32_f32_f32rcptexterc_xsfmmbase, &params);
+      &skl_gemm_alpha_beta_scaling_f32_f32_f32rcptexterc_xsfmmbase, &params);
 }
 
 /* Computes C = alpha * A * B + beta * C for packed matrices A, B, and C. */
@@ -1288,7 +1288,7 @@ SKL_FUNC void skl_gemm_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f(
   __asm__ volatile("sf.vsettnt %0, x0, e32, w1" : "=r"(ete) : : "vtype", "vl");
 
   skl_gemm_fused_f32rcptex1c_f32rcp1xte_f32_rcptexterc_xsfmm32a32f(
-      skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase, m1 * ete, n1 * ete, k,
-      a, rsa1, csa1, b, rsb1, csb1, c, rsc0, csc0, rsc1, csc1, false,
-      skl_gemm_alpha_beta_scaling_f32_f32_f32rcptexterc_xsfmmbase, &params);
+      &skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase, m1 * ete, n1 * ete,
+      k, a, rsa1, csa1, b, rsb1, csb1, c, rsc0, csc0, rsc1, csc1, false,
+      &skl_gemm_alpha_beta_scaling_f32_f32_f32rcptexterc_xsfmmbase, &params);
 }

--- a/src/gemm/gemm_f32c_f32_f32_xsfmm32a32f.c
+++ b/src/gemm/gemm_f32c_f32_f32_xsfmm32a32f.c
@@ -15,7 +15,7 @@
 typedef void (*skl_gemm_tile_zero_f32_f32_xsfmmbase_t)(size_t tm,
                                                        size_t tn) SKL_XSFMM_OUT;
 
-typedef void (*skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase_t)(
+typedef void (*skl_gemm_tile_load_f32_rcptexterc_f32_xsfmmbase_t)(
     size_t m, size_t n, const void *c, size_t rsc0, size_t csc0, size_t rsc1,
     size_t csc1, size_t row1, size_t col1, size_t tss, size_t rstss,
     size_t cstss) SKL_XSFMM_OUT;
@@ -24,7 +24,7 @@ typedef void (*skl_gemm_inner_loop_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f_t)(
     size_t m, size_t n, size_t k, const float *a, size_t rsa1, size_t csa1,
     const float *b, size_t rsb1, size_t csb1) SKL_XSFMM_INOUT;
 
-typedef void (*skl_gemm_fused_kernel_f32_f32_f32rcptexterc_xsfmmbase_t)(
+typedef void (*skl_gemm_fused_kernel_f32_f32_rcptexterc_xsfmmbase_t)(
     size_t tm, size_t tn, size_t tss, void *c, size_t rsc0, size_t csc0,
     size_t rsc1, size_t csc1, size_t row1, size_t col1,
     void *params) SKL_XSFMM_IN;
@@ -194,10 +194,10 @@ void skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase(
  * packed matrix C.
  */
 SKL_FUNC_PRIVATE
-void skl_gemm_apply_fused_f32_f32_f32rcptexterc_xsfmmbase(
+void skl_gemm_apply_fused_f32_f32_rcptexterc_xsfmmbase(
     size_t m, size_t n, size_t tss, size_t rstss, size_t cstss, void *c,
     size_t rsc0, size_t csc0, size_t rsc1, size_t csc1, size_t row1,
-    size_t col1, skl_gemm_fused_kernel_f32_f32_f32rcptexterc_xsfmmbase_t kernel,
+    size_t col1, skl_gemm_fused_kernel_f32_f32_rcptexterc_xsfmmbase_t kernel,
     void *params) SKL_XSFMM_IN {
   if (m == 0 || n == 0) {
     return;
@@ -1114,14 +1114,14 @@ skl_gemm_inner_loop_2x2_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f(
  * ETE. If m1 > n1, then the n1 x m1 inner loop function should be called.
  */
 SKL_FUNC_PRIVATE void
-skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_f32rcptexterc_xsfmm32a32f(
-    skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase_t tile_load, size_t m1,
+skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_rcptexterc_xsfmm32a32f(
+    skl_gemm_tile_load_f32_rcptexterc_f32_xsfmmbase_t tile_load, size_t m1,
     size_t n1,
     skl_gemm_inner_loop_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f_t inner_loop,
     size_t m, size_t n, size_t k, const float *a, size_t rsa1, size_t csa1,
     const float *b, size_t rsb1, size_t csb1, void *c, size_t rsc0, size_t csc0,
     size_t rsc1, size_t csc1, size_t row1, size_t col1, bool accum,
-    skl_gemm_fused_kernel_f32_f32_f32rcptexterc_xsfmmbase_t kernel,
+    skl_gemm_fused_kernel_f32_f32_rcptexterc_xsfmmbase_t kernel,
     void *params) SKL_XSFMM_NEW {
   if (m == 0 || n == 0) {
     return;
@@ -1165,33 +1165,32 @@ skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_f32rcptexterc_xsfmm32a32f(
     inner_loop(m, n, k, a, rsa1, csa1, b, rsb1, csb1);
   }
 
-  skl_gemm_apply_fused_f32_f32_f32rcptexterc_xsfmmbase(
+  skl_gemm_apply_fused_f32_f32_rcptexterc_xsfmmbase(
       m, n, trans ? mt0c : mt0, rstss, cstss, c, rsc0, csc0, rsc1, csc1, row1,
       col1, kernel, params);
 
   __asm__ volatile("sf.vtdiscard");
 }
 
-#define SKL_GEMM_TILE(M1, N1, M1XN1, M, N, ROW1, COL1)                          \
-  do {                                                                          \
-    skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_f32rcptexterc_xsfmm32a32f( \
-        tile_load, M1, N1,                                                      \
-        skl_gemm_inner_loop_##M1XN1##_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f,   \
-        M, N, k, a + (ROW1) * rsa1, rsa1, csa1, b + (COL1) * csb1, rsb1, csb1,  \
-        c, rsc0, csc0, rsc1, csc1, ROW1, COL1, accum, kernel, params);          \
+#define SKL_GEMM_TILE(M1, N1, M1XN1, M, N, ROW1, COL1)                         \
+  do {                                                                         \
+    skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_rcptexterc_xsfmm32a32f(   \
+        tile_load, M1, N1,                                                     \
+        skl_gemm_inner_loop_##M1XN1##_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f,  \
+        M, N, k, a + (ROW1) * rsa1, rsa1, csa1, b + (COL1) * csb1, rsb1, csb1, \
+        c, rsc0, csc0, rsc1, csc1, ROW1, COL1, accum, kernel, params);         \
   } while (0)
 
 /* Computes A * B (accum == false) or C + A * B (accum == true) and applies a
  * fused kernel.
  */
 SKL_FUNC_PRIVATE void
-skl_gemm_fused_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f(
-    skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase_t tile_load, size_t m,
+skl_gemm_fused_f32rcptex1c_f32rcp1xte_f32_rcptexterc_xsfmm32a32f(
+    skl_gemm_tile_load_f32_rcptexterc_f32_xsfmmbase_t tile_load, size_t m,
     size_t n, size_t k, const float *a, size_t rsa1, size_t csa1,
     const float *b, size_t rsb1, size_t csb1, void *c, size_t rsc0, size_t csc0,
     size_t rsc1, size_t csc1, bool accum,
-    skl_gemm_fused_kernel_f32_f32_f32rcptexterc_xsfmmbase_t kernel,
-    void *params) {
+    skl_gemm_fused_kernel_f32_f32_rcptexterc_xsfmmbase_t kernel, void *params) {
   if (m == 0 || n == 0) {
     return;
   }
@@ -1271,7 +1270,7 @@ SKL_FUNC void skl_gemm_f32c_f32_f32_xsfmm32a32f(size_t m, size_t n, size_t k,
   size_t ete = 0; // Effective tile edge length (always TE for TEW = 32).
   __asm__ volatile("sf.vsettnt %0, x0, e32, w1" : "=r"(ete) : : "vtype", "vl");
 
-  skl_gemm_fused_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f(
+  skl_gemm_fused_f32rcptex1c_f32rcp1xte_f32_rcptexterc_xsfmm32a32f(
       skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase, m, n, k, a, ete, csa,
       b, rsb, ete, c, rsc, 1, ete * rsc, ete, false,
       skl_gemm_alpha_beta_scaling_f32_f32_f32rcptexterc_xsfmmbase, &params);
@@ -1288,7 +1287,7 @@ SKL_FUNC void skl_gemm_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f(
   size_t ete = 0; // Effective tile edge length (always TE for TEW = 32).
   __asm__ volatile("sf.vsettnt %0, x0, e32, w1" : "=r"(ete) : : "vtype", "vl");
 
-  skl_gemm_fused_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f(
+  skl_gemm_fused_f32rcptex1c_f32rcp1xte_f32_rcptexterc_xsfmm32a32f(
       skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase, m1 * ete, n1 * ete, k,
       a, rsa1, csa1, b, rsb1, csb1, c, rsc0, csc0, rsc1, csc1, false,
       skl_gemm_alpha_beta_scaling_f32_f32_f32rcptexterc_xsfmmbase, &params);

--- a/src/gemm/gemm_f32c_f32_f32_xsfmm32a32f.c
+++ b/src/gemm/gemm_f32c_f32_f32_xsfmm32a32f.c
@@ -15,12 +15,17 @@
 typedef void (*skl_gemm_tile_zero_f32_f32_xsfmmbase_t)(size_t tm,
                                                        size_t tn) SKL_XSFMM_OUT;
 
+typedef void (*skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase_t)(
+    size_t m, size_t n, const void *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1, size_t row1, size_t col1, size_t tss, size_t rstss,
+    size_t cstss) SKL_XSFMM_OUT;
+
 typedef void (*skl_gemm_inner_loop_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f_t)(
     size_t m, size_t n, size_t k, const float *a, size_t rsa1, size_t csa1,
     const float *b, size_t rsb1, size_t csb1) SKL_XSFMM_INOUT;
 
 typedef void (*skl_gemm_fused_kernel_f32_f32_f32rcptexterc_xsfmmbase_t)(
-    size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
+    size_t tm, size_t tn, size_t tss, void *c, size_t rsc0, size_t csc0,
     size_t rsc1, size_t csc1, size_t row1, size_t col1,
     void *params) SKL_XSFMM_IN;
 
@@ -115,11 +120,13 @@ void skl_gemm_tile_zero_f32_f32_xsfmmbase(size_t m, size_t n, size_t tss,
   }
 }
 
-/* Load the leading m x n portion of packed matrix C into the tile state. */
+/* Load the leading m x n portion of packed matrix C starting at block
+ * (row1, col1) into the tile state. */
 SKL_FUNC_PRIVATE
 void skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase(
-    size_t m, size_t n, const float *c, size_t rsc0, size_t csc0, size_t rsc1,
-    size_t csc1, size_t tss, size_t rstss, size_t cstss) SKL_XSFMM_OUT {
+    size_t m, size_t n, const void *c, size_t rsc0, size_t csc0, size_t rsc1,
+    size_t csc1, size_t row1, size_t col1, size_t tss, size_t rstss,
+    size_t cstss) SKL_XSFMM_OUT {
   if (m == 0 || n == 0) {
     return;
   }
@@ -141,7 +148,8 @@ void skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase(
     for (size_t j1 = 0; j1 < n1; ++j1) {
       size_t tn = n_avl >= ete ? ete : n_avl;
       size_t tss_tile = tss + i1 * rstss + j1 * cstss;
-      const float *c_block = c + i1 * rsc1 + j1 * csc1;
+      const float *c_block =
+          (float *)c + (row1 + i1) * rsc1 + (col1 + j1) * csc1;
       size_t i0 = 0;
       if (csc0 == 1) {
         __asm__ volatile(
@@ -187,7 +195,7 @@ void skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase(
  */
 SKL_FUNC_PRIVATE
 void skl_gemm_apply_fused_f32_f32_f32rcptexterc_xsfmmbase(
-    size_t m, size_t n, size_t tss, size_t rstss, size_t cstss, float *c,
+    size_t m, size_t n, size_t tss, size_t rstss, size_t cstss, void *c,
     size_t rsc0, size_t csc0, size_t rsc1, size_t csc1, size_t row1,
     size_t col1, skl_gemm_fused_kernel_f32_f32_f32rcptexterc_xsfmmbase_t kernel,
     void *params) SKL_XSFMM_IN {
@@ -601,7 +609,7 @@ SKL_FUNC_PRIVATE void skl_gemm_alpha_beta_scaling_m2_f32_f32_f32_xsfmmbase(
  */
 SKL_FUNC_PRIVATE
 void skl_gemm_alpha_beta_scaling_f32_f32_f32rcptexterc_xsfmmbase(
-    size_t tm, size_t tn, size_t tss, float *c, size_t rsc0, size_t csc0,
+    size_t tm, size_t tn, size_t tss, void *c, size_t rsc0, size_t csc0,
     size_t rsc1, size_t csc1, size_t row1, size_t col1,
     void *params) SKL_XSFMM_IN {
   /* Use row-major code when rsc0 == 1 if possible. */
@@ -625,7 +633,7 @@ void skl_gemm_alpha_beta_scaling_f32_f32_f32rcptexterc_xsfmmbase(
                *)params;
   float alpha = params_cast->alpha;
   float beta = params_cast->beta;
-  float *c_block = c + row1 * rsc1 + col1 * csc1;
+  float *c_block = (float *)c + row1 * rsc1 + col1 * csc1;
 
   size_t ete = 0;
   __asm__ volatile("sf.vsettnt %0, x0, e32, w1" : "=r"(ete) : : "vtype", "vl");
@@ -1107,11 +1115,12 @@ skl_gemm_inner_loop_2x2_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f(
  */
 SKL_FUNC_PRIVATE void
 skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_f32rcptexterc_xsfmm32a32f(
-    size_t m1, size_t n1,
+    skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase_t tile_load, size_t m1,
+    size_t n1,
     skl_gemm_inner_loop_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f_t inner_loop,
     size_t m, size_t n, size_t k, const float *a, size_t rsa1, size_t csa1,
-    const float *b, size_t rsb1, size_t csb1, float *c, size_t rsc0,
-    size_t csc0, size_t rsc1, size_t csc1, size_t row1, size_t col1, bool accum,
+    const float *b, size_t rsb1, size_t csb1, void *c, size_t rsc0, size_t csc0,
+    size_t rsc1, size_t csc1, size_t row1, size_t col1, bool accum,
     skl_gemm_fused_kernel_f32_f32_f32rcptexterc_xsfmmbase_t kernel,
     void *params) SKL_XSFMM_NEW {
   if (m == 0 || n == 0) {
@@ -1138,9 +1147,8 @@ skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_f32rcptexterc_xsfmm32a32f(
   }
 
   if (accum) {
-    skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase(
-        m, n, c + row1 * rsc1 + col1 * csc1, rsc0, csc0, rsc1, csc1,
-        trans ? mt0c : mt0, rstss, cstss);
+    tile_load(m, n, c, rsc0, csc0, rsc1, csc1, row1, col1, trans ? mt0c : mt0,
+              rstss, cstss);
   } else {
     if (trans) {
       // NOLINTBEGIN(readability-suspicious-call-argument)
@@ -1167,7 +1175,7 @@ skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_f32rcptexterc_xsfmm32a32f(
 #define SKL_GEMM_TILE(M1, N1, M1XN1, M, N, ROW1, COL1)                          \
   do {                                                                          \
     skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_f32rcptexterc_xsfmm32a32f( \
-        M1, N1,                                                                 \
+        tile_load, M1, N1,                                                      \
         skl_gemm_inner_loop_##M1XN1##_f32rcptex1c_f32rcp1xte_f32_xsfmm32a32f,   \
         M, N, k, a + (ROW1) * rsa1, rsa1, csa1, b + (COL1) * csb1, rsb1, csb1,  \
         c, rsc0, csc0, rsc1, csc1, ROW1, COL1, accum, kernel, params);          \
@@ -1178,9 +1186,10 @@ skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_f32rcptexterc_xsfmm32a32f(
  */
 SKL_FUNC_PRIVATE void
 skl_gemm_fused_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f(
-    size_t m, size_t n, size_t k, const float *a, size_t rsa1, size_t csa1,
-    const float *b, size_t rsb1, size_t csb1, float *c, size_t rsc0,
-    size_t csc0, size_t rsc1, size_t csc1, bool accum,
+    skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase_t tile_load, size_t m,
+    size_t n, size_t k, const float *a, size_t rsa1, size_t csa1,
+    const float *b, size_t rsb1, size_t csb1, void *c, size_t rsc0, size_t csc0,
+    size_t rsc1, size_t csc1, bool accum,
     skl_gemm_fused_kernel_f32_f32_f32rcptexterc_xsfmmbase_t kernel,
     void *params) {
   if (m == 0 || n == 0) {
@@ -1263,7 +1272,8 @@ SKL_FUNC void skl_gemm_f32c_f32_f32_xsfmm32a32f(size_t m, size_t n, size_t k,
   __asm__ volatile("sf.vsettnt %0, x0, e32, w1" : "=r"(ete) : : "vtype", "vl");
 
   skl_gemm_fused_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f(
-      m, n, k, a, ete, csa, b, rsb, ete, c, rsc, 1, ete * rsc, ete, false,
+      skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase, m, n, k, a, ete, csa,
+      b, rsb, ete, c, rsc, 1, ete * rsc, ete, false,
       skl_gemm_alpha_beta_scaling_f32_f32_f32rcptexterc_xsfmmbase, &params);
 }
 
@@ -1279,7 +1289,7 @@ SKL_FUNC void skl_gemm_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f(
   __asm__ volatile("sf.vsettnt %0, x0, e32, w1" : "=r"(ete) : : "vtype", "vl");
 
   skl_gemm_fused_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f(
-      m1 * ete, n1 * ete, k, a, rsa1, csa1, b, rsb1, csb1, c, rsc0, csc0, rsc1,
-      csc1, false, skl_gemm_alpha_beta_scaling_f32_f32_f32rcptexterc_xsfmmbase,
-      &params);
+      skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase, m1 * ete, n1 * ete, k,
+      a, rsa1, csa1, b, rsb1, csb1, c, rsc0, csc0, rsc1, csc1, false,
+      skl_gemm_alpha_beta_scaling_f32_f32_f32rcptexterc_xsfmmbase, &params);
 }


### PR DESCRIPTION
This PR updates `c` to have a `void *` type rather than `float *` in the fused kernel API. This enables reuse of the GEMM dispatch function for different `c` types.

The tile load function API has been modified from
```
void skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase(
    size_t m, size_t n, const float *c, size_t rsc0, size_t csc0, size_t rsc1,
    size_t csc1, size_t tss, size_t rstss, size_t cstss) SKL_XSFMM_OUT;
```
to
```
void skl_gemm_tile_load_f32_f32rcptexterc_f32_xsfmmbase(
    size_t m, size_t n, const void *c, size_t rsc0, size_t csc0, size_t rsc1,
    size_t csc1, size_t row1, size_t col1, size_t tss, size_t rstss,
    size_t cstss) SKL_XSFMM_OUT;
```

`skl_gemm_apply_fused_f32_f32_f32rcptexterc_xsfmmbase` now takes `void *c` instead of `float *c` and has been renamed to `skl_gemm_apply_fused_f32_f32_rcptexterc_xsfmmbase`.

`skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f` now takes an addition `tile_load` argument which points to the tile load function to be used and also takes `void *c` instead of `float *c`. It has been renamed to `skl_gemm_apply_tiling_f32rcptex1c_f32rcp1xte_f32_rcptexterc_xsfmm32a32f`. In other words, the type specifier substring has been changed from `<a type>rcptex1c_<b type>rcp1xte_<c type>rcptexterc` to `<a type>rcptex1c_<b type>rcp1xte_<accum type>_rcptexterc`.

The GEMM dispatch function `skl_gemm_fused_f32rcptex1c_f32rcp1xte_f32rcptexterc_xsfmm32a32f` takes `void *c` instead of `float *c` and has been renamed to `skl_gemm_fused_f32rcptex1c_f32rcp1xte_f32_rcptexterc_xsfmm32a32f`. The name changes are the same as those for the tiling application function.

