### PR TITLE
[Sigmoid] Fix benchmark-only tests compile errors

### DIFF
--- a/test/sigmoid/sigmoid_bf16_xsfvfbfa.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfbfa.c
@@ -35,27 +35,27 @@
 #define SWIGLU_MAX (+6.f)
 #define SWIGLU_DELTA (__bf16)0.5
 
-static void test_swish_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n) {
+void test_swish_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_xsfvfbfa(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA, in, n);
 }
 
-static void test_glu_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n) {
+void test_glu_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_xsfvfbfa(out, in, in, n);
 }
 
-static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_ref(out, in, in, n);
 }
 
-static void test_swiglu_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n) {
+void test_swiglu_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_xsfvfbfa(out, in, in, SWIGLU_DELTA, n);
 }
 
-static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_bf16_xsfvfbfa.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfbfa.c
@@ -39,27 +39,25 @@ static void test_swish_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_xsfvfbfa(out, SWISH_BETA, in, n);
 }
 
-static void test_glu_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_glu_bf16_xsfvfbfa(out, in, in, n);
-}
-
-static void test_swiglu_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swiglu_bf16_xsfvfbfa(out, in, in, SWIGLU_DELTA, n);
-}
-
-#if defined(SKL_ENABLE_TESTS)
 static void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA, in, n);
+}
+
+static void test_glu_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_glu_bf16_xsfvfbfa(out, in, in, n);
 }
 
 static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_ref(out, in, in, n);
 }
 
+static void test_swiglu_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swiglu_bf16_xsfvfbfa(out, in, in, SWIGLU_DELTA, n);
+}
+
 static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
-#endif
 
 unary_bf16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_bf16_xsfvfbfa.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfbfa.c
@@ -39,25 +39,27 @@ static void test_swish_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_xsfvfbfa(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_ref(out, SWISH_BETA, in, n);
-}
-
 static void test_glu_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_xsfvfbfa(out, in, in, n);
-}
-
-static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_glu_bf16_ref(out, in, in, n);
 }
 
 static void test_swiglu_bf16_xsfvfbfa(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_xsfvfbfa(out, in, in, SWIGLU_DELTA, n);
 }
 
+#if defined(SKL_ENABLE_TESTS)
+static void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_ref(out, SWISH_BETA, in, n);
+}
+
+static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_glu_bf16_ref(out, in, in, n);
+}
+
 static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
+#endif
 
 unary_bf16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_bf16_xsfvfbfexp16e_xsfvfbfa.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfbfexp16e_xsfvfbfa.c
@@ -36,8 +36,8 @@
 #define SWIGLU_MAX (+6.f)
 #define SWIGLU_DELTA (__bf16)0.5
 
-void test_swish_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out,
-                                                   const __bf16 *in, size_t n) {
+void test_swish_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out, const __bf16 *in,
+                                            size_t n) {
   skl_swish_bf16_xsfvfbfexp16e_xsfvfbfa(out, SWISH_BETA, in, n);
 }
 
@@ -46,7 +46,7 @@ void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
 }
 
 void test_glu_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out, const __bf16 *in,
-                                                 size_t n) {
+                                          size_t n) {
   skl_glu_bf16_xsfvfbfexp16e_xsfvfbfa(out, in, in, n);
 }
 
@@ -54,9 +54,8 @@ void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_ref(out, in, in, n);
 }
 
-void test_swiglu_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out,
-                                                    const __bf16 *in,
-                                                    size_t n) {
+void test_swiglu_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out, const __bf16 *in,
+                                             size_t n) {
   skl_swiglu_bf16_xsfvfbfexp16e_xsfvfbfa(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_bf16_xsfvfbfexp16e_xsfvfbfa.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfbfexp16e_xsfvfbfa.c
@@ -41,17 +41,9 @@ static void test_swish_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out,
   skl_swish_bf16_xsfvfbfexp16e_xsfvfbfa(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_ref(out, SWISH_BETA, in, n);
-}
-
 static void test_glu_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out, const __bf16 *in,
                                                  size_t n) {
   skl_glu_bf16_xsfvfbfexp16e_xsfvfbfa(out, in, in, n);
-}
-
-static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_glu_bf16_ref(out, in, in, n);
 }
 
 static void test_swiglu_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out,
@@ -60,9 +52,19 @@ static void test_swiglu_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out,
   skl_swiglu_bf16_xsfvfbfexp16e_xsfvfbfa(out, in, in, SWIGLU_DELTA, n);
 }
 
+#if defined(SKL_ENABLE_TESTS)
+static void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_ref(out, SWISH_BETA, in, n);
+}
+
+static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_glu_bf16_ref(out, in, in, n);
+}
+
 static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
+#endif
 
 unary_bf16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_bf16_xsfvfbfexp16e_xsfvfbfa.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfbfexp16e_xsfvfbfa.c
@@ -36,31 +36,31 @@
 #define SWIGLU_MAX (+6.f)
 #define SWIGLU_DELTA (__bf16)0.5
 
-static void test_swish_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out,
+void test_swish_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out,
                                                    const __bf16 *in, size_t n) {
   skl_swish_bf16_xsfvfbfexp16e_xsfvfbfa(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA, in, n);
 }
 
-static void test_glu_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out, const __bf16 *in,
+void test_glu_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out, const __bf16 *in,
                                                  size_t n) {
   skl_glu_bf16_xsfvfbfexp16e_xsfvfbfa(out, in, in, n);
 }
 
-static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_ref(out, in, in, n);
 }
 
-static void test_swiglu_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out,
+void test_swiglu_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out,
                                                     const __bf16 *in,
                                                     size_t n) {
   skl_swiglu_bf16_xsfvfbfexp16e_xsfvfbfa(out, in, in, SWIGLU_DELTA, n);
 }
 
-static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_bf16_xsfvfbfexp16e_xsfvfbfa.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfbfexp16e_xsfvfbfa.c
@@ -41,9 +41,17 @@ static void test_swish_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out,
   skl_swish_bf16_xsfvfbfexp16e_xsfvfbfa(out, SWISH_BETA, in, n);
 }
 
