### PR TITLE
[CI] Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     types: [ opened, synchronize ]
+  workflow_dispatch:
 
 env:
   BUILD_TYPE: Release


### PR DESCRIPTION
This PR adds the `workflow_dispatch` trigger to the CI yaml to enable manual triggering of CI.