+static void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_ref(out, SWISH_BETA, in, n);
+}
+
 static void test_glu_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out, const __bf16 *in,
                                                  size_t n) {
   skl_glu_bf16_xsfvfbfexp16e_xsfvfbfa(out, in, in, n);
+}
+
+static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_glu_bf16_ref(out, in, in, n);
 }
 
 static void test_swiglu_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out,
@@ -52,19 +60,9 @@ static void test_swiglu_bf16_xsfvfbfexp16e_xsfvfbfa(__bf16 *out,
   skl_swiglu_bf16_xsfvfbfexp16e_xsfvfbfa(out, in, in, SWIGLU_DELTA, n);
 }
 
-#if defined(SKL_ENABLE_TESTS)
-static void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_ref(out, SWISH_BETA, in, n);
-}
-
-static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_glu_bf16_ref(out, in, in, n);
-}
-
 static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
-#endif
 
 unary_bf16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_bf16_xsfvfexp32e.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfexp32e.c
@@ -37,47 +37,47 @@
 #define SWIGLU_MAX (+6.f)
 #define SWIGLU_DELTA (__bf16)0.5
 
-static void test_swish_b1_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
+void test_swish_b1_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
                                            size_t n) {
   skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_ONE, in, n);
 }
 
-static void ref_swish_b1_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_swish_b1_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA_ONE, in, n);
 }
 
-static void test_swish_bp_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
+void test_swish_bp_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
                                            size_t n) {
   skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_POS, in, n);
 }
 
-static void ref_swish_bp_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_swish_bp_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA_POS, in, n);
 }
 
-static void test_swish_bn_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
+void test_swish_bn_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
                                            size_t n) {
   skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_NEG, in, n);
 }
 
-static void ref_swish_bn_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_swish_bn_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA_NEG, in, n);
 }
 
-static void test_glu_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in, size_t n) {
+void test_glu_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_xsfvfexp32e(out, in, in, n);
 }
 
-static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_ref(out, in, in, n);
 }
 
-static void test_swiglu_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
+void test_swiglu_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
                                          size_t n) {
   skl_swiglu_bf16_xsfvfexp32e(out, in, in, SWIGLU_DELTA, n);
 }
 
-static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_bf16_xsfvfexp32e.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfexp32e.c
@@ -37,39 +37,13 @@
 #define SWIGLU_MAX (+6.f)
 #define SWIGLU_DELTA (__bf16)0.5
 
-static void test_swish_b1_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
-                                           size_t n) {
-  skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_ONE, in, n);
-}
-
-static void ref_swish_b1_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_ref(out, SWISH_BETA_ONE, in, n);
-}
-
 static void test_swish_bp_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
                                            size_t n) {
   skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_POS, in, n);
 }
 
-static void ref_swish_bp_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_ref(out, SWISH_BETA_POS, in, n);
-}
-
-static void test_swish_bn_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
-                                           size_t n) {
-  skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_NEG, in, n);
-}
-
-static void ref_swish_bn_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_ref(out, SWISH_BETA_NEG, in, n);
-}
-
 static void test_glu_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_xsfvfexp32e(out, in, in, n);
-}
-
-static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_glu_bf16_ref(out, in, in, n);
 }
 
 static void test_swiglu_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
@@ -77,9 +51,37 @@ static void test_swiglu_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
   skl_swiglu_bf16_xsfvfexp32e(out, in, in, SWIGLU_DELTA, n);
 }
 
+#if defined(SKL_ENABLE_TESTS)
+static void test_swish_b1_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
+                                           size_t n) {
+  skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_ONE, in, n);
+}
+
+static void test_swish_bn_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
+                                           size_t n) {
+  skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_NEG, in, n);
+}
+
+static void ref_swish_b1_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_ref(out, SWISH_BETA_ONE, in, n);
+}
+
+static void ref_swish_bp_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_ref(out, SWISH_BETA_POS, in, n);
+}
+
+static void ref_swish_bn_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_ref(out, SWISH_BETA_NEG, in, n);
+}
+
+static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_glu_bf16_ref(out, in, in, n);
+}
+
 static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
+#endif
 
 unary_bf16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_bf16_xsfvfexp32e.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfexp32e.c
@@ -37,8 +37,7 @@
 #define SWIGLU_MAX (+6.f)
 #define SWIGLU_DELTA (__bf16)0.5
 
-void test_swish_b1_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
-                                           size_t n) {
+void test_swish_b1_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_ONE, in, n);
 }
 
@@ -46,8 +45,7 @@ void ref_swish_b1_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA_ONE, in, n);
 }
 
-void test_swish_bp_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
-                                           size_t n) {
+void test_swish_bp_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_POS, in, n);
 }
 
@@ -55,8 +53,7 @@ void ref_swish_bp_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA_POS, in, n);
 }
 
-void test_swish_bn_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
-                                           size_t n) {
+void test_swish_bn_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_NEG, in, n);
 }
 
@@ -72,8 +69,7 @@ void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_ref(out, in, in, n);
 }
 
-void test_swiglu_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
-                                         size_t n) {
+void test_swiglu_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_xsfvfexp32e(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_bf16_xsfvfexp32e.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfexp32e.c
@@ -37,24 +37,22 @@
 #define SWIGLU_MAX (+6.f)
 #define SWIGLU_DELTA (__bf16)0.5
 
+static void test_swish_b1_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
+                                           size_t n) {
+  skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_ONE, in, n);
+}
+
+static void ref_swish_b1_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_ref(out, SWISH_BETA_ONE, in, n);
+}
+
 static void test_swish_bp_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
                                            size_t n) {
   skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_POS, in, n);
 }
 
-static void test_glu_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_glu_bf16_xsfvfexp32e(out, in, in, n);
-}
-
-static void test_swiglu_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
-                                         size_t n) {
-  skl_swiglu_bf16_xsfvfexp32e(out, in, in, SWIGLU_DELTA, n);
-}
-
-#if defined(SKL_ENABLE_TESTS)
-static void test_swish_b1_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
-                                           size_t n) {
-  skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_ONE, in, n);
+static void ref_swish_bp_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_ref(out, SWISH_BETA_POS, in, n);
 }
 
 static void test_swish_bn_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
@@ -62,26 +60,26 @@ static void test_swish_bn_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
   skl_swish_bf16_xsfvfexp32e(out, SWISH_BETA_NEG, in, n);
 }
 
-static void ref_swish_b1_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_ref(out, SWISH_BETA_ONE, in, n);
-}
-
-static void ref_swish_bp_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_ref(out, SWISH_BETA_POS, in, n);
-}
-
 static void ref_swish_bn_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA_NEG, in, n);
+}
+
+static void test_glu_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_glu_bf16_xsfvfexp32e(out, in, in, n);
 }
 
 static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_ref(out, in, in, n);
 }
 
+static void test_swiglu_bf16_xsfvfexp32e(__bf16 *out, const __bf16 *in,
+                                         size_t n) {
+  skl_swiglu_bf16_xsfvfexp32e(out, in, in, SWIGLU_DELTA, n);
+}
+
 static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
-#endif
 
 unary_bf16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_bf16_xsfvfexpa.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfexpa.c
@@ -51,8 +51,7 @@ void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_ref(out, in, in, n);
 }
 
-void test_swiglu_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in,
-                                       size_t n) {
+void test_swiglu_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_xsfvfexpa(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_bf16_xsfvfexpa.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfexpa.c
@@ -35,28 +35,28 @@
 #define SWIGLU_MAX (+6.f)
 #define SWIGLU_DELTA (__bf16)0.5
 
-static void test_swish_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in, size_t n) {
+void test_swish_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_xsfvfexpa(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA, in, n);
 }
 
-static void test_glu_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in, size_t n) {
+void test_glu_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_xsfvfexpa(out, in, in, n);
 }
 
-static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_ref(out, in, in, n);
 }
 
-static void test_swiglu_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in,
+void test_swiglu_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in,
                                        size_t n) {
   skl_swiglu_bf16_xsfvfexpa(out, in, in, SWIGLU_DELTA, n);
 }
 
-static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_bf16_xsfvfexpa.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfexpa.c
@@ -39,8 +39,16 @@ static void test_swish_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_xsfvfexpa(out, SWISH_BETA, in, n);
 }
 
+static void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_ref(out, SWISH_BETA, in, n);
+}
+
 static void test_glu_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_xsfvfexpa(out, in, in, n);
+}
+
+static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_glu_bf16_ref(out, in, in, n);
 }
 
 static void test_swiglu_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in,
@@ -48,19 +56,9 @@ static void test_swiglu_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in,
   skl_swiglu_bf16_xsfvfexpa(out, in, in, SWIGLU_DELTA, n);
 }
 
-#if defined(SKL_ENABLE_TESTS)
-static void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_ref(out, SWISH_BETA, in, n);
-}
-
-static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_glu_bf16_ref(out, in, in, n);
-}
-
 static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
-#endif
 
 unary_bf16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_bf16_xsfvfexpa.c
+++ b/test/sigmoid/sigmoid_bf16_xsfvfexpa.c
@@ -39,16 +39,8 @@ static void test_swish_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_xsfvfexpa(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_ref(out, SWISH_BETA, in, n);
-}
-
 static void test_glu_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_xsfvfexpa(out, in, in, n);
-}
-
-static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_glu_bf16_ref(out, in, in, n);
 }
 
 static void test_swiglu_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in,
@@ -56,9 +48,19 @@ static void test_swiglu_bf16_xsfvfexpa(__bf16 *out, const __bf16 *in,
   skl_swiglu_bf16_xsfvfexpa(out, in, in, SWIGLU_DELTA, n);
 }
 
+#if defined(SKL_ENABLE_TESTS)
+static void ref_swish_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_ref(out, SWISH_BETA, in, n);
+}
+
+static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_glu_bf16_ref(out, in, in, n);
+}
+
 static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
+#endif
 
 unary_bf16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_bf16_zve32f.c
+++ b/test/sigmoid/sigmoid_bf16_zve32f.c
@@ -37,43 +37,43 @@
 #define SWIGLU_MAX (+6.f)
 #define SWIGLU_DELTA (__bf16)0.5
 
-static void test_swish_b1_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
+void test_swish_b1_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_zve32f(out, SWISH_BETA_ONE, in, n);
 }
 
-static void ref_swish_b1_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_swish_b1_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA_ONE, in, n);
 }
 
-static void test_swish_bp_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
+void test_swish_bp_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_zve32f(out, SWISH_BETA_POS, in, n);
 }
 
-static void ref_swish_bp_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_swish_bp_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA_POS, in, n);
 }
 
-static void test_swish_bn_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
+void test_swish_bn_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_zve32f(out, SWISH_BETA_NEG, in, n);
 }
 
-static void ref_swish_bn_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_swish_bn_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA_NEG, in, n);
 }
 
-static void test_glu_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
+void test_glu_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_zve32f(out, in, in, n);
 }
 
-static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_ref(out, in, in, n);
 }
 
-static void test_swiglu_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
+void test_swiglu_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_zve32f(out, in, in, SWIGLU_DELTA, n);
 }
 
-static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_bf16_zve32f.c
+++ b/test/sigmoid/sigmoid_bf16_zve32f.c
@@ -37,47 +37,45 @@
 #define SWIGLU_MAX (+6.f)
 #define SWIGLU_DELTA (__bf16)0.5
 
-static void test_swish_bp_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_zve32f(out, SWISH_BETA_POS, in, n);
-}
-
-static void test_glu_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_glu_bf16_zve32f(out, in, in, n);
-}
-
-static void test_swiglu_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swiglu_bf16_zve32f(out, in, in, SWIGLU_DELTA, n);
-}
-
-#if defined(SKL_ENABLE_TESTS)
 static void test_swish_b1_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_zve32f(out, SWISH_BETA_ONE, in, n);
-}
-
-static void test_swish_bn_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_zve32f(out, SWISH_BETA_NEG, in, n);
 }
 
 static void ref_swish_b1_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA_ONE, in, n);
 }
 
+static void test_swish_bp_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_zve32f(out, SWISH_BETA_POS, in, n);
+}
+
 static void ref_swish_bp_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA_POS, in, n);
+}
+
+static void test_swish_bn_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_zve32f(out, SWISH_BETA_NEG, in, n);
 }
 
 static void ref_swish_bn_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_ref(out, SWISH_BETA_NEG, in, n);
 }
 
+static void test_glu_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_glu_bf16_zve32f(out, in, in, n);
+}
+
 static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_ref(out, in, in, n);
+}
+
+static void test_swiglu_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swiglu_bf16_zve32f(out, in, in, SWIGLU_DELTA, n);
 }
 
 static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
-#endif
 
 unary_bf16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_bf16_zve32f.c
+++ b/test/sigmoid/sigmoid_bf16_zve32f.c
@@ -37,45 +37,47 @@
 #define SWIGLU_MAX (+6.f)
 #define SWIGLU_DELTA (__bf16)0.5
 
-static void test_swish_b1_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_zve32f(out, SWISH_BETA_ONE, in, n);
-}
-
-static void ref_swish_b1_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_ref(out, SWISH_BETA_ONE, in, n);
-}
-
 static void test_swish_bp_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swish_bf16_zve32f(out, SWISH_BETA_POS, in, n);
-}
-
-static void ref_swish_bp_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_ref(out, SWISH_BETA_POS, in, n);
-}
-
-static void test_swish_bn_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_zve32f(out, SWISH_BETA_NEG, in, n);
-}
-
-static void ref_swish_bn_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_swish_bf16_ref(out, SWISH_BETA_NEG, in, n);
 }
 
 static void test_glu_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
   skl_glu_bf16_zve32f(out, in, in, n);
 }
 
-static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
-  skl_glu_bf16_ref(out, in, in, n);
-}
-
 static void test_swiglu_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_zve32f(out, in, in, SWIGLU_DELTA, n);
+}
+
+#if defined(SKL_ENABLE_TESTS)
+static void test_swish_b1_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_zve32f(out, SWISH_BETA_ONE, in, n);
+}
+
+static void test_swish_bn_bf16_zve32f(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_zve32f(out, SWISH_BETA_NEG, in, n);
+}
+
+static void ref_swish_b1_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_ref(out, SWISH_BETA_ONE, in, n);
+}
+
+static void ref_swish_bp_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_ref(out, SWISH_BETA_POS, in, n);
+}
+
+static void ref_swish_bn_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_swish_bf16_ref(out, SWISH_BETA_NEG, in, n);
+}
+
+static void ref_glu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
+  skl_glu_bf16_ref(out, in, in, n);
 }
 
 static void ref_swiglu_bf16(__bf16 *out, const __bf16 *in, size_t n) {
   skl_swiglu_bf16_ref(out, in, in, SWIGLU_DELTA, n);
 }
+#endif
 
 unary_bf16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_f16_xsfvfexp16e.c
+++ b/test/sigmoid/sigmoid_f16_xsfvfexp16e.c
@@ -40,17 +40,9 @@ static void test_swish_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
   skl_swish_f16_xsfvfexp16e(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
-  skl_swish_f16_ref(out, SWISH_BETA, in, n);
-}
-
 static void test_glu_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
                                      size_t n) {
   skl_glu_f16_xsfvfexp16e(out, in, in, n);
-}
-
-static void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
-  skl_glu_f16_ref(out, in, in, n);
 }
 
 static void test_swiglu_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
@@ -58,9 +50,19 @@ static void test_swiglu_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
   skl_swiglu_f16_xsfvfexp16e(out, in, in, SWIGLU_DELTA, n);
 }
 
+#if defined(SKL_ENABLE_TESTS)
+static void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
+  skl_swish_f16_ref(out, SWISH_BETA, in, n);
+}
+
+static void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
+  skl_glu_f16_ref(out, in, in, n);
+}
+
 static void ref_swiglu_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swiglu_f16_ref(out, in, in, SWIGLU_DELTA, n);
 }
+#endif
 
 unary_f16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_f16_xsfvfexp16e.c
+++ b/test/sigmoid/sigmoid_f16_xsfvfexp16e.c
@@ -35,8 +35,7 @@
 #define SWIGLU_MAX (+9.f)
 #define SWIGLU_DELTA (_Float16)0.5
 
-void test_swish_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
-                                       size_t n) {
+void test_swish_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swish_f16_xsfvfexp16e(out, SWISH_BETA, in, n);
 }
 
@@ -44,8 +43,7 @@ void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swish_f16_ref(out, SWISH_BETA, in, n);
 }
 
-void test_glu_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
-                                     size_t n) {
+void test_glu_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in, size_t n) {
   skl_glu_f16_xsfvfexp16e(out, in, in, n);
 }
 
@@ -53,8 +51,7 @@ void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_glu_f16_ref(out, in, in, n);
 }
 
-void test_swiglu_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
-                                        size_t n) {
+void test_swiglu_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swiglu_f16_xsfvfexp16e(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_f16_xsfvfexp16e.c
+++ b/test/sigmoid/sigmoid_f16_xsfvfexp16e.c
@@ -40,9 +40,17 @@ static void test_swish_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
   skl_swish_f16_xsfvfexp16e(out, SWISH_BETA, in, n);
 }
 
+static void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
+  skl_swish_f16_ref(out, SWISH_BETA, in, n);
+}
+
 static void test_glu_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
                                      size_t n) {
   skl_glu_f16_xsfvfexp16e(out, in, in, n);
+}
+
+static void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
+  skl_glu_f16_ref(out, in, in, n);
 }
 
 static void test_swiglu_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
@@ -50,19 +58,9 @@ static void test_swiglu_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
   skl_swiglu_f16_xsfvfexp16e(out, in, in, SWIGLU_DELTA, n);
 }
 
-#if defined(SKL_ENABLE_TESTS)
-static void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
-  skl_swish_f16_ref(out, SWISH_BETA, in, n);
-}
-
-static void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
-  skl_glu_f16_ref(out, in, in, n);
-}
-
 static void ref_swiglu_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swiglu_f16_ref(out, in, in, SWIGLU_DELTA, n);
 }
-#endif
 
 unary_f16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_f16_xsfvfexp16e.c
+++ b/test/sigmoid/sigmoid_f16_xsfvfexp16e.c
@@ -35,30 +35,30 @@
 #define SWIGLU_MAX (+9.f)
 #define SWIGLU_DELTA (_Float16)0.5
 
-static void test_swish_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
+void test_swish_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
                                        size_t n) {
   skl_swish_f16_xsfvfexp16e(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
+void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swish_f16_ref(out, SWISH_BETA, in, n);
 }
 
-static void test_glu_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
+void test_glu_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
                                      size_t n) {
   skl_glu_f16_xsfvfexp16e(out, in, in, n);
 }
 
-static void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
+void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_glu_f16_ref(out, in, in, n);
 }
 
-static void test_swiglu_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
+void test_swiglu_f16_xsfvfexp16e(_Float16 *out, const _Float16 *in,
                                         size_t n) {
   skl_swiglu_f16_xsfvfexp16e(out, in, in, SWIGLU_DELTA, n);
 }
 
-static void ref_swiglu_f16(_Float16 *out, const _Float16 *in, size_t n) {
+void ref_swiglu_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swiglu_f16_ref(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_f16_xsfvfexpa_zvfh.c
+++ b/test/sigmoid/sigmoid_f16_xsfvfexpa_zvfh.c
@@ -35,30 +35,30 @@
 #define SWIGLU_MAX (+9.f)
 #define SWIGLU_DELTA (_Float16)0.5
 
-static void test_swish_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
+void test_swish_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
                                           size_t n) {
   skl_swish_f16_xsfvfexpa_zvfh(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
+void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swish_f16_ref(out, SWISH_BETA, in, n);
 }
 
-static void test_glu_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
+void test_glu_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
                                         size_t n) {
   skl_glu_f16_xsfvfexpa_zvfh(out, in, in, n);
 }
 
-static void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
+void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_glu_f16_ref(out, in, in, n);
 }
 
-static void test_swiglu_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
+void test_swiglu_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
                                            size_t n) {
   skl_swiglu_f16_xsfvfexpa_zvfh(out, in, in, SWIGLU_DELTA, n);
 }
 
-static void ref_swiglu_f16(_Float16 *out, const _Float16 *in, size_t n) {
+void ref_swiglu_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swiglu_f16_ref(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_f16_xsfvfexpa_zvfh.c
+++ b/test/sigmoid/sigmoid_f16_xsfvfexpa_zvfh.c
@@ -36,7 +36,7 @@
 #define SWIGLU_DELTA (_Float16)0.5
 
 void test_swish_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
-                                          size_t n) {
+                                   size_t n) {
   skl_swish_f16_xsfvfexpa_zvfh(out, SWISH_BETA, in, n);
 }
 
@@ -44,8 +44,7 @@ void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swish_f16_ref(out, SWISH_BETA, in, n);
 }
 
-void test_glu_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
-                                        size_t n) {
+void test_glu_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
   skl_glu_f16_xsfvfexpa_zvfh(out, in, in, n);
 }
 
@@ -54,7 +53,7 @@ void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
 }
 
 void test_swiglu_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
-                                           size_t n) {
+                                    size_t n) {
   skl_swiglu_f16_xsfvfexpa_zvfh(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_f16_xsfvfexpa_zvfh.c
+++ b/test/sigmoid/sigmoid_f16_xsfvfexpa_zvfh.c
@@ -40,9 +40,17 @@ static void test_swish_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
   skl_swish_f16_xsfvfexpa_zvfh(out, SWISH_BETA, in, n);
 }
 
+static void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
+  skl_swish_f16_ref(out, SWISH_BETA, in, n);
+}
+
 static void test_glu_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
                                         size_t n) {
   skl_glu_f16_xsfvfexpa_zvfh(out, in, in, n);
+}
+
+static void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
+  skl_glu_f16_ref(out, in, in, n);
 }
 
 static void test_swiglu_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
@@ -50,19 +58,9 @@ static void test_swiglu_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
   skl_swiglu_f16_xsfvfexpa_zvfh(out, in, in, SWIGLU_DELTA, n);
 }
 
-#if defined(SKL_ENABLE_TESTS)
-static void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
-  skl_swish_f16_ref(out, SWISH_BETA, in, n);
-}
-
-static void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
-  skl_glu_f16_ref(out, in, in, n);
-}
-
 static void ref_swiglu_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swiglu_f16_ref(out, in, in, SWIGLU_DELTA, n);
 }
-#endif
 
 unary_f16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_f16_xsfvfexpa_zvfh.c
+++ b/test/sigmoid/sigmoid_f16_xsfvfexpa_zvfh.c
@@ -40,17 +40,9 @@ static void test_swish_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
   skl_swish_f16_xsfvfexpa_zvfh(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
-  skl_swish_f16_ref(out, SWISH_BETA, in, n);
-}
-
 static void test_glu_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
                                         size_t n) {
   skl_glu_f16_xsfvfexpa_zvfh(out, in, in, n);
-}
-
-static void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
-  skl_glu_f16_ref(out, in, in, n);
 }
 
 static void test_swiglu_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
@@ -58,9 +50,19 @@ static void test_swiglu_f16_xsfvfexpa_zvfh(_Float16 *out, const _Float16 *in,
   skl_swiglu_f16_xsfvfexpa_zvfh(out, in, in, SWIGLU_DELTA, n);
 }
 
+#if defined(SKL_ENABLE_TESTS)
+static void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
+  skl_swish_f16_ref(out, SWISH_BETA, in, n);
+}
+
+static void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
+  skl_glu_f16_ref(out, in, in, n);
+}
+
 static void ref_swiglu_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swiglu_f16_ref(out, in, in, SWIGLU_DELTA, n);
 }
+#endif
 
 unary_f16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_f16_zvfh.c
+++ b/test/sigmoid/sigmoid_f16_zvfh.c
@@ -39,27 +39,25 @@ static void test_swish_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swish_f16_zvfh(out, SWISH_BETA, in, n);
 }
 
-static void test_glu_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
-  skl_glu_f16_zvfh(out, in, in, n);
-}
-
-static void test_swiglu_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
-  skl_swiglu_f16_zvfh(out, in, in, SWIGLU_DELTA, n);
-}
-
-#if defined(SKL_ENABLE_TESTS)
 static void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swish_f16_ref(out, SWISH_BETA, in, n);
+}
+
+static void test_glu_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
+  skl_glu_f16_zvfh(out, in, in, n);
 }
 
 static void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_glu_f16_ref(out, in, in, n);
 }
 
+static void test_swiglu_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
+  skl_swiglu_f16_zvfh(out, in, in, SWIGLU_DELTA, n);
+}
+
 static void ref_swiglu_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swiglu_f16_ref(out, in, in, SWIGLU_DELTA, n);
 }
-#endif
 
 unary_f16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_f16_zvfh.c
+++ b/test/sigmoid/sigmoid_f16_zvfh.c
@@ -35,27 +35,27 @@
 #define SWIGLU_MAX (+9.f)
 #define SWIGLU_DELTA (_Float16)0.5
 
-static void test_swish_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
+void test_swish_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swish_f16_zvfh(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
+void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swish_f16_ref(out, SWISH_BETA, in, n);
 }
 
-static void test_glu_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
+void test_glu_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
   skl_glu_f16_zvfh(out, in, in, n);
 }
 
-static void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
+void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_glu_f16_ref(out, in, in, n);
 }
 
-static void test_swiglu_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
+void test_swiglu_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swiglu_f16_zvfh(out, in, in, SWIGLU_DELTA, n);
 }
 
-static void ref_swiglu_f16(_Float16 *out, const _Float16 *in, size_t n) {
+void ref_swiglu_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swiglu_f16_ref(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_f16_zvfh.c
+++ b/test/sigmoid/sigmoid_f16_zvfh.c
@@ -39,25 +39,27 @@ static void test_swish_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swish_f16_zvfh(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
-  skl_swish_f16_ref(out, SWISH_BETA, in, n);
-}
-
 static void test_glu_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
   skl_glu_f16_zvfh(out, in, in, n);
-}
-
-static void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
-  skl_glu_f16_ref(out, in, in, n);
 }
 
 static void test_swiglu_f16_zvfh(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swiglu_f16_zvfh(out, in, in, SWIGLU_DELTA, n);
 }
 
+#if defined(SKL_ENABLE_TESTS)
+static void ref_swish_f16(_Float16 *out, const _Float16 *in, size_t n) {
+  skl_swish_f16_ref(out, SWISH_BETA, in, n);
+}
+
+static void ref_glu_f16(_Float16 *out, const _Float16 *in, size_t n) {
+  skl_glu_f16_ref(out, in, in, n);
+}
+
 static void ref_swiglu_f16(_Float16 *out, const _Float16 *in, size_t n) {
   skl_swiglu_f16_ref(out, in, in, SWIGLU_DELTA, n);
 }
+#endif
 
 unary_f16_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_f32_xsfvfexp32e.c
+++ b/test/sigmoid/sigmoid_f32_xsfvfexp32e.c
@@ -39,27 +39,25 @@ static void test_swish_f32_xsfvfexp32e(float *out, const float *in, size_t n) {
   skl_swish_f32_xsfvfexp32e(out, SWISH_BETA, in, n);
 }
 
-static void test_glu_f32_xsfvfexp32e(float *out, const float *in, size_t n) {
-  skl_glu_f32_xsfvfexp32e(out, in, in, n);
-}
-
-static void test_swiglu_f32_xsfvfexp32e(float *out, const float *in, size_t n) {
-  skl_swiglu_f32_xsfvfexp32e(out, in, in, SWIGLU_DELTA, n);
-}
-
-#if defined(SKL_ENABLE_TESTS)
 static void ref_swish_f32(float *out, const float *in, size_t n) {
   skl_swish_f32_ref(out, SWISH_BETA, in, n);
+}
+
+static void test_glu_f32_xsfvfexp32e(float *out, const float *in, size_t n) {
+  skl_glu_f32_xsfvfexp32e(out, in, in, n);
 }
 
 static void ref_glu_f32(float *out, const float *in, size_t n) {
   skl_glu_f32_ref(out, in, in, n);
 }
 
+static void test_swiglu_f32_xsfvfexp32e(float *out, const float *in, size_t n) {
+  skl_swiglu_f32_xsfvfexp32e(out, in, in, SWIGLU_DELTA, n);
+}
+
 static void ref_swiglu_f32(float *out, const float *in, size_t n) {
   skl_swiglu_f32_ref(out, in, in, SWIGLU_DELTA, n);
 }
-#endif
 
 unary_f32_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_f32_xsfvfexp32e.c
+++ b/test/sigmoid/sigmoid_f32_xsfvfexp32e.c
@@ -35,27 +35,27 @@
 #define SWIGLU_MAX (+18.f)
 #define SWIGLU_DELTA 0.5f
 
-static void test_swish_f32_xsfvfexp32e(float *out, const float *in, size_t n) {
+void test_swish_f32_xsfvfexp32e(float *out, const float *in, size_t n) {
   skl_swish_f32_xsfvfexp32e(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_f32(float *out, const float *in, size_t n) {
+void ref_swish_f32(float *out, const float *in, size_t n) {
   skl_swish_f32_ref(out, SWISH_BETA, in, n);
 }
 
-static void test_glu_f32_xsfvfexp32e(float *out, const float *in, size_t n) {
+void test_glu_f32_xsfvfexp32e(float *out, const float *in, size_t n) {
   skl_glu_f32_xsfvfexp32e(out, in, in, n);
 }
 
-static void ref_glu_f32(float *out, const float *in, size_t n) {
+void ref_glu_f32(float *out, const float *in, size_t n) {
   skl_glu_f32_ref(out, in, in, n);
 }
 
-static void test_swiglu_f32_xsfvfexp32e(float *out, const float *in, size_t n) {
+void test_swiglu_f32_xsfvfexp32e(float *out, const float *in, size_t n) {
   skl_swiglu_f32_xsfvfexp32e(out, in, in, SWIGLU_DELTA, n);
 }
 
-static void ref_swiglu_f32(float *out, const float *in, size_t n) {
+void ref_swiglu_f32(float *out, const float *in, size_t n) {
   skl_swiglu_f32_ref(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_f32_xsfvfexp32e.c
+++ b/test/sigmoid/sigmoid_f32_xsfvfexp32e.c
@@ -39,25 +39,27 @@ static void test_swish_f32_xsfvfexp32e(float *out, const float *in, size_t n) {
   skl_swish_f32_xsfvfexp32e(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_f32(float *out, const float *in, size_t n) {
-  skl_swish_f32_ref(out, SWISH_BETA, in, n);
-}
-
 static void test_glu_f32_xsfvfexp32e(float *out, const float *in, size_t n) {
   skl_glu_f32_xsfvfexp32e(out, in, in, n);
-}
-
-static void ref_glu_f32(float *out, const float *in, size_t n) {
-  skl_glu_f32_ref(out, in, in, n);
 }
 
 static void test_swiglu_f32_xsfvfexp32e(float *out, const float *in, size_t n) {
   skl_swiglu_f32_xsfvfexp32e(out, in, in, SWIGLU_DELTA, n);
 }
 
+#if defined(SKL_ENABLE_TESTS)
+static void ref_swish_f32(float *out, const float *in, size_t n) {
+  skl_swish_f32_ref(out, SWISH_BETA, in, n);
+}
+
+static void ref_glu_f32(float *out, const float *in, size_t n) {
+  skl_glu_f32_ref(out, in, in, n);
+}
+
 static void ref_swiglu_f32(float *out, const float *in, size_t n) {
   skl_swiglu_f32_ref(out, in, in, SWIGLU_DELTA, n);
 }
+#endif
 
 unary_f32_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_f32_xsfvfexpa.c
+++ b/test/sigmoid/sigmoid_f32_xsfvfexpa.c
@@ -39,27 +39,25 @@ static void test_swish_f32_xsfvfexpa(float *out, const float *in, size_t n) {
   skl_swish_f32_xsfvfexpa(out, SWISH_BETA, in, n);
 }
 
-static void test_glu_f32_xsfvfexpa(float *out, const float *in, size_t n) {
-  skl_glu_f32_xsfvfexpa(out, in, in, n);
-}
-
-static void test_swiglu_f32_xsfvfexpa(float *out, const float *in, size_t n) {
-  skl_swiglu_f32_xsfvfexpa(out, in, in, SWIGLU_DELTA, n);
-}
-
-#if defined(SKL_ENABLE_TESTS)
 static void ref_swish_f32(float *out, const float *in, size_t n) {
   skl_swish_f32_ref(out, SWISH_BETA, in, n);
+}
+
+static void test_glu_f32_xsfvfexpa(float *out, const float *in, size_t n) {
+  skl_glu_f32_xsfvfexpa(out, in, in, n);
 }
 
 static void ref_glu_f32(float *out, const float *in, size_t n) {
   skl_glu_f32_ref(out, in, in, n);
 }
 
+static void test_swiglu_f32_xsfvfexpa(float *out, const float *in, size_t n) {
+  skl_swiglu_f32_xsfvfexpa(out, in, in, SWIGLU_DELTA, n);
+}
+
 static void ref_swiglu_f32(float *out, const float *in, size_t n) {
   skl_swiglu_f32_ref(out, in, in, SWIGLU_DELTA, n);
 }
-#endif
 
 unary_f32_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_f32_xsfvfexpa.c
+++ b/test/sigmoid/sigmoid_f32_xsfvfexpa.c
@@ -35,27 +35,27 @@
 #define SWIGLU_MAX (+18.f)
 #define SWIGLU_DELTA 0.5f
 
-static void test_swish_f32_xsfvfexpa(float *out, const float *in, size_t n) {
+void test_swish_f32_xsfvfexpa(float *out, const float *in, size_t n) {
   skl_swish_f32_xsfvfexpa(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_f32(float *out, const float *in, size_t n) {
+void ref_swish_f32(float *out, const float *in, size_t n) {
   skl_swish_f32_ref(out, SWISH_BETA, in, n);
 }
 
-static void test_glu_f32_xsfvfexpa(float *out, const float *in, size_t n) {
+void test_glu_f32_xsfvfexpa(float *out, const float *in, size_t n) {
   skl_glu_f32_xsfvfexpa(out, in, in, n);
 }
 
-static void ref_glu_f32(float *out, const float *in, size_t n) {
+void ref_glu_f32(float *out, const float *in, size_t n) {
   skl_glu_f32_ref(out, in, in, n);
 }
 
-static void test_swiglu_f32_xsfvfexpa(float *out, const float *in, size_t n) {
+void test_swiglu_f32_xsfvfexpa(float *out, const float *in, size_t n) {
   skl_swiglu_f32_xsfvfexpa(out, in, in, SWIGLU_DELTA, n);
 }
 
-static void ref_swiglu_f32(float *out, const float *in, size_t n) {
+void ref_swiglu_f32(float *out, const float *in, size_t n) {
   skl_swiglu_f32_ref(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_f32_xsfvfexpa.c
+++ b/test/sigmoid/sigmoid_f32_xsfvfexpa.c
@@ -39,25 +39,27 @@ static void test_swish_f32_xsfvfexpa(float *out, const float *in, size_t n) {
   skl_swish_f32_xsfvfexpa(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_f32(float *out, const float *in, size_t n) {
-  skl_swish_f32_ref(out, SWISH_BETA, in, n);
-}
-
 static void test_glu_f32_xsfvfexpa(float *out, const float *in, size_t n) {
   skl_glu_f32_xsfvfexpa(out, in, in, n);
-}
-
-static void ref_glu_f32(float *out, const float *in, size_t n) {
-  skl_glu_f32_ref(out, in, in, n);
 }
 
 static void test_swiglu_f32_xsfvfexpa(float *out, const float *in, size_t n) {
   skl_swiglu_f32_xsfvfexpa(out, in, in, SWIGLU_DELTA, n);
 }
 
+#if defined(SKL_ENABLE_TESTS)
+static void ref_swish_f32(float *out, const float *in, size_t n) {
+  skl_swish_f32_ref(out, SWISH_BETA, in, n);
+}
+
+static void ref_glu_f32(float *out, const float *in, size_t n) {
+  skl_glu_f32_ref(out, in, in, n);
+}
+
 static void ref_swiglu_f32(float *out, const float *in, size_t n) {
   skl_swiglu_f32_ref(out, in, in, SWIGLU_DELTA, n);
 }
+#endif
 
 unary_f32_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_f32_zve32f.c
+++ b/test/sigmoid/sigmoid_f32_zve32f.c
@@ -35,27 +35,27 @@
 #define SWIGLU_MAX (+18.f)
 #define SWIGLU_DELTA 0.5f
 
-static void test_swish_f32_zve32f(float *out, const float *in, size_t n) {
+void test_swish_f32_zve32f(float *out, const float *in, size_t n) {
   skl_swish_f32_zve32f(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_f32(float *out, const float *in, size_t n) {
+void ref_swish_f32(float *out, const float *in, size_t n) {
   skl_swish_f32_ref(out, SWISH_BETA, in, n);
 }
 
-static void test_glu_f32_zve32f(float *out, const float *in, size_t n) {
+void test_glu_f32_zve32f(float *out, const float *in, size_t n) {
   skl_glu_f32_zve32f(out, in, in, n);
 }
 
-static void ref_glu_f32(float *out, const float *in, size_t n) {
+void ref_glu_f32(float *out, const float *in, size_t n) {
   skl_glu_f32_ref(out, in, in, n);
 }
 
-static void test_swiglu_f32_zve32f(float *out, const float *in, size_t n) {
+void test_swiglu_f32_zve32f(float *out, const float *in, size_t n) {
   skl_swiglu_f32_zve32f(out, in, in, SWIGLU_DELTA, n);
 }
 
-static void ref_swiglu_f32(float *out, const float *in, size_t n) {
+void ref_swiglu_f32(float *out, const float *in, size_t n) {
   skl_swiglu_f32_ref(out, in, in, SWIGLU_DELTA, n);
 }
 

--- a/test/sigmoid/sigmoid_f32_zve32f.c
+++ b/test/sigmoid/sigmoid_f32_zve32f.c
@@ -39,27 +39,25 @@ static void test_swish_f32_zve32f(float *out, const float *in, size_t n) {
   skl_swish_f32_zve32f(out, SWISH_BETA, in, n);
 }
 
-static void test_glu_f32_zve32f(float *out, const float *in, size_t n) {
-  skl_glu_f32_zve32f(out, in, in, n);
-}
-
-static void test_swiglu_f32_zve32f(float *out, const float *in, size_t n) {
-  skl_swiglu_f32_zve32f(out, in, in, SWIGLU_DELTA, n);
-}
-
-#if defined(SKL_ENABLE_TESTS)
 static void ref_swish_f32(float *out, const float *in, size_t n) {
   skl_swish_f32_ref(out, SWISH_BETA, in, n);
+}
+
+static void test_glu_f32_zve32f(float *out, const float *in, size_t n) {
+  skl_glu_f32_zve32f(out, in, in, n);
 }
 
 static void ref_glu_f32(float *out, const float *in, size_t n) {
   skl_glu_f32_ref(out, in, in, n);
 }
 
+static void test_swiglu_f32_zve32f(float *out, const float *in, size_t n) {
+  skl_swiglu_f32_zve32f(out, in, in, SWIGLU_DELTA, n);
+}
+
 static void ref_swiglu_f32(float *out, const float *in, size_t n) {
   skl_swiglu_f32_ref(out, in, in, SWIGLU_DELTA, n);
 }
-#endif
 
 unary_f32_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)

--- a/test/sigmoid/sigmoid_f32_zve32f.c
+++ b/test/sigmoid/sigmoid_f32_zve32f.c
@@ -39,25 +39,27 @@ static void test_swish_f32_zve32f(float *out, const float *in, size_t n) {
   skl_swish_f32_zve32f(out, SWISH_BETA, in, n);
 }
 
-static void ref_swish_f32(float *out, const float *in, size_t n) {
-  skl_swish_f32_ref(out, SWISH_BETA, in, n);
-}
-
 static void test_glu_f32_zve32f(float *out, const float *in, size_t n) {
   skl_glu_f32_zve32f(out, in, in, n);
-}
-
-static void ref_glu_f32(float *out, const float *in, size_t n) {
-  skl_glu_f32_ref(out, in, in, n);
 }
 
 static void test_swiglu_f32_zve32f(float *out, const float *in, size_t n) {
   skl_swiglu_f32_zve32f(out, in, in, SWIGLU_DELTA, n);
 }
 
+#if defined(SKL_ENABLE_TESTS)
+static void ref_swish_f32(float *out, const float *in, size_t n) {
+  skl_swish_f32_ref(out, SWISH_BETA, in, n);
+}
+
+static void ref_glu_f32(float *out, const float *in, size_t n) {
+  skl_glu_f32_ref(out, in, in, n);
+}
+
 static void ref_swiglu_f32(float *out, const float *in, size_t n) {
   skl_swiglu_f32_ref(out, in, in, SWIGLU_DELTA, n);
 }
+#endif
 
 unary_f32_t tests[] = {
 #if defined(SKL_ENABLE_BENCHMARKS)


### PR DESCRIPTION
When SKL_ENABLE_TESTS=OFF and SKL_ENABLE_BENCHMARKS=ON, some static
symbols were defined yet not used, leading to the compiler emitting
errors at compile-time.  This patch makes those symbols extern. Since
we're building executables, this shouldn't cause any problem